### PR TITLE
Elkpr/426

### DIFF
--- a/sources/controllers/Display.controller.php
+++ b/sources/controllers/Display.controller.php
@@ -1217,13 +1217,13 @@ function loadAttachmentContext($id_msg)
 			// Let's see, do we want thumbs?
 			if (!empty($modSettings['attachmentThumbnails']) && !empty($modSettings['attachmentThumbWidth']) && !empty($modSettings['attachmentThumbHeight']) && ($attachment['width'] > $modSettings['attachmentThumbWidth'] || $attachment['height'] > $modSettings['attachmentThumbHeight']) && strlen($attachment['filename']) < 249)
 			{
-				// A proper thumb doesn't exist yet? Create one!
+				// A proper thumb doesn't exist yet? Create one! Or, it needs update.
 				if (empty($attachment['id_thumb']) || $attachment['thumb_width'] > $modSettings['attachmentThumbWidth'] || $attachment['thumb_height'] > $modSettings['attachmentThumbHeight'] || ($attachment['thumb_width'] < $modSettings['attachmentThumbWidth'] && $attachment['thumb_height'] < $modSettings['attachmentThumbHeight']))
 				{
 					$filename = getAttachmentFilename($attachment['filename'], $attachment['id_attach'], $attachment['id_folder']);
 
 					require_once(SUBSDIR . '/Attachments.subs.php');
-					$attachment = $attachment + updateAttachmentThumbnail($filename, $id_msg, $attachment['id_thumb']);
+					$attachment = array_merge($attachment, updateAttachmentThumbnail($filename, $attachment['id_attach'], $id_msg, $attachment['id_thumb']));
 				}
 
 				// Only adjust dimensions on successful thumbnail creation.

--- a/sources/subs/Attachments.subs.php
+++ b/sources/subs/Attachments.subs.php
@@ -2404,15 +2404,17 @@ function setRemovalNotice($messages, $notice)
  * Update an attachment's thumbnail
  * 
  * @param string $filename
+ * @param int $id_attach
  * @param int $id_msg
  * @param int $old_id_thumb = 0
+ *
  * @return array The updated information
  */
-function updateAttachmentThumbnail($filename, $id_msg, $old_id_thumb = 0)
+function updateAttachmentThumbnail($filename, $id_attach, $id_msg, $old_id_thumb = 0)
 {
 	global $modSettings;
 
-	$attachment = array();
+	$attachment = array('id_attach' => $id_attach);
 
 	require_once(SUBSDIR . '/Graphics.subs.php');
 	if (createThumbnail($filename, $modSettings['attachmentThumbWidth'], $modSettings['attachmentThumbHeight']))


### PR DESCRIPTION
I have rebased https://github.com/elkarte/Elkarte/pull/426 to the updated master, and added a few fixes from https://github.com/joshuaadickerson/NotElkarte/tree/AttachmentThumb_new.
(This last branch was not rebased to master yet, when I fixed this PR.)

IMO, this is a very good (re)start on the (very spread out everywhere) attachments code. And it should be improved further. For example, add automanagement for updates that create a new thumbnail, and split out thumbnail creation in createAttachments. Also, we can eventually improve implementation when the needs of the code are more clear.
I think I would rather accept it though, and continue reimplementation of them attachments.
