### PR TITLE
I know I was told it works as is, but I just don't see how

### DIFF
--- a/sources/controllers/Xml.controller.php
+++ b/sources/controllers/Xml.controller.php
@@ -157,7 +157,7 @@ function action_corefeatures()
 	{
 		require_once(ADMINDIR . '/ManageCoreFeatures.php');
 		$controller = new ManageCoreFeatures_Controller();
-		$result = $controller->settings();
+		$result = $controller->action_index();
 
 		// Load up the core features of the system
 		if (empty($result))


### PR DESCRIPTION
so here is my proposal so the class returns the items that the xml function needs ($context etc) .... Could also redo the xml function to use ->settings(), not sure what the plan is but till then ...

Signed-off-by: Spuds spuds@spudsdesign.com
