### PR TITLE
Clear error log buttons

### DIFF
--- a/themes/default/Errors.template.php
+++ b/themes/default/Errors.template.php
@@ -61,7 +61,6 @@ function template_error_log()
 				<input type="submit" name="removeSelection" value="' . $txt['remove_selection'] . '" onclick="return confirm(\'' . $txt['remove_selection_confirm'] . '\');" class="button_submit" />
 				<input type="submit" name="delall" value="', $context['has_filter'] ? $txt['remove_filtered_results'] : $txt['remove_all'], '" onclick="return confirm(\'', $context['has_filter'] ? $txt['remove_filtered_results_confirm'] : $txt['sure_about_errorlog_remove'], '\');" class="button_submit" />
 			</div>
-			<br />
 			', template_pagesection(false, false, 'go_down'), '
 			<table class="table_grid" id="error_log">
 				<tr>


### PR DESCRIPTION
I want the same buttons at the top that are on the bottom to clear logs, or clear selection. I don't always scroll to the bottom. If you agree, merge! :dancers: 
