### PR TITLE
fixes "Jumpy second and third level links in droppys"

### DIFF
--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -1138,7 +1138,7 @@ table.table_padding td {
 }
 /* Necessary to allow highlighting of 1st level while hovering over submenu. */
 .dropmenu li:hover li a, .dropmenu li.sfhover li a {
-	padding: 1px 9px;
+	padding: 1px 10px;
 	background: none;
 	color: #666;
 	border: none;


### PR DESCRIPTION
Details http://www.elkarte.net/index.php?topic=397.0, used padding instead of the transparent border, saves a few bytes :P
