### PR TITLE
warning_settings isn't properly used.

### DIFF
--- a/sources/Load.php
+++ b/sources/Load.php
@@ -61,6 +61,8 @@ function reloadSettings()
 		if (empty($modSettings['defaultMaxMembers']) || $modSettings['defaultMaxMembers'] <= 0 || $modSettings['defaultMaxMembers'] > 999)
 			$modSettings['defaultMaxMembers'] = 30;
 
+		$modSettings['warning_enable'] = $modSettings['warning_settings'][0];
+
 		if (!empty($modSettings['cache_enable']))
 			cache_put_data('modSettings', $modSettings, 90);
 	}

--- a/sources/admin/Admin.php
+++ b/sources/admin/Admin.php
@@ -140,7 +140,7 @@ function AdminMain()
 						'general' => array($txt['mods_cat_security_general']),
 						'spam' => array($txt['antispam_title']),
 						'badbehavior' => array($txt['badbehavior_title']),
-						'moderation' => array($txt['moderation_settings_short'], 'enabled' => substr($modSettings['warning_settings'], 0, 1) == 1),
+						'moderation' => array($txt['moderation_settings_short'], 'enabled' => !empty($modSettings['warning_enable'])),
 					),
 				),
 				'languages' => array(

--- a/sources/admin/ManageSettings.php
+++ b/sources/admin/ManageSettings.php
@@ -775,7 +775,7 @@ function ModifyModerationSettings($return_config = false)
 		checkSession();
 
 		// Make sure these don't have an effect.
-		if (substr($modSettings['warning_settings'], 0, 1) != 1)
+		if ($modSettings['warning_settings'][0] != 1)
 		{
 			$_POST['warning_watch'] = 0;
 			$_POST['warning_moderate'] = 0;

--- a/sources/controllers/Display.controller.php
+++ b/sources/controllers/Display.controller.php
@@ -894,7 +894,7 @@ function Display()
 	$context['can_remove_poll'] &= $modSettings['pollMode'] == '1' && $topicinfo['id_poll'] > 0;
 	$context['can_reply'] &= empty($topicinfo['locked']) || allowedTo('moderate_board');
 	$context['can_reply_unapproved'] &= $modSettings['postmod_active'] && (empty($topicinfo['locked']) || allowedTo('moderate_board'));
-	$context['can_issue_warning'] &= in_array('w', $context['admin_features']) && substr($modSettings['warning_settings'], 0, 1) == 1;
+	$context['can_issue_warning'] &= in_array('w', $context['admin_features']) && !empty($modSettings['warning_enable']);
 
 	// Handle approval flags...
 	$context['can_reply_approved'] = $context['can_reply'];

--- a/sources/controllers/ModerationCenter.controller.php
+++ b/sources/controllers/ModerationCenter.controller.php
@@ -90,7 +90,7 @@ function action_modcenter($dont_call = false)
 				),
 				'warnings' => array(
 					'label' => $txt['mc_warnings'],
-					'enabled' => in_array('w', $context['admin_features']) && substr($modSettings['warning_settings'], 0, 1) == 1 && $context['can_moderate_boards'],
+					'enabled' => in_array('w', $context['admin_features']) && !empty($modSettings['warning_enable']) && $context['can_moderate_boards'],
 					'function' => 'action_viewWarnings',
 					'subsections' => array(
 						'log' => array($txt['mc_warning_log']),
@@ -138,7 +138,7 @@ function action_modcenter($dont_call = false)
 			'areas' => array(
 				'userwatch' => array(
 					'label' => $txt['mc_watched_users_title'],
-					'enabled' => in_array('w', $context['admin_features']) && substr($modSettings['warning_settings'], 0, 1) == 1 && $context['can_moderate_boards'],
+					'enabled' => in_array('w', $context['admin_features']) && !empty($modSettings['warning_enable']) && $context['can_moderate_boards'],
 					'function' => 'action_viewWatchedUsers',
 					'subsections' => array(
 						'member' => array($txt['mc_watched_users_member']),

--- a/sources/controllers/PersonalMessage.controller.php
+++ b/sources/controllers/PersonalMessage.controller.php
@@ -135,7 +135,7 @@ function action_pm()
 
 	// This is convenient.  Do you know how annoying it is to do this every time?!
 	$context['current_label_redirect'] = 'action=pm;f=' . $context['folder'] . (isset($_GET['start']) ? ';start=' . $_GET['start'] : '') . (isset($_REQUEST['l']) ? ';l=' . $_REQUEST['l'] : '');
-	$context['can_issue_warning'] = in_array('w', $context['admin_features']) && allowedTo('issue_warning') && substr($modSettings['warning_settings'], 0, 1) == 1;
+	$context['can_issue_warning'] = in_array('w', $context['admin_features']) && allowedTo('issue_warning') && !empty($modSettings['warning_enable']);
 
 	// Are PM drafts enabled?
 	$context['drafts_pm_save'] = !empty($modSettings['drafts_enabled']) && !empty($modSettings['drafts_pm_enabled']) && allowedTo('pm_draft');

--- a/sources/controllers/Profile.controller.php
+++ b/sources/controllers/Profile.controller.php
@@ -155,7 +155,7 @@ function action_modifyprofile()
 				),
 				'viewwarning' => array(
 					'label' => $txt['profile_view_warnings'],
-					'enabled' => in_array('w', $context['admin_features']) && substr($modSettings['warning_settings'], 0, 1) == 1 && $cur_profile['warning'] && (!empty($modSettings['warning_show']) && ($context['user']['is_owner'] || $modSettings['warning_show'] == 2)),
+					'enabled' => in_array('w', $context['admin_features']) && !empty($modSettings['warning_enable']) && $cur_profile['warning'] && (!empty($modSettings['warning_show']) && ($context['user']['is_owner'] || $modSettings['warning_show'] == 2)),
 					'file' => 'ProfileInfo.controller.php',
 					'function' => 'action_viewWarning',
 					'permission' => array(
@@ -297,7 +297,7 @@ function action_modifyprofile()
 				),
 				'issuewarning' => array(
 					'label' => $txt['profile_issue_warning'],
-					'enabled' => in_array('w', $context['admin_features']) && substr($modSettings['warning_settings'], 0, 1) == 1 && (!$context['user']['is_owner'] || $context['user']['is_admin']),
+					'enabled' => in_array('w', $context['admin_features']) && !empty($modSettings['warning_enable']) && (!$context['user']['is_owner'] || $context['user']['is_admin']),
 					'file' => 'ProfileAccount.controller.php',
 					'function' => 'action_issuewarning',
 					'token' => 'profile-iw%u',

--- a/sources/controllers/ProfileInfo.controller.php
+++ b/sources/controllers/ProfileInfo.controller.php
@@ -37,7 +37,7 @@ function action_summary($memID)
 		'can_send_pm' => allowedTo('pm_send'),
 		'can_send_email' => allowedTo('send_email_to_members'),
 		'can_have_buddy' => allowedTo('profile_identity_own') && !empty($modSettings['enable_buddylist']),
-		'can_issue_warning' => in_array('w', $context['admin_features']) && allowedTo('issue_warning') && substr($modSettings['warning_settings'], 0, 1) == 1,
+		'can_issue_warning' => in_array('w', $context['admin_features']) && allowedTo('issue_warning') && !empty($modSettings['warning_enable']),
 	);
 	$context['member'] = &$memberContext[$memID];
 	$context['can_view_warning'] = in_array('w', $context['admin_features']) && (allowedTo('issue_warning') && !$context['user']['is_owner']) || (!empty($modSettings['warning_show']) && ($modSettings['warning_show'] > 1 || $context['user']['is_owner']));
@@ -55,7 +55,6 @@ function action_summary($memID)
 	);
 
 	// See if they have broken any warning levels...
-	list ($modSettings['warning_enable'], $modSettings['user_limit']) = explode(',', $modSettings['warning_settings']);
 	if (!empty($modSettings['warning_mute']) && $modSettings['warning_mute'] <= $context['member']['warning'])
 		$context['warning_status'] = $txt['profile_warning_is_muted'];
 	elseif (!empty($modSettings['warning_moderate']) && $modSettings['warning_moderate'] <= $context['member']['warning'])


### PR DESCRIPTION
There are several places where $modSettings['warning_settings'] was used as an array, but it was never made an array in the first instace. Either it should be used as a string or be splitted into an array. My fix does the same as it was aldready done in Admin.php
