### PR TITLE
Ant's chainsaw massacre :P

### DIFF
--- a/themes/default/Admin.template.php
+++ b/themes/default/Admin.template.php
@@ -40,7 +40,7 @@ function template_admin()
 										<a href="', $scripturl, '?action=quickhelp;help=live_news" onclick="return reqOverlayDiv(this.href);" class="help"><img src="', $settings['images_url'], '/helptopics_hd.png" class="icon" alt="', $txt['help'], '" /></a> ', $txt['live'], '
 									</h3>
 								</div>
-								<div class="windowbg nopadding">
+								<div class="windowbg">
 									<div class="content">
 										<div id="ourAnnouncements">', $txt['lfyi'], '</div>
 									</div>
@@ -55,7 +55,7 @@ function template_admin()
 										<a href="', $scripturl, '?action=admin;area=credits">', $txt['support_title'], '</a>
 									</h3>
 								</div>
-								<div class="windowbg nopadding">
+								<div class="windowbg">
 									<div class="content">
 										<div id="version_details">
 											<strong>', $txt['support_versions'], ':</strong><br />
@@ -335,8 +335,8 @@ function template_view_versions()
 						<div class="information">', $txt['version_check_desc'], '</div>
 							<table class="table_grid">
 								<thead>
-									<tr class="catbg lefttext">
-										<th class="first_th" scope="col" style="width:50%">
+									<tr class="table_head lefttext">
+										<th scope="col" style="width:50%">
 											<strong>', $txt['admin_elkfile'], '</strong>
 										</th>
 										<th scope="col" style="width:25%">
@@ -755,7 +755,7 @@ function template_edit_censored()
 					<script><!-- // --><![CDATA[
 						document.getElementById("moreCensoredWords_link").style.display = "";
 					// ]]></script>
-					<hr class="hrcolor clear" style="width:100%; height:1px" />
+					<hr class="clear" />
 					<dl class="settings">
 						<dt>
 							<strong><label for="censorWholeWord_check">', $txt['censor_whole_words'], ':</label></strong>
@@ -1052,7 +1052,7 @@ function template_show_settings()
 			if ($config_var == '')
 				echo '
 					</dl>
-					<hr class="hrcolor clear" />
+					<hr class="clear" />
 					<dl class="settings">';
 			else
 				echo '
@@ -1303,14 +1303,14 @@ function template_repair_boards()
 				<p>
 					', $txt['errors_fix'], '
 				</p>
-				<p class="padding">
+				<p>
 					<strong><a href="', $scripturl, '?action=admin;area=repairboards;fixErrors;', $context['session_var'], '=', $context['session_id'], '">', $txt['yes'], '</a> - <a href="', $scripturl, '?action=admin;area=maintain">', $txt['no'], '</a></strong>
 				</p>';
 		}
 		else
 			echo '
 				<p>', $txt['maintain_no_errors'], '</p>
-				<p class="padding">
+				<p>
 					<a href="', $scripturl, '?action=admin;area=maintain;sa=routine">', $txt['maintain_return'], '</a>
 				</p>';
 
@@ -1332,7 +1332,7 @@ function template_repair_boards()
 		{
 			echo '
 				<p>', $txt['errors_fixed'], '</p>
-				<p class="padding">
+				<p>
 					<a href="', $scripturl, '?action=admin;area=maintain;sa=routine">', $txt['maintain_return'], '</a>
 				</p>';
 		}
@@ -1377,10 +1377,10 @@ function template_php_info()
 		echo '
 		<table id="', str_replace(' ', '_', $area), '" class="table_grid">
 			<thead>
-			<tr class="catbg">
-				<th class="first_th" scope="col" style="width:33%"></th>
-				<th scope="col" style="width:33%" class="centertext"><strong>', $area, '</strong></th>
-				<th class="last_th" scope="col" style="width:33%"></th>
+			<tr class="table_head">
+				<th scope="col" style="width:33%"></th>
+				<th scope="col" style="width:33%"><strong>', $area, '</strong></th>
+				<th scope="col" style="width:33%"></th>
 			</tr>
 			</thead>
 			<tbody>';
@@ -1466,7 +1466,7 @@ function template_clean_cache_button_below()
 
 /**
  * Admin quick search box.
- */
+ * @todo - See comments under https://github.com/elkarte/Elkarte/issues/617#issuecomment-20564476 */
 function template_admin_quick_search()
 {
 	global $context, $settings, $txt, $scripturl;

--- a/themes/default/Announce.template.php
+++ b/themes/default/Announce.template.php
@@ -46,7 +46,7 @@ function template_announce()
 							<label for="checkall"><input type="checkbox" id="checkall" class="input_check" onclick="invertAll(this, this.form);" checked="checked" /> <em>', $txt['check_all'], '</em></label>
 						</li>
 					</ul>
-					<hr class="hrcolor" />
+					<hr />
 					<div id="confirm_buttons">
 						<input type="submit" value="', $txt['post'], '" class="button_submit" />
 						<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
@@ -76,7 +76,7 @@ function template_announcement_send()
 						<div class="full_bar">', $context['percentage_done'], '% ', $txt['announce_done'], '</div>
 						<div class="green_percent" style="width: ', $context['percentage_done'], '%;">&nbsp;</div>
 					</div>
-					<hr class="hrcolor" />
+					<hr />
 					<div id="confirm_buttons">
 						<input type="submit" name="b" value="', $txt['announce_continue'], '" class="button_submit" />
 						<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />

--- a/themes/default/BoardIndex.template.php
+++ b/themes/default/BoardIndex.template.php
@@ -251,10 +251,10 @@ function template_info_center()
 			echo '
 				<table id="ic_recentposts">
 					<tr>
-						<th class="recentpost first_th">', $txt['message'], '</th>
+						<th class="recentpost">', $txt['message'], '</th>
 						<th class="recentposter">', $txt['author'], '</th>
 						<th class="recentboard">', $txt['board'], '</th>
-						<th class="recenttime last_th">', $txt['date'], '</th>
+						<th class="recenttime">', $txt['date'], '</th>
 					</tr>';
 
 			/* Each post in latest_posts has:

--- a/themes/default/Display.template.php
+++ b/themes/default/Display.template.php
@@ -34,11 +34,11 @@ function template_main()
 	// Show the topic information - icon, subject, etc.
 	echo '
 			<div id="forumposts" class="forumposts">
-				<h3 class="catbg">
+				<h2 class="category_header">
 					<img src="', $settings['images_url'], '/topic/', $context['class'], '.png" alt="" />
-					', $txt['topic'], ': ', $context['subject'], '&nbsp;<span>(', $context['num_views_text'], ')</span>
-					<span class="nextlinks floatright">', $context['previous_next'], '</span>
-				</h3>';
+					', $txt['topic'], ': ', $context['subject'], '&nbsp;<span class="views_text">(', $context['num_views_text'], ')</span>
+					<span class="nextlinks">', $context['previous_next'], '</span>
+				</h2>';
 
 	if (!empty($settings['display_who_viewing']))
 	{
@@ -89,8 +89,8 @@ function template_main()
 			echo '
 					<ul class="poster">', template_build_poster_div($message, $ignoring), '</ul>';
 
-			echo '
-					<div class="postarea"', (empty($options['hide_poster_area']) ? '' : ' style="margin:0"'), '>
+				echo '
+					<div class="postarea', empty($options['hide_poster_area']) ? '' : '2', '">
 						<div class="keyinfo">
 						', (!empty($options['hide_poster_area']) ? '<ul class="poster poster2">' .  template_build_poster_div($message, $ignoring) . '</ul>' : '');
 
@@ -313,10 +313,10 @@ function template_quickreply_below()
 		echo '
 			<a id="quickreply"></a>
 			<div class="forumposts" id="quickreplybox">
-				<h3 class="catbg">
+				<h2 class="category_header">
 					<a href="javascript:oQuickReply.swap();"><img src="', $settings['images_url'], '/', $options['display_quick_reply'] > 1 ? 'collapse' : 'expand', '.png" alt="+" id="quickReplyExpand" class="icon" /></a>
 					<a href="javascript:oQuickReply.swap();">', $txt['quick_reply'], '</a>
-				</h3>
+				</h2>
 				<div id="quickReplyOptions" class="windowbg"', $options['display_quick_reply'] > 1 ? '' : ' style="display: none"', '>
 					<div class="editor_wrapper">
 						<p class="smalltext lefttext">', $txt['quick_reply_desc'], '</p>
@@ -375,7 +375,7 @@ function template_quickreply_below()
 		}
 
 		echo '
-							<div class="padding">
+							<div>
 								<input type="submit" name="post" value="', $txt['post'], '" onclick="return submitThisOnce(this);" accesskey="s" tabindex="', $context['tabindex']++, '" class="button_submit" />
 								<input type="submit" name="preview" value="', $txt['preview'], '" onclick="return submitThisOnce(this);" accesskey="p" tabindex="', $context['tabindex']++, '" class="button_submit" />';
 
@@ -391,7 +391,7 @@ function template_quickreply_below()
 
 			if (!empty($context['drafts_autosave']) && !empty($options['drafts_autosave_enabled']))
 				echo '
-								<div class="clear righttext padding"><span id="throbber" style="display:none"><img src="' . $settings['images_url'] . '/loading_sm.gif" alt="" class="centericon" />&nbsp;</span><span id="draft_lastautosave"></span></div>';
+								<div class="clear righttext"><span id="throbber" style="display:none"><img src="' . $settings['images_url'] . '/loading_sm.gif" alt="" class="centericon" />&nbsp;</span><span id="draft_lastautosave"></span></div>';
 		}
 
 		echo '
@@ -845,7 +845,7 @@ function template_display_poll_above()
 		// Show a warning if they are allowed more than one option.
 		if ($context['poll']['allowed_warning'])
 			echo '
-							<p class="smallpadding">', $context['poll']['allowed_warning'], '</p>';
+							<p>', $context['poll']['allowed_warning'], '</p>';
 
 		echo '
 							<ul class="options">';
@@ -890,7 +890,7 @@ function template_display_calendar_above()
 	echo '
 			<div class="linked_events">
 				<div class="title_bar">
-					<h3 class="titlebg headerpadding">', $txt['calendar_linked_events'], '</h3>
+					<h3 class="titlebg">', $txt['calendar_linked_events'], '</h3>
 				</div>
 				<div class="windowbg">
 					<div class="content">

--- a/themes/default/Emailuser.template.php
+++ b/themes/default/Emailuser.template.php
@@ -179,7 +179,7 @@ function template_custom_email()
 							<textarea id="email_body" name="email_body" rows="10" cols="20" style="' . (isBrowser('is_ie8') ? 'width: 635px; max-width: 90%; min-width: 90%' : 'width: 90%') . ';"></textarea>
 						</dd>
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<div class="flow_auto">
 						<input type="submit" name="send" value="', $txt['sendtopic_send'], '" class="button_submit" />
 					</div>

--- a/themes/default/Errors.template.php
+++ b/themes/default/Errors.template.php
@@ -32,7 +32,7 @@ function template_fatal_error()
 			</h3>
 		</div>
 		<div class="windowbg generic_list_wrapper">
-			<div ', $context['error_code'], 'class="padding">', $context['error_message'], '</div>
+			<div ', $context['error_code'], '>', $context['error_message'], '</div>
 		</div>
 	</div>';
 
@@ -194,7 +194,7 @@ function template_show_file()
 		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css?alp21" />
 	</head>
 	<body>
-		<table class="errorfile_table">';
+		<table id="errorfile_table" class="table_grid">';
 	foreach ($context['file_data']['contents'] as $index => $line)
 	{
 		$line_num = $index + $context['file_data']['min'];
@@ -222,17 +222,15 @@ function template_attachment_errors()
 				', $txt['attach_error_title'], '
 			</h3>
 		</div>
-		<div class="windowbg">
-			<div class="padding">';
+		<div class="windowbg">';
 
 	foreach ($context['attachment_error_keys'] as $key)
 		template_show_error($key);
 
 	echo
-				!empty($context['back_link']) ? ('<a class="button_link" href="' . $context['back_link'] . '">' . $txt['back'] . '</a>&nbsp;') : '',
-				'
-				<a class="button_link" href="', $context['redirect_link'], '">', $txt['continue'], '</a>
-			</div>
+			!empty($context['back_link']) ? ('<a class="button_link" href="' . $context['back_link'] . '">' . $txt['back'] . '</a>&nbsp;') : '','
+			<a class="button_link" href="', $context['redirect_link'], '">', $txt['continue'], '</a>
+
 		</div>
 	</div>';
 }

--- a/themes/default/GenericControls.template.php
+++ b/themes/default/GenericControls.template.php
@@ -119,6 +119,8 @@ function template_control_richedit($editor_id, $smileyContainer = null, $bbcCont
 			echo ',
 					toolbar: "emoticon,source",';
 
+		// @todo - Check width for editor. It overflows a little past where it should be.
+		// Should be able to fix with box-sizing or something. 100% should work for width.
 		echo '
 				});
 				$("#', $editor_id, '").data("sceditor").createPermanentDropDown();
@@ -184,7 +186,7 @@ function template_control_richedit_buttons($editor_id)
 		if (!empty($context['drafts_autosave']) && !empty($options['drafts_autosave_enabled']))
 			echo '
 		<br />
-		<span class="righttext padding" style="display: block">
+		<span class="righttext" style="display: block">
 			<span id="throbber" style="display:none"><img src="' . $settings['images_url'] . '/loading_sm.gif" alt="" class="centericon" />&nbsp;</span>
 			<span id="draft_lastautosave" ></span>
 		</span>';
@@ -200,7 +202,7 @@ function template_control_richedit_buttons($editor_id)
 		// Load in the PM autosaver if its enabled and the user wants to use it
 		if (!empty($context['drafts_autosave']) && !empty($options['drafts_autosave_enabled']))
 			echo '
-		<span class="righttext padding" style="display: block">
+		<span class="righttext" style="display: block">
 			<span id="throbber" style="display:none"><img src="' . $settings['images_url'] . '/loading_sm.gif" alt="" class="centericon" />&nbsp;</span>
 			<span id="draft_lastautosave" ></span>
 		</span>';

--- a/themes/default/GenericList.template.php
+++ b/themes/default/GenericList.template.php
@@ -86,7 +86,7 @@ function template_show_list($list_id = null)
 			</div>';
 
 	echo '
-			<table class="table_grid" style="width:', !empty($cur_list['width']) ? $cur_list['width'] : '100%', '">';
+			<table class="table_grid" style="width:', !empty($cur_list['width']) ? $cur_list['width'] : '', '">';
 
 	// Show the column headers.
 	$header_count = count($cur_list['headers']);
@@ -94,7 +94,7 @@ function template_show_list($list_id = null)
 	{
 		echo '
 			<thead>
-				<tr class="catbg">';
+				<tr class="table_head">';
 
 		// Loop through each column and add a table header.
 		$i = 0;
@@ -102,9 +102,9 @@ function template_show_list($list_id = null)
 		{
 			$i ++;
 			if ($i === 1)
-				$col_header['class'] = empty($col_header['class']) ? 'first_th' : 'first_th ' . $col_header['class'];
+				$col_header['class'] = empty($col_header['class']) ? '' : $col_header['class'];
 			elseif ($i === $header_count)
-				$col_header['class'] = empty($col_header['class']) ? 'last_th' : 'last_th ' . $col_header['class'];
+				$col_header['class'] = empty($col_header['class']) ? '' : $col_header['class'];
 
 			echo '
 					<th scope="col" id="header_', $list_id, '_', $col_header['id'], '"', empty($col_header['class']) ? '' : ' class="' . $col_header['class'] . '"', empty($col_header['style']) ? '' : ' style="' . $col_header['style'] . '"', empty($col_header['colspan']) ? '' : ' colspan="' . $col_header['colspan'] . '"', '>', empty($col_header['href']) ? '' : '<a href="' . $col_header['href'] . '" rel="nofollow">', empty($col_header['label']) ? '&nbsp;' : $col_header['label'], empty($col_header['href']) ? '' : (empty($col_header['sort_image']) ? '</a>' : ' <img class="sort" src="' . $settings['images_url'] . '/sort_' . $col_header['sort_image'] . '.png" alt="" /></a>'), '</th>';

--- a/themes/default/Maillist.template.php
+++ b/themes/default/Maillist.template.php
@@ -392,7 +392,7 @@ function template_bounce_template()
 						<br />';
 
 	echo '
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="preview" id="preview_button" value="', $txt['preview'], '" class="button_submit" />
 					<input type="submit" name="save" value="', $context['page_title'], '" class="button_submit" />
 				</div>

--- a/themes/default/ManageAttachments.template.php
+++ b/themes/default/ManageAttachments.template.php
@@ -78,7 +78,7 @@ function template_maintenance()
 			<div class="content">
 				<form action="', $scripturl, '?action=admin;area=manageattachments;sa=repair;', $context['session_var'], '=', $context['session_id'], '" method="post" accept-charset="UTF-8">
 					<p>', $txt['attachment_integrity_check_desc'], '</p>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="repair" value="', $txt['attachment_check_now'], '" class="button_submit" />
 					<br class="clear_right" />
 				</form>
@@ -135,7 +135,7 @@ function template_maintenance()
 				<div class="content">
 					<form action="', $scripturl, '?action=admin;area=manageattachments;sa=transfer" method="post" accept-charset="UTF-8">
 						<p>', $txt['attachment_transfer_desc'], '</p>
-						<hr class="hrcolor" />
+						<hr />
 						<dl class="settings">
 							<dt>', $txt['attachment_transfer_from'], '</dt>
 							<dd><select name="from">
@@ -177,11 +177,11 @@ function template_maintenance()
 							<dd><input type="checkbox" name="empty_it"', $context['checked'] ? ' checked="checked"' : '', ' /></dd>';
 	echo '
 						</dl>
-						<hr class="hrcolor"/>
+						<hr />
 						<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 						<input type="submit" onclick="start_progress()" name="transfer" value="', $txt['attachment_transfer_now'], '" class="button_submit" />
 						<div id="progress_msg"></div>
-						<div id="show_progress" class="padding"></div>
+						<div id="show_progress"></div>
 						<br class="clear_right" />
 					</form>
 					<script><!-- // --><![CDATA[

--- a/themes/default/ManageBoards.template.php
+++ b/themes/default/ManageBoards.template.php
@@ -448,7 +448,7 @@ function template_modify_board()
 							});
 						});
 					// ]]></script>
-					<hr class="hrcolor" />';
+					<hr />';
 
 	if (empty($context['board']['is_recycle']) && empty($context['board']['topics']))
 		echo '

--- a/themes/default/ManageCalendar.template.php
+++ b/themes/default/ManageCalendar.template.php
@@ -72,7 +72,7 @@ function template_edit_holiday()
 							</select>
 						</dd>
 					</dl>
-					<hr class="hrcolor" />';
+					<hr />';
 
 	if ($context['is_new'])
 		echo '

--- a/themes/default/ManageLanguages.template.php
+++ b/themes/default/ManageLanguages.template.php
@@ -80,8 +80,8 @@ function template_download_language()
 			</div>
 			<table class="table_grid">
 				<thead>
-					<tr class="catbg">
-						<th class="first_th" scope="col">
+					<tr class="table_head">
+						<th scope="col">
 							', $txt['languages_download_filename'], '
 						</th>
 						<th scope="col" style="width:100">
@@ -90,7 +90,7 @@ function template_download_language()
 						<th scope="col" style="width:100">
 							', $txt['languages_download_exists'], '
 						</th>
-						<th class="last_th centertext" scope="col" style="width:4%">
+						<th scope="col" style="width:4%">
 							', $txt['languages_download_copy'], '
 						</th>
 					</tr>
@@ -189,7 +189,7 @@ function template_download_language()
 
 	// Install?
 	echo '
-			<div class="righttext padding">
+			<div class="righttext">
 				<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 				<input type="hidden" name="', $context['admin-dlang_token_var'], '" value="', $context['admin-dlang_token'], '" />
 				<input type="submit" name="do_install" value="', $txt['add_language_elk_install'], '" class="button_submit" />

--- a/themes/default/ManageMaintenance.template.php
+++ b/themes/default/ManageMaintenance.template.php
@@ -532,7 +532,7 @@ function template_convert_msgbody()
 
 	echo '
 				<form action="', $scripturl, '?action=admin;area=maintain;sa=database;activity=convertmsgbody" method="post" accept-charset="UTF-8">
-				<hr class="hrcolor" />
+				<hr />
 				<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 				<input type="hidden" name="', $context['admin-maint_token_var'], '" value="', $context['admin-maint_token'], '" />
 				<input type="submit" name="do_conversion" value="', $txt['convert_proceed'], '" class="button_submit" />

--- a/themes/default/ManageMembergroups.template.php
+++ b/themes/default/ManageMembergroups.template.php
@@ -571,8 +571,8 @@ function template_group_members()
 			', template_pagesection(false, false, 'go_down'), '
 			<table class="table_grid">
 				<thead>
-					<tr class="catbg">
-						<th class="first_th"><a href="', $scripturl, '?action=', $context['current_action'], (isset($context['admin_area']) ? ';area=' . $context['admin_area'] : ''), ';sa=members;start=', $context['start'], ';sort=name', $context['sort_by'] == 'name' && $context['sort_direction'] == 'up' ? ';desc' : '', ';group=', $context['group']['id'], '">', $txt['name'], $context['sort_by'] == 'name' ? ' <img class="sort" src="' . $settings['images_url'] . '/sort_' . $context['sort_direction'] . '.png" alt="" />' : '', '</a></th>';
+					<tr class="table_head">
+						<th><a href="', $scripturl, '?action=', $context['current_action'], (isset($context['admin_area']) ? ';area=' . $context['admin_area'] : ''), ';sa=members;start=', $context['start'], ';sort=name', $context['sort_by'] == 'name' && $context['sort_direction'] == 'up' ? ';desc' : '', ';group=', $context['group']['id'], '">', $txt['name'], $context['sort_by'] == 'name' ? ' <img class="sort" src="' . $settings['images_url'] . '/sort_' . $context['sort_direction'] . '.png" alt="" />' : '', '</a></th>';
 
 	if ($context['can_send_email'])
 		echo '
@@ -584,7 +584,7 @@ function template_group_members()
 						<th ', empty($context['group']['assignable']) ? ' class="last_th" colspan="2"' : '', '><a href="', $scripturl, '?action=', $context['current_action'], (isset($context['admin_area']) ? ';area=' . $context['admin_area'] : ''), ';sa=members;start=', $context['start'], ';sort=posts', $context['sort_by'] == 'posts' && $context['sort_direction'] == 'up' ? ';desc' : '', ';group=', $context['group']['id'], '">', $txt['posts'], $context['sort_by'] == 'posts' ? ' <img src="' . $settings['images_url'] . '/sort_' . $context['sort_direction'] . '.png" alt="" />' : '','</a></th>';
 	if (!empty($context['group']['assignable']))
 		echo '
-						<th class="last_th centertext" style="width:4%"><input type="checkbox" class="input_check" onclick="invertAll(this, this.form);" /></th>';
+						<th style="width:4%"><input type="checkbox" class="input_check" onclick="invertAll(this, this.form);" /></th>';
 	echo '
 					</tr>
 				</thead>

--- a/themes/default/ManageMembers.template.php
+++ b/themes/default/ManageMembers.template.php
@@ -163,10 +163,10 @@ function template_search_members()
 			<div class="flow_hidden">
 				<table style="width:49%" class="table_grid floatleft">
 					<thead>
-						<tr class="catbg">
-							<th scope="col" class="first_th">', $txt['membergroups'], '</th>
-							<th scope="col" class="centertext">', $txt['primary'], '</th>
-							<th scope="col" class="last_th centertext">', $txt['additional'], '</th>
+						<tr class="table_head">
+							<th scope="col">', $txt['membergroups'], '</th>
+							<th scope="col">', $txt['primary'], '</th>
+							<th scope="col">', $txt['additional'], '</th>
 						</tr>
 					</thead>
 					<tbody>';
@@ -200,7 +200,7 @@ function template_search_members()
 
 				<table style="width:49%" class="table_grid floatright">
 					<thead>
-						<tr class="catbg">
+						<tr class="table_head">
 							<th scope="col" class="first_th">
 								', $txt['membergroups_postgroups'], '
 							</th>

--- a/themes/default/ManageNews.template.php
+++ b/themes/default/ManageNews.template.php
@@ -327,7 +327,7 @@ function template_email_members_send()
 						<div class="full_bar">', $context['percentage_done'], '% ', $txt['email_done'], '</div>
 						<div class="green_percent" style="width: ', $context['percentage_done'], '%;">&nbsp;</div>
 					</div>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="cont" value="', $txt['email_continue'], '" class="button_submit" />
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 					<input type="hidden" name="subject" value="', $context['subject'], '" />

--- a/themes/default/ManagePaid.template.php
+++ b/themes/default/ManagePaid.template.php
@@ -63,7 +63,7 @@ function template_modify_subscription()
 							<input type="checkbox" name="active" id="activated_check"', empty($context['sub']['active']) ? '' : ' checked="checked"', ' class="input_check" />
 						</dd>
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<dl class="settings">
 						<dt>
 							', $txt['paid_mod_prim_group'], ':<br /><span class="smalltext">', $txt['paid_mod_prim_group_desc'], '</span>
@@ -105,7 +105,7 @@ function template_modify_subscription()
 							<textarea name="emailcomplete" rows="6" cols="40">', $context['sub']['email_complete'], '</textarea>
 						</dd>
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="radio" name="duration_type" id="duration_type_fixed" value="fixed" ', empty($context['sub']['duration']) || $context['sub']['duration'] == 'fixed' ? 'checked="checked"' : '', ' class="input_radio" onclick="toggleDuration(\'fixed\');" />
 					<strong>', $txt['paid_mod_fixed_price'], '</strong>
 					<br />
@@ -190,7 +190,7 @@ function template_modify_subscription()
 							</dl>
 						</fieldset>
 					</div>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="save" value="', $txt['paid_settings_save'], '" class="button_submit" />
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 					<input type="hidden" name="', $context['admin-pms_token_var'], '" value="', $context['admin-pms_token'], '" />
@@ -472,7 +472,7 @@ function template_user_subscription()
 					', sprintf($modSettings['paid_currency_symbol'], $subscription['costs']['fixed']);
 
 				echo '
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="sub_id[', $subscription['id'], ']" value="', $txt['paid_order'], '" class="button_submit" />';
 			}
 			else
@@ -495,11 +495,11 @@ function template_user_subscription()
 		</div>
 		<table class="table_grid">
 			<thead>
-				<tr class="catbg">
-					<th class="first_th" style="width:30%">', $txt['paid_name'], '</th>
-					<th class="centertext">', $txt['paid_status'], '</th>
-					<th class="centertext">', $txt['start_date'], '</th>
-					<th class="last_th centertext">', $txt['end_date'], '</th>
+				<tr class="table_head">
+					<th class="style="width:30%">', $txt['paid_name'], '</th>
+					<th>', $txt['paid_status'], '</th>
+					<th>', $txt['start_date'], '</th>
+					<th>', $txt['end_date'], '</th>
 				</tr>
 			</thead>
 			<tbody>';

--- a/themes/default/ManagePermissions.template.php
+++ b/themes/default/ManagePermissions.template.php
@@ -46,21 +46,21 @@ function template_permission_index()
 		echo '
 			<table class="table_grid">
 				<thead>
-					<tr class="catbg">
-						<th class="first_th">', $txt['membergroups_name'], '</th>
-						<th class="centertext" style="width:10%">', $txt['membergroups_members_top'], '</th>';
+					<tr class="table_head">
+						<th>', $txt['membergroups_name'], '</th>
+						<th style="width:10%">', $txt['membergroups_members_top'], '</th>';
 
 			if (empty($modSettings['permission_enable_deny']))
 				echo '
-						<th class="centertext" style="width:16%">', $txt['membergroups_permissions'], '</th>';
+						<th style="width:16%">', $txt['membergroups_permissions'], '</th>';
 			else
 				echo '
-						<th class="centertext" style="width:8%">', $txt['permissions_allowed'], '</th>
-						<th class="centertext" style="width:8%">', $txt['permissions_denied'], '</th>';
+						<th style="width:8%">', $txt['permissions_allowed'], '</th>
+						<th style="width:8%">', $txt['permissions_denied'], '</th>';
 
 			echo '
-						<th class="centertext" style="width:10%;vertical-align:middle">', $context['can_modify'] ? $txt['permissions_modify'] : $txt['permissions_view'], '</th>
-						<th class="last_th centertext" style="width:4%;vertical-align:middle">
+						<th style="width:10%; vertical-align:middle">', $context['can_modify'] ? $txt['permissions_modify'] : $txt['permissions_view'], '</th>
+						<th style="width:4%;vertical-align:middle">
 							', $context['can_modify'] ? '<input type="checkbox" class="input_check" onclick="invertAll(this, this.form, \'group\');" />' : '', '
 						</th>
 					</tr>
@@ -388,10 +388,10 @@ function template_edit_profiles()
 
 			<table class="table_grid">
 				<thead>
-					<tr class="catbg">
-						<th class="first_th">', $txt['permissions_profile_name'], '</th>
-						<th', !empty($context['show_rename_boxes']) ? ' class="last_th"' : '', '>', $txt['permissions_profile_used_by'], '</th>
-						<th class="last_th" style="width:5%', !empty($context['show_rename_boxes']) ? ';display:none"' : '"', ' >', $txt['delete'], '</th>
+					<tr class="table_head">
+						<th>', $txt['permissions_profile_name'], '</th>
+						<th>', $txt['permissions_profile_used_by'], '</th>
+						<th style="width:5%', !empty($context['show_rename_boxes']) ? ';display:none"' : '"', ' >', $txt['delete'], '</th>
 					</tr>
 				</thead>
 				<tbody>';
@@ -425,7 +425,7 @@ function template_edit_profiles()
 	echo '
 				</tbody>
 			</table>
-			<div class="flow_auto righttext padding">
+			<div class="flow_auto righttext">
 				<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 				<input type="hidden" name="', $context['admin-mpp_token_var'], '" value="', $context['admin-mpp_token'], '" />';
 
@@ -465,7 +465,7 @@ function template_edit_profiles()
 							</select>
 						</dd>
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 					<input type="hidden" name="', $context['admin-mpp_token_var'], '" value="', $context['admin-mpp_token'], '" />
 					<input type="submit" name="create" value="', $txt['permissions_profile_new_create'], '" class="button_submit" />
@@ -566,9 +566,7 @@ function template_modify_group()
 
 	if ($context['profile']['can_modify'])
 		echo '
-			<div class="padding">
-				<input type="submit" value="', $txt['permissions_commit'], '" class="button_submit" />
-			</div>';
+			<input type="submit" value="', $txt['permissions_commit'], '" class="button_submit" />';
 
 	echo '
 			<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
@@ -591,18 +589,18 @@ function template_modify_group_simple($type)
 	echo '
 			<table class="table_grid">
 				<thead>
-					<tr class="catbg">
-						<th class="first_th lefttext" colspan="2" style="width:100%"></th>';
+					<tr class="table_head">
+						<th class="lefttext" colspan="2" style="width:100%"></th>';
 				if (empty($modSettings['permission_enable_deny']) || $context['group']['id'] == -1)
 					echo '
 						<th></th>
 						<th></th>
-						<th class="last_th centertext">&nbsp;</th>';
+						<th>&nbsp;</th>';
 				else
 					echo '
-						<th class="centertext">', $txt['permissions_option_on'], '</th>
-						<th class="centertext">', $txt['permissions_option_off'], '</th>
-						<th class="last_th centertext">', $txt['permissions_option_deny'], '</th>';
+						<th>', $txt['permissions_option_on'], '</th>
+						<th>', $txt['permissions_option_off'], '</th>
+						<th>', $txt['permissions_option_deny'], '</th>';
 
 				echo '
 					</tr>
@@ -893,7 +891,7 @@ function template_modify_group_classic($type)
 				if ($has_display_content)
 				{
 					echo '
-							<tr class="catbg">
+							<tr class="table_head">
 								<th class="lefttext" colspan="2" style="width:100%">
 									<strong class="smalltext">', $permissionGroup['name'], '</strong>
 								</th>';
@@ -903,9 +901,9 @@ function template_modify_group_classic($type)
 								<th></th><th></th><th></th>';
 					else
 						echo '
-								<th class="centertext"><div>', $txt['permissions_option_on'], '</div></th>
-								<th class="centertext"><div>', $txt['permissions_option_off'], '</div></th>
-								<th class="centertext"><div>', $txt['permissions_option_deny'], '</div></th>';
+								<th><div>', $txt['permissions_option_on'], '</div></th>
+								<th><div>', $txt['permissions_option_off'], '</div></th>
+								<th><div>', $txt['permissions_option_deny'], '</div></th>';
 					echo '
 							</tr>';
 				}
@@ -1138,7 +1136,7 @@ function template_postmod_permissions()
 				<div class="information">', $txt['permissions_post_moderation_deny_note'], '</div>';
 
 	echo '
-				<div class="righttext padding">
+				<div class="righttext">
 					', $txt['permissions_post_moderation_select'], ':
 					<select name="pid" onchange="document.forms.postmodForm.submit();">';
 
@@ -1153,18 +1151,18 @@ function template_postmod_permissions()
 			</div>
 			<table class="table_grid">
 				<thead>
-					<tr class="catbg">
-						<th class="first_th"></th>
-						<th class="centertext" colspan="3">
+					<tr class="table_head">
+						<th></th>
+						<th colspan="3">
 							', $txt['permissions_post_moderation_new_topics'], '
 						</th>
-						<th class="centertext" colspan="3">
+						<th colspan="3">
 							', $txt['permissions_post_moderation_replies_own'], '
 						</th>
-						<th class="centertext" colspan="3">
+						<th colspan="3">
 							', $txt['permissions_post_moderation_replies_any'], '
 						</th>
-						<th class="last_th centertext" colspan="3">
+						<th colspan="3">
 							', $txt['permissions_post_moderation_attachments'], '
 						</th>
 					</tr>
@@ -1172,18 +1170,18 @@ function template_postmod_permissions()
 						<th style="width:30%">
 							', $txt['permissions_post_moderation_group'], '
 						</th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_allow.png" alt="', $txt['permissions_post_moderation_allow'], '" title="', $txt['permissions_post_moderation_allow'], '" /></th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_moderate.png" alt="', $txt['permissions_post_moderation_moderate'], '" title="', $txt['permissions_post_moderation_moderate'], '" /></th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_deny.png" alt="', $txt['permissions_post_moderation_disallow'], '" title="', $txt['permissions_post_moderation_disallow'], '" /></th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_allow.png" alt="', $txt['permissions_post_moderation_allow'], '" title="', $txt['permissions_post_moderation_allow'], '" /></th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_moderate.png" alt="', $txt['permissions_post_moderation_moderate'], '" title="', $txt['permissions_post_moderation_moderate'], '" /></th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_deny.png" alt="', $txt['permissions_post_moderation_disallow'], '" title="', $txt['permissions_post_moderation_disallow'], '" /></th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_allow.png" alt="', $txt['permissions_post_moderation_allow'], '" title="', $txt['permissions_post_moderation_allow'], '" /></th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_moderate.png" alt="', $txt['permissions_post_moderation_moderate'], '" title="', $txt['permissions_post_moderation_moderate'], '" /></th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_deny.png" alt="', $txt['permissions_post_moderation_disallow'], '" title="', $txt['permissions_post_moderation_disallow'], '" /></th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_allow.png" alt="', $txt['permissions_post_moderation_allow'], '" title="', $txt['permissions_post_moderation_allow'], '" /></th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_moderate.png" alt="', $txt['permissions_post_moderation_moderate'], '" title="', $txt['permissions_post_moderation_moderate'], '" /></th>
-						<th class="centertext"><img src="', $settings['default_images_url'], '/admin/post_moderation_deny.png" alt="', $txt['permissions_post_moderation_disallow'], '" title="', $txt['permissions_post_moderation_disallow'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_allow.png" alt="', $txt['permissions_post_moderation_allow'], '" title="', $txt['permissions_post_moderation_allow'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_moderate.png" alt="', $txt['permissions_post_moderation_moderate'], '" title="', $txt['permissions_post_moderation_moderate'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_deny.png" alt="', $txt['permissions_post_moderation_disallow'], '" title="', $txt['permissions_post_moderation_disallow'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_allow.png" alt="', $txt['permissions_post_moderation_allow'], '" title="', $txt['permissions_post_moderation_allow'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_moderate.png" alt="', $txt['permissions_post_moderation_moderate'], '" title="', $txt['permissions_post_moderation_moderate'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_deny.png" alt="', $txt['permissions_post_moderation_disallow'], '" title="', $txt['permissions_post_moderation_disallow'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_allow.png" alt="', $txt['permissions_post_moderation_allow'], '" title="', $txt['permissions_post_moderation_allow'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_moderate.png" alt="', $txt['permissions_post_moderation_moderate'], '" title="', $txt['permissions_post_moderation_moderate'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_deny.png" alt="', $txt['permissions_post_moderation_disallow'], '" title="', $txt['permissions_post_moderation_disallow'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_allow.png" alt="', $txt['permissions_post_moderation_allow'], '" title="', $txt['permissions_post_moderation_allow'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_moderate.png" alt="', $txt['permissions_post_moderation_moderate'], '" title="', $txt['permissions_post_moderation_moderate'], '" /></th>
+						<th><img src="', $settings['default_images_url'], '/admin/post_moderation_deny.png" alt="', $txt['permissions_post_moderation_disallow'], '" title="', $txt['permissions_post_moderation_disallow'], '" /></th>
 					</tr>
 				</thead>
 				<tbody>';
@@ -1218,7 +1216,7 @@ function template_postmod_permissions()
 	echo '
 				</tbody>
 			</table>
-			<div class="righttext padding">
+			<div class="righttext">
 				<input type="submit" name="save_changes" value="', $txt['permissions_commit'], '" class="button_submit" />
 				<input type="hidden" name="', $context['admin-mppm_token_var'], '" value="', $context['admin-mppm_token'], '" />
 			</div>

--- a/themes/default/ManageSearch.template.php
+++ b/themes/default/ManageSearch.template.php
@@ -257,7 +257,7 @@ function template_create_index()
 							</select>
 						</dd>
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="save" value="', $txt['search_create_index_start'], '" class="button_submit" />
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 				</div>
@@ -287,7 +287,7 @@ function template_create_index_progress()
 							<div class="green_percent" style="width: ', $context['percentage'], '%;">&nbsp;</div>
 						</div>
 					</div>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="cont" value="', $txt['search_create_index_continue'], '" class="button_submit" />
 				</div>
 			</div>
@@ -364,7 +364,7 @@ function template_spider_edit()
 							<textarea name="spider_ip" id="spider_ip" rows="4" cols="20">', $context['spider']['ip_info'], '</textarea>
 						</dd>
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="save" value="', $context['page_title'], '" class="button_submit" />
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 					<input type="hidden" name="', $context['admin-ses_token_var'], '" value="', $context['admin-ses_token'], '" />
@@ -429,7 +429,7 @@ function template_show_spider_stats()
 					<p>
 						', sprintf($txt['spider_stats_delete_older'], '<input type="text" name="older" id="older" value="90" size="3" class="input_text" />'), '
 					</p>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 					<input type="hidden" name="', $context['admin-ss_token_var'], '" value="', $context['admin-ss_token'], '" />
 					<input type="submit" name="delete_entries" value="', $txt['spider_logs_delete_submit'], '" onclick="if (document.getElementById(\'older\').value &lt; 1 &amp;&amp; !confirm(\'' . addcslashes($txt['spider_logs_delete_confirm'], "'") . '\')) return false; return true;" class="button_submit" />

--- a/themes/default/ManageSmileys.template.php
+++ b/themes/default/ManageSmileys.template.php
@@ -153,7 +153,7 @@ function template_modifyset()
 
 		echo '
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="smiley_save" value="', $txt['smiley_sets_save'], '" class="button_submit" />
 				</div>
 			</div>
@@ -242,7 +242,7 @@ function template_modifysmiley()
 							</select>
 						</dd>
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="smiley_save" value="', $txt['smileys_save'], '" class="button_submit" />
 					<input type="submit" name="deletesmiley" value="', $txt['smileys_delete'], '" onclick="return confirm(\'', $txt['smileys_delete_confirm'], '\');" class="button_submit" />
 				</div>
@@ -393,7 +393,7 @@ function template_addsmiley()
 							</select>
 						</dd>
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="smiley_save" value="', $txt['smileys_save'], '" class="button_submit" />
 				</div>
 			</div>
@@ -525,7 +525,7 @@ function template_editicon()
 					<input type="hidden" name="icon" value="', $context['icon']['id'], '" />';
 
 	echo '
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="icons_save" value="', $txt['smileys_save'], '" class="button_submit" />
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 				</div>

--- a/themes/default/Memberlist.template.php
+++ b/themes/default/Memberlist.template.php
@@ -21,24 +21,22 @@ function template_main()
 {
 	global $context, $settings, $scripturl, $txt;
 
+	template_pagesection('memberlist_buttons', 'right', 'go_down');
+
 	echo '
-	<div class="main_section" id="memberlist">
-		', template_pagesection('memberlist_buttons', 'right', 'go_down'), '
-		<div class="cat_bar">
-			<h4 class="catbg">
+	<div id="memberlist">
+		<h2 class="category_header">
 				<span class="floatleft">', $txt['members_list'], '</span>';
 		if (!isset($context['old_search']))
 				echo '
-				<span class="floatright">', $context['letter_links'], '</span>';
+				<span class="floatright" letter_links>', $context['letter_links'], '</span>';
 		echo '
-			</h4>
-		</div>';
+		</h2>';
 
 	echo '
-		<div id="mlist" class="tborder topic_table">
-			<table class="table_grid">
+		<table class="table_grid">
 			<thead>
-				<tr class="catbg">';
+				<tr class="table_head">';
 
 	// Display each of the column headers of the table.
 	foreach ($context['columns'] as $key => $column)
@@ -50,13 +48,15 @@ function template_main()
 		// This is a selected column, so underline it or some such.
 		if ($column['selected'])
 			echo '
-					<th scope="col" class="', isset($column['class']) ? ' ' . $column['class'] : '', '" style="width: auto;white-space: nowrap"' . (isset($column['colspan']) ? ' colspan="' . $column['colspan'] . '"' : '') . '>
-						<a href="' . $column['href'] . '" rel="nofollow">' . $column['label'] . '</a><img class="sort" src="' . $settings['images_url'] . '/sort_' . $context['sort_direction'] . '.png" alt="" /></th>';
+					<th scope="col" class="', isset($column['class']) ? ' ' . $column['class'] : '', '" style="width: auto; white-space: nowrap"' . (isset($column['colspan']) ? ' colspan="' . $column['colspan'] . '"' : '') . '>
+						<a href="' . $column['href'] . '" rel="nofollow">' . $column['label'] . '</a><img class="sort" src="' . $settings['images_url'] . '/sort_' . $context['sort_direction'] . '.png" alt="" />
+					</th>';
 		// This is just some column... show the link and be done with it.
 		else
 			echo '
 					<th scope="col" class="', isset($column['class']) ? ' ' . $column['class'] : '', '"', isset($column['width']) ? ' style="width:' . $column['width'] . '"' : '', isset($column['colspan']) ? ' colspan="' . $column['colspan'] . '"' : '', '>
-						', $column['link'], '</th>';
+						', $column['link'], '
+					</th>';
 	}
 	echo '
 				</tr>
@@ -74,7 +74,7 @@ function template_main()
 					<td class="centertext">
 						', $context['can_send_pm'] ? '<a href="' . $member['online']['href'] . '" title="' . $member['online']['text'] . '">' : '', $settings['use_image_buttons'] ? '<img src="' . $member['online']['image_href'] . '" alt="' . $member['online']['text'] . '" class="centericon" />' : $member['online']['label'], $context['can_send_pm'] ? '</a>' : '', '
 					</td>
-					<td class="lefttext">', $member['link'], '</td>';
+					<td>', $member['link'], '</td>';
 
 			if ($context['can_send_email'])
 				echo '
@@ -86,8 +86,8 @@ function template_main()
 
 			// Group and date.
 			echo '
-					<td class="lefttext">', empty($member['group']) ? $member['post_group'] : $member['group'], '</td>
-					<td class="lefttext">', $member['registered_date'], '</td>';
+					<td>', empty($member['group']) ? $member['post_group'] : $member['group'], '</td>
+					<td>', $member['registered_date'], '</td>';
 
 			if (!isset($context['disabled_fields']['posts']))
 			{
@@ -100,7 +100,7 @@ function template_main()
 			{
 				foreach ($context['custom_profile_fields']['columns'] as $key => $column)
 					echo '
-						<td class="lefttext">', $member['options'][substr($key, 5)], '</td>';
+						<td>', $member['options'][substr($key, 5)], '</td>';
 			}
 
 			echo '
@@ -113,13 +113,12 @@ function template_main()
 	else
 		echo '
 				<tr>
-					<td colspan="', $context['colspan'], '" class="windowbg">', $txt['search_no_results'], '</td>
+					<td colspan="', $context['colspan'], '" class="standard_row">', $txt['search_no_results'], '</td>
 				</tr>';
 
 				echo '
 			</tbody>
-			</table>
-		</div>';
+		</table>';
 
 	// If it is displaying the result of a search show a "search again" link to edit their criteria.
 	if (isset($context['old_search']))
@@ -143,42 +142,38 @@ function template_search()
 {
 	global $context, $settings, $scripturl, $txt;
 
+	template_pagesection('memberlist_buttons', 'right', '', array('top_button' => false));
+
 	// Start the submission form for the search!
 	echo '
-	<form action="', $scripturl, '?action=memberlist;sa=search" method="post" accept-charset="UTF-8">
-		<div id="memberlist">', template_pagesection('memberlist_buttons', 'right', '', array('top_button' => false)), '
-			<div class="cat_bar">
-				<h3 class="catbg mlist">
-					', !empty($settings['use_buttons']) ? '<img src="' . $settings['images_url'] . '/buttons/search_hd.png" alt="" class="icon" />' : '', $txt['mlist_search'], '
-				</h3>
-			</div>
-			<div id="memberlist_search" class="clear">
-				<div class="roundframe">
-					<dl id="mlist_search" class="settings">
-						<dt>
-							<label><strong>', $txt['search_for'], ':</strong></label>
-						</dt>
-						<dd>
-							<input type="text" name="search" value="', $context['old_search'], '" size="40" class="input_text" placeholder="', $txt['search'], '" autofocus="autofocus" required="required" />
-						</dd>
-						<dt>
-							<label><strong>', $txt['mlist_search_filter'], ':</strong></label>
-						</dt>';
+	<form id="memberlist" class="standard_category" action="', $scripturl, '?action=memberlist;sa=search" method="post" accept-charset="UTF-8">
+		<h2 class="category_header">
+			', !empty($settings['use_buttons']) ? '<img src="' . $settings['images_url'] . '/buttons/search_hd.png" alt="" class="icon" />' : '', $txt['mlist_search'], '
+		</h2>
+		<div class="content">
+			<dl id="memberlist_search" class="settings">
+				<dt>
+					<label><strong>', $txt['search_for'], ':</strong></label>
+				</dt>
+				<dd>
+					<input type="text" name="search" value="', $context['old_search'], '" size="40" class="input_text" placeholder="', $txt['search'], '" autofocus="autofocus" required="required" />
+				</dd>
+				<dt>
+					<label><strong>', $txt['mlist_search_filter'], ':</strong></label>
+				</dt>';
 
 	foreach ($context['search_fields'] as $id => $title)
 	{
 		echo '
-						<dd>
-							<label for="fields-', $id, '"><input type="checkbox" name="fields[]" id="fields-', $id, '" value="', $id, '" ', in_array($id, $context['search_defaults']) ? 'checked="checked"' : '', ' class="input_check floatright" />', $title, '</label>
-						</dd>';
+				<dd>
+					<label for="fields-', $id, '"><input type="checkbox" name="fields[]" id="fields-', $id, '" value="', $id, '" ', in_array($id, $context['search_defaults']) ? 'checked="checked"' : '', ' class="input_check floatright" />', $title, '</label>
+				</dd>';
 	}
 
 	echo '
-					</dl>
-					<div class="flow_auto">
-						<input type="submit" name="submit" value="' . $txt['search'] . '" class="button_submit" />
-					</div>
-				</div>
+			</dl>
+			<div class="submit_buttons_wrap">
+				<input type="submit" name="submit" value="' . $txt['search'] . '" class="button_submit" />
 			</div>
 		</div>
 	</form>';

--- a/themes/default/Members.template.php
+++ b/themes/default/Members.template.php
@@ -53,12 +53,12 @@ function template_find_members()
 		// ]]></script>
 	</head>
 	<body id="help_popup">
-		<form action="', $scripturl, '?action=findmember;', $context['session_var'], '=', $context['session_id'], '" method="post" accept-charset="UTF-8" class="padding description">
+		<form action="', $scripturl, '?action=findmember;', $context['session_var'], '=', $context['session_id'], '" method="post" accept-charset="UTF-8">
 			<div class="roundframe">
 				<div class="cat_bar">
 					<h3 class="catbg">', $txt['find_members'], '</h3>
 				</div>
-				<div class="padding">
+				<div>
 					<strong>', $txt['find_username'], ':</strong><br />
 					<input type="text" name="search" id="search" value="', isset($context['last_search']) ? $context['last_search'] : '', '" style="margin-top: 4px; width: 96%;" class="input_text" autofocus="autofocus" placeholder="', $txt['find_members'], '" required="required" /><br />
 					<span class="smalltext"><em>', $txt['find_wildcards'], '</em></span><br />';
@@ -85,7 +85,7 @@ function template_find_members()
 	else
 	{
 		echo '
-				<ul class="padding">';
+				<ul>';
 
 		$alternate = true;
 		foreach ($context['results'] as $result)

--- a/themes/default/MergeTopics.template.php
+++ b/themes/default/MergeTopics.template.php
@@ -90,7 +90,7 @@ function template_merge()
 
 	echo '
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<dl class="settings merge_topic">
 						<dt>
 							<strong>', $txt['merge_to_topic_id'], ': </strong>
@@ -146,12 +146,12 @@ function template_merge_extra_options()
 			</div>
 			<table class="bordercolor table_grid">
 				<thead>
-					<tr class="catbg">
-						<th scope="col" class="first_th centertext" style="width:6em">', $txt['merge_check'], '</th>
+					<tr class="table_head">
+						<th scope="col" style="width:6em">', $txt['merge_check'], '</th>
 						<th scope="col" class="lefttext">', $txt['subject'], '</th>
 						<th scope="col" class="lefttext">', $txt['started_by'], '</th>
 						<th scope="col" class="lefttext">', $txt['last_post'], '</th>
-						<th scope="col" class="last_th centertext" style="width:10em">' . $txt['merge_include_notifications'] . '</th>
+						<th scope="col" style="width:10em">' . $txt['merge_include_notifications'] . '</th>
 					</tr>
 				</thead>
 				<tbody>';

--- a/themes/default/ModerationCenter.template.php
+++ b/themes/default/ModerationCenter.template.php
@@ -573,7 +573,7 @@ function template_moderation_settings()
 
 	echo '
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 					<input type="hidden" name="', $context['mod-set_token_var'], '" value="', $context['mod-set_token'], '" />
 					<input type="submit" name="save" value="', $txt['save'], '" class="button_submit" />
@@ -687,7 +687,7 @@ function template_warn_template()
 						<br />';
 
 	echo '
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" name="preview" id="preview_button" value="', $txt['preview'], '" class="button_submit" />
 					<input type="submit" name="save" value="', $context['page_title'], '" class="button_submit" />
 				</div>

--- a/themes/default/MoveTopic.template.php
+++ b/themes/default/MoveTopic.template.php
@@ -22,7 +22,7 @@ function template_main()
 	global $context, $txt, $scripturl;
 
 	echo '
-	<div id="move_topic" class="lower_padding">
+	<div id="move_topic">
 		<form action="', $scripturl, '?action=movetopic2;current_board=' . $context['current_board'] . ';topic=', $context['current_topic'], '.0" method="post" accept-charset="UTF-8" onsubmit="submitonce(this);">
 			<div class="cat_bar">
 				<h3 class="catbg">', $txt['move_topic'], '</h3>

--- a/themes/default/Packages.template.php
+++ b/themes/default/Packages.template.php
@@ -140,12 +140,12 @@ function template_view_package()
 			</div>
 			<table class="table_grid">
 			<thead>
-				<tr class="catbg">
-					<th class="first_th" scope="col" style="width:20px"></th>
+				<tr class="table_head">
+					<th scope="col" style="width:20px"></th>
 					<th scope="col" style="width:30px"></th>
 					<th scope="col" class="lefttext">', $txt['package_install_type'], '</th>
 					<th scope="col" class="lefttext" style="width:50%">', $txt['package_install_action'], '</th>
-					<th class="last_th lefttext" scope="col" style="width:20%">', $txt['package_install_desc'], '</th>
+					<th class="lefttext" scope="col" style="width:20%">', $txt['package_install_desc'], '</th>
 				</tr>
 			</thead>
 			<tbody>';
@@ -173,8 +173,8 @@ function template_view_package()
 			{
 				echo '
 				<tr id="operation_', $action_num, '">
-					<td colspan="5" class="windowbg3">
-						<table class="table_padding" style="width:100%">';
+					<td colspan="5" class="standard_row">
+						<table class="table_grid">';
 
 				// Show the operations.
 				$alternate2 = true;
@@ -270,8 +270,8 @@ function template_view_package()
 					{
 						echo '
 					<tr id="operation_', $action_num, '">
-						<td colspan="5" class="windowbg3">
-							<table class="table_padding" style="width:100%">';
+						<td colspan="5" class="standard_row">
+							<table class="table_grid">';
 
 						$alternate2 = true;
 						$operation_num = 1;
@@ -316,7 +316,7 @@ function template_view_package()
 	if (!$context['ftp_needed'] && (!empty($context['actions']) || !empty($context['database_changes'])))
 	{
 		echo '
-			<div class="righttext padding">
+			<div class="righttext">
 				<input type="submit" value="', $context['uninstalling'] ? $txt['package_uninstall_now'] : $txt['package_install_now'], '" onclick="return ', !empty($context['has_failure']) ? '(submitThisOnce(this) &amp;&amp; confirm(\'' . ($context['uninstalling'] ? $txt['package_will_fail_popup_uninstall'] : $txt['package_will_fail_popup']) . '\'))' : 'submitThisOnce(this)', ';" class="button_submit" />
 			</div>';
 	}
@@ -611,7 +611,7 @@ function template_browse()
 								<input type="text" name="version_emulate" id="ve" value="', $context['forum_version'], '" size="25" class="input_text" />
 							</dd>
 						</dl>
-						<div class="righttext padding">
+						<div class="righttext">
 							<input type="submit" value="', $txt['package_apply'], '" class="button_submit" />
 						</div>
 					</div>
@@ -813,7 +813,7 @@ function template_servers()
 							<input type="file" name="package" size="38" class="input_file" />
 						</dd>
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<input type="submit" value="' . $txt['package_upload'] . '" class="button_submit" />
 					<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />
 				</form>
@@ -889,7 +889,7 @@ function template_package_list()
 				// This is supposed to be a rule..
 				elseif ($package['is_line'])
 					echo '
-							<hr class="hrcolor" />';
+							<hr />';
 				// A remote link.
 				elseif ($package['is_remote'])
 				{
@@ -957,7 +957,7 @@ function template_package_list()
 	echo '
 			</div>
 		</div>
-		<div class="padding smalltext floatleft">
+		<div>
 			', $txt['package_installed_key'], '
 			<img src="', $settings['images_url'], '/icons/package_installed.png" alt="" class="centericon" style="margin-left: 1ex;" /> ', $txt['package_installed_current'], '
 			<img src="', $settings['images_url'], '/icons/package_old.png" alt="" class="centericon" style="margin-left: 2ex;" /> ', $txt['package_installed_old'], '
@@ -1278,13 +1278,10 @@ function template_view_operations()
 		<script src="', $settings['default_theme_url'], '/scripts/theme.js?alp21"></script>
 	</head>
 	<body>
-		<div class="padding windowbg">
-			<div class="padding">
-				', $context['operations']['search'], '
-			</div>
-			<div class="padding">
+		<div class="windowbg">
+			', $context['operations']['search'], '
+			<br />
 				', $context['operations']['replace'], '
-			</div>
 		</div>
 	</body>
 </html>';
@@ -1519,14 +1516,14 @@ function template_file_permissions()
 		</div>
 		<table class="table_grid">
 			<thead>
-				<tr class="catbg">
-					<th class="first_th lefttext" style="width:30%">&nbsp;', $txt['package_file_perms_name'], '&nbsp;</th>
+				<tr class="table_head">
+					<th class="lefttext" style="width:30%">&nbsp;', $txt['package_file_perms_name'], '&nbsp;</th>
 					<th class="lefttext" style="width:30%">', $txt['package_file_perms_status'], '</th>
-					<th class="centertext" style="width:8%"><span class="filepermissions">', $txt['package_file_perms_status_read'], '</span></th>
-					<th class="centertext" style="width:8%"><span class="filepermissions">', $txt['package_file_perms_status_write'], '</span></th>
-					<th class="centertext" style="width:8%"><span class="filepermissions">', $txt['package_file_perms_status_execute'], '</span></th>
-					<th class="centertext" style="width:8%"><span class="filepermissions">', $txt['package_file_perms_status_custom'], '</span></th>
-					<th class="last_th centertext" style="width:8%"><span class="filepermissions">', $txt['package_file_perms_status_no_change'], '</span></th>
+					<th style="width:8%"><span class="filepermissions">', $txt['package_file_perms_status_read'], '</span></th>
+					<th style="width:8%"><span class="filepermissions">', $txt['package_file_perms_status_write'], '</span></th>
+					<th style="width:8%"><span class="filepermissions">', $txt['package_file_perms_status_execute'], '</span></th>
+					<th style="width:8%"><span class="filepermissions">', $txt['package_file_perms_status_custom'], '</span></th>
+					<th style="width:8%"><span class="filepermissions">', $txt['package_file_perms_status_no_change'], '</span></th>
 				</tr>
 			</thead>
 			<tbody>';

--- a/themes/default/PersonalMessage.template.php
+++ b/themes/default/PersonalMessage.template.php
@@ -25,18 +25,16 @@ function template_pm_above()
 	echo '
 					<div id="personal_messages">';
 
-	// Show the capacity bar, if available.
+	// Show the capacity bar, if available. @todo - This needs work.
 	if (!empty($context['limit_bar']))
 		echo '
-						<div class="title_bar">
-							<h3 class="titlebg">
-								<span class="floatleft">', $txt['pm_capacity'], ':</span>
-								<span class="floatleft capacity_bar">
-									<span class="', $context['limit_bar']['percent'] > 85 ? 'full' : ($context['limit_bar']['percent'] > 40 ? 'filled' : 'empty'), '" style="width: ', $context['limit_bar']['percent'] / 10, 'em;"></span>
-								</span>
-								<span class="floatright', $context['limit_bar']['percent'] > 90 ? ' alert' : '', '">', $context['limit_bar']['text'], '</span>
-							</h3>
-						</div>';
+						<h3 class="titlebg">
+							<span class="floatleft">', $txt['pm_capacity'], ':</span>
+							<span class="floatleft capacity_bar">
+								<span class="', $context['limit_bar']['percent'] > 85 ? 'full' : ($context['limit_bar']['percent'] > 40 ? 'filled' : 'empty'), '" style="width: ', $context['limit_bar']['percent'] / 10, 'em;"></span>
+							</span>
+							<span class="floatright', $context['limit_bar']['percent'] > 90 ? ' alert' : '', '">', $context['limit_bar']['text'], '</span>
+						</h3>';
 
 	// Message sent? Show a small indication.
 	if (isset($context['pm_sent']))
@@ -72,7 +70,7 @@ function template_folder()
 				// ]]></script>';
 
 	echo '
-				<form class="flow_hidden" action="', $scripturl, '?action=pm;sa=pmactions;', $context['display_mode'] == 2 ? 'conversation;' : '', 'f=', $context['folder'], ';start=', $context['start'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', '" method="post" accept-charset="UTF-8" name="pmFolder">';
+				<form action="', $scripturl, '?action=pm;sa=pmactions;', $context['display_mode'] == 2 ? 'conversation;' : '', 'f=', $context['folder'], ';start=', $context['start'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', '" method="post" accept-charset="UTF-8" name="pmFolder">';
 
 	// If we are not in single display mode show the subjects on the top! @todo - Horrible markup here.
 	if ($context['display_mode'] != 1)
@@ -98,9 +96,9 @@ function template_folder()
 		// Show the helpful titlebar - generally.
 		if ($context['display_mode'] != 1)
 			echo '
-						<h3 class="catbg">
+						<h2 class="category_header">
 							', $txt[$context['display_mode'] == 0 ? 'messages' : 'conversation'], '
-						</h3>';
+						</h2>';
 
 		while ($message = $context['get_pmessage']('message'))
 		{
@@ -115,12 +113,12 @@ function template_folder()
 							<ul class="poster">', template_build_pmposter_div($message), '</ul>';
 
 				echo '
-							<div class="postarea"', (empty($options['hide_poster_area']) ? '' : ' style="margin:0"'), '>
+							<div class="postarea', empty($options['hide_poster_area']) ? '' : '2', '">
 								<div class="keyinfo">
 									', (!empty($options['hide_poster_area']) ? '<ul class="poster poster2">' .  template_build_pmposter_div($message) . '</ul>' : ''), '
 									<span id="post_subject_', $message['id'], '" class="post_subject">', $message['subject'], '</span>
 									<h5 id="info_', $message['id'], '">';
-
+			// @todo - above needs fixing re document outlining (a11y stuffz). 
 			// Show who the message was sent to.
 			echo '
 										<strong> ', $txt['sent_to'], ':</strong> ';
@@ -318,9 +316,9 @@ function template_build_pmposter_div($message)
 
 	// Show a link to the member's profile.
 	$poster_div .= '
-								<a class="linklevel1 name" href="' . $scripturl . '?action=profile;u=' . $message['member']['id'] . '">
+									<a class="linklevel1 name" href="' . $scripturl . '?action=profile;u=' . $message['member']['id'] . '">
 									' . $message['member']['name'] . '
-								</a>';
+									</a>';
 
 	// The new member info dropdown starts here. Note that conditionals have not been fully checked yet.
 	$poster_div .= '
@@ -542,11 +540,12 @@ function template_subject_list()
 {
 	global $context, $settings, $txt, $scripturl;
 
+	// @todo - Should really get rid of some of the inline CCS in this table.
 	echo '
 					<table class="table_grid">
 						<thead>
-							<tr class="catbg">
-								<th style="width:4%" class="centertext first_th">
+							<tr class="table_head">
+								<th style="width:4%">
 									<a href="', $scripturl, '?action=pm;view;f=', $context['folder'], ';start=', $context['start'], ';sort=', $context['sort_by'], ($context['sort_direction'] == 'up' ? '' : ';desc'), ($context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : ''), '"><img src="', $settings['images_url'], '/im_switch.png" alt="', $txt['pm_change_view'], '" title="', $txt['pm_change_view'], '" width="16" height="16" /></a>
 								</th>
 								<th class="lefttext" style="width:22%">
@@ -558,7 +557,7 @@ function template_subject_list()
 								<th class="lefttext">
 									<a href="', $scripturl, '?action=pm;f=', $context['folder'], ';start=', $context['start'], ';sort=name', $context['sort_by'] == 'name' && $context['sort_direction'] == 'up' ? ';desc' : '', $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', '">', ($context['from_or_to'] == 'from' ? $txt['from'] : $txt['to']), $context['sort_by'] == 'name' ? ' <img class="sort" src="' . $settings['images_url'] . '/sort_' . $context['sort_direction'] . '.png" alt="" />' : '', '</a>
 								</th>
-								<th style="width:4%" class="centertext last_th">
+								<th style="width:4%">
 									<input type="checkbox" onclick="invertAll(this, this.form);" class="input_check" />
 								</th>
 							</tr>
@@ -567,7 +566,7 @@ function template_subject_list()
 
 	if (!$context['show_delete'])
 		echo '
-							<tr class="windowbg2">
+							<tr class="standard_row">
 								<td colspan="5">', $txt['msg_alert_none'], '</td>
 							</tr>';
 	$next_alternate = false;
@@ -575,7 +574,7 @@ function template_subject_list()
 	while ($message = $context['get_pmessage']('subject'))
 	{
 		echo '
-							<tr class="', $next_alternate ? 'windowbg' : 'windowbg2', '">
+							<tr class="', $next_alternate ? 'standard_row' : 'alternate_row', '">
 								<td class="centertext" style="width:4%">
 									<script><!-- // --><![CDATA[
 										currentLabels[', $message['id'], '] = {';
@@ -665,9 +664,7 @@ function template_search()
 
 	echo '
 	<form action="', $scripturl, '?action=pm;sa=search2" method="post" accept-charset="UTF-8" name="searchform" id="searchform">
-		<div class="cat_bar">
-			<h3 class="catbg">', $txt['pm_search_title'], '</h3>
-		</div>';
+		<h2 class="category_header">', $txt['pm_search_title'], '</h2>';
 
 	if (!empty($context['search_errors']))
 	{
@@ -682,15 +679,13 @@ function template_search()
 	{
 		echo '
 		<fieldset id="simple_search">
-			<div class="roundframe">
-				<div id="search_term_input">
-					<strong>', $txt['pm_search_text'], ':</strong>
-					<input type="text" name="search"', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' size="40" class="input_text" placeholder="', $txt['search'], '" required="required" autofocus="autofocus" />
-					<input type="submit" name="pm_search" value="', $txt['pm_search_go'], '" class="button_submit floatnone" />
-				</div>
-				<a class="button_link" href="', $scripturl, '?action=pm;sa=search;advanced" onclick="elk_setThemeOption(\'minmax_preferences\', \'1\', null, elk_session_id, elk_session_var, \';minmax_key=pmsearch\');this.href += \';search=\' + escape(document.forms.searchform.search.value);">', $txt['pm_search_advanced'], '</a>
-				<input type="hidden" name="advanced" value="0" />
+			<div id="search_term_input">
+				<strong>', $txt['pm_search_text'], ':</strong>
+				<input type="text" name="search"', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' size="40" class="input_text" placeholder="', $txt['search'], '" required="required" autofocus="autofocus" />
+				<input type="submit" name="pm_search" value="', $txt['pm_search_go'], '" class="button_submit floatnone" />
 			</div>
+			<a class="button_link" href="', $scripturl, '?action=pm;sa=search;advanced" onclick="elk_setThemeOption(\'minmax_preferences\', \'1\', null, elk_session_id, elk_session_var, \';minmax_key=pmsearch\');this.href += \';search=\' + escape(document.forms.searchform.search.value);">', $txt['pm_search_advanced'], '</a>
+			<input type="hidden" name="advanced" value="0" />
 		</fieldset>';
 	}
 	// Advanced search!
@@ -698,68 +693,61 @@ function template_search()
 	{
 		echo '
 		<fieldset id="advanced_search">
-			<div class="roundframe">
-				<dl class="settings" id="search_options">
-					<dt>
-						<strong>', $txt['pm_search_text'], ':</strong>
-					</dt>
-					<dd>
-						<input type="text" name="search"', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' size="40" class="input_text floatnone" placeholder="', $txt['search'], '" required="required" autofocus="autofocus" />
-						<select name="searchtype">
-							<option value="1"', empty($context['search_params']['searchtype']) ? ' selected="selected"' : '', '>', $txt['pm_search_match_all'], '</option>
-							<option value="2"', !empty($context['search_params']['searchtype']) ? ' selected="selected"' : '', '>', $txt['pm_search_match_any'], '</option>
-						</select>
-					</dd>
-					<dt>',
-						$txt['pm_search_user'], ':
-					</dt>
-					<dd>
-						<input type="text" name="userspec" value="', empty($context['search_params']['userspec']) ? '*' : $context['search_params']['userspec'], '" size="40" class="input_text" />
-					</dd>
-					<dt>',
-						$txt['pm_search_order'], ':
-					</dt>
-					<dd>
-						<select name="sort">
-							<option value="relevance|desc">', $txt['pm_search_orderby_relevant_first'], '</option>
-							<option value="id_pm|desc">', $txt['pm_search_orderby_recent_first'], '</option>
-							<option value="id_pm|asc">', $txt['pm_search_orderby_old_first'], '</option>
-						</select>
-					</dd>
-					<dt class="options">',
-						$txt['pm_search_options'], ':
-					</dt>
-					<dd class="options">
-						<label for="show_complete">
-							<input type="checkbox" name="show_complete" id="show_complete" value="1"', !empty($context['search_params']['show_complete']) ? ' checked="checked"' : '', ' class="input_check" /> ', $txt['pm_search_show_complete'], '
-						</label><br />
-						<label for="subject_only">
-							<input type="checkbox" name="subject_only" id="subject_only" value="1"', !empty($context['search_params']['subject_only']) ? ' checked="checked"' : '', ' class="input_check" /> ', $txt['pm_search_subject_only'], '
-						</label><br />
-						<label for="sent_only">
-							<input type="checkbox" name="sent_only" id="sent_only" value="1"', !empty($context['search_params']['sent_only']) ? ' checked="checked"' : '', ' class="input_check" /> ', $txt['pm_search_sent_only'], '
-						</label>
-					</dd>
-					<dt class="between">',
-						$txt['pm_search_post_age'], ':
-					</dt>
-					<dd>',
-						$txt['pm_search_between'], ' <input type="text" name="minage" value="', empty($context['search_params']['minage']) ? '0' : $context['search_params']['minage'], '" size="5" maxlength="5" class="input_text" />&nbsp;', $txt['pm_search_between_and'], '&nbsp;<input type="text" name="maxage" value="', empty($context['search_params']['maxage']) ? '9999' : $context['search_params']['maxage'], '" size="5" maxlength="5" class="input_text" /> ', $txt['pm_search_between_days'], '
-					</dd>
-					<dt>
-					</dt>
-					<dd>
-						<a class="button_link floatleft" href="', $scripturl, '?action=pm;sa=search;basic" onclick="elk_setThemeOption(\'minmax_preferences\', \'0\', null, elk_session_id, elk_session_var, \';minmax_key=pmsearch\');this.href += \';search=\' + escape(document.forms.searchform.search.value)">', $txt['pm_search_simple'], '</a>
-					</dd>
-				</dl>
-				<input type="hidden" name="advanced" value="1" />';
+			<dl class="settings" id="search_options">
+				<dt>
+					<strong>', $txt['pm_search_text'], ':</strong>
+				</dt>
+				<dd>
+					<input type="text" name="search"', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' size="40" class="input_text" placeholder="', $txt['search'], '" required="required" autofocus="autofocus" />
+					<select name="searchtype">
+						<option value="1"', empty($context['search_params']['searchtype']) ? ' selected="selected"' : '', '>', $txt['pm_search_match_all'], '</option>
+						<option value="2"', !empty($context['search_params']['searchtype']) ? ' selected="selected"' : '', '>', $txt['pm_search_match_any'], '</option>
+					</select>
+				</dd>
+				<dt>',
+					$txt['pm_search_user'], ':
+				</dt>
+				<dd>
+					<input type="text" name="userspec" value="', empty($context['search_params']['userspec']) ? '*' : $context['search_params']['userspec'], '" size="40" class="input_text" />
+				</dd>
+				<dt>',
+					$txt['pm_search_order'], ':
+				</dt>
+				<dd>
+					<select name="sort">
+						<option value="relevance|desc">', $txt['pm_search_orderby_relevant_first'], '</option>
+						<option value="id_pm|desc">', $txt['pm_search_orderby_recent_first'], '</option>
+						<option value="id_pm|asc">', $txt['pm_search_orderby_old_first'], '</option>
+					</select>
+				</dd>
+				<dt class="options">',
+					$txt['pm_search_options'], ':
+				</dt>
+				<dd class="options">
+					<label for="show_complete">
+						<input type="checkbox" name="show_complete" id="show_complete" value="1"', !empty($context['search_params']['show_complete']) ? ' checked="checked"' : '', ' class="input_check" /> ', $txt['pm_search_show_complete'], '
+					</label><br />
+					<label for="subject_only">
+						<input type="checkbox" name="subject_only" id="subject_only" value="1"', !empty($context['search_params']['subject_only']) ? ' checked="checked"' : '', ' class="input_check" /> ', $txt['pm_search_subject_only'], '
+					</label><br />
+					<label for="sent_only">
+						<input type="checkbox" name="sent_only" id="sent_only" value="1"', !empty($context['search_params']['sent_only']) ? ' checked="checked"' : '', ' class="input_check" /> ', $txt['pm_search_sent_only'], '
+					</label>
+				</dd>
+				<dt class="between">',
+					$txt['pm_search_post_age'], ':
+				</dt>
+				<dd>',
+					$txt['pm_search_between'], ' <input type="text" name="minage" value="', empty($context['search_params']['minage']) ? '0' : $context['search_params']['minage'], '" size="5" maxlength="5" class="input_text" />&nbsp;', $txt['pm_search_between_and'], '&nbsp;<input type="text" name="maxage" value="', empty($context['search_params']['maxage']) ? '9999' : $context['search_params']['maxage'], '" size="5" maxlength="5" class="input_text" /> ', $txt['pm_search_between_days'], '
+				</dd>
+			</dl>
+			<input type="hidden" name="advanced" value="1" />';
 
 		if (!$context['currently_using_labels'])
 			echo '
-				<input type="submit" name="pm_search" value="', $txt['pm_search_go'], '" class="button_submit" />';
+			<input type="submit" name="pm_search" value="', $txt['pm_search_go'], '" class="button_submit" />';
 
 		echo '
-			</div>
 		</fieldset>';
 
 		// Do we have some labels setup? If so offer to search by them!
@@ -767,13 +755,10 @@ function template_search()
 		{
 			echo '
 		<fieldset class="labels">
-			<div class="roundframe">
-				<div class="title_bar">
-					<h4 class="titlebg">
+			<h3 class="category_header">
 						<img id="advanced_panel_toggle" class="panel_toggle" style="display: none;" src="', $settings['images_url'], '/', empty($context['minmax_preferences']['pm']) ? 'collapse' : 'expand', '.png"  alt="*" /><a href="#" id="advanced_panel_link">', $txt['pm_search_choose_label'], '</a>
-					</h4>
-				</div>
-				<div id="advanced_panel_div"', empty($context['minmax_preferences']['pm']) ? '' : ' style="display: none;"', '>
+			</h3>
+			<div id="advanced_panel_div"', empty($context['minmax_preferences']['pm']) ? '' : ' style="display: none;"', '>
 				<ul id="searchLabelsExpand">';
 
 			foreach ($context['search_labels'] as $label)
@@ -785,12 +770,10 @@ function template_search()
 
 			echo '
 				</ul>
-				</div>
-				<p>
-					<span class="floatleft"><input type="checkbox" name="all" id="check_all" value="" ', $context['check_all'] ? 'checked="checked"' : '', ' onclick="invertAll(this, this.form, \'searchlabel\');" class="input_check" /><em> <label for="check_all">', $txt['check_all'], '</label></em></span>
-					<input type="submit" name="pm_search" value="', $txt['pm_search_go'], '" class="button_submit" />
-				</p>
-				<br class="clear_right" />
+			</div>
+			<div class="submit_buttons_wrap">
+				<span class="floatleft"><input type="checkbox" name="all" id="check_all" value="" ', $context['check_all'] ? 'checked="checked"' : '', ' onclick="invertAll(this, this.form, \'searchlabel\');" class="input_check" /><em> <label for="check_all">', $txt['check_all'], '</label></em></span>
+				<input type="submit" name="pm_search" value="', $txt['pm_search_go'], '" class="button_submit" />
 			</div>
 		</fieldset>';
 
@@ -846,75 +829,76 @@ function template_search_results()
 	global $context, $scripturl, $txt;
 
 	echo '
-		<div class="cat_bar">
-			<h3 class="catbg">', $txt['pm_search_results'], '</h3>
-		</div>';
-	template_pagesection(false, false, 'go_down');
+		', template_pagesection(false, false, 'go_down'), '
+		<div class="forumposts">
+			<h2 class="category_header">
+				', $txt['pm_search_results'], '
+			</h2>';
 
 	// complete results ?
+	// @todo - Should really get rid of some of the inline CCS in this table.
 	if (empty($context['search_params']['show_complete']) && !empty($context['personal_messages']))
 		echo '
-	<table class="table_grid">
-	<thead>
-		<tr class="catbg">
-			<th class="lefttext first_th" style="width:30%">', $txt['date'], '</th>
-			<th class="lefttext" style="width:50%">', $txt['subject'], '</th>
-			<th class="lefttext last_th" style="width:20%">', $txt['from'], '</th>
-		</tr>
-	</thead>
-	<tbody>';
+			<table class="table_grid">
+				<thead>
+					<tr class="table_head">
+						<th class="lefttext" style="width:30%">', $txt['date'], '</th>
+						<th class="lefttext" style="width:50%">', $txt['subject'], '</th>
+						<th class="lefttext" style="width:20%">', $txt['from'], '</th>
+					</tr>
+				</thead>
+				<tbody>';
 
 	$alternate = true;
 	// Print each message out...
 	foreach ($context['personal_messages'] as $message)
 	{
 		// We showing it all?
+		// @todo - Needs markup rewrite here.
 		if (!empty($context['search_params']['show_complete']))
 		{
 			echo '
-			<div class="title_bar">
-				<h3 class="titlebg">
-					<span class="floatright">', $txt['search_on'], ': ', $message['time'], '</span>
-					<span class="floatleft">', $message['counter'], '&nbsp;&nbsp;<a href="', $message['href'], '">', $message['subject'], '</a></span>
-				</h3>
-			</div>
-			<div class="cat_bar">
-				<h3 class="catbg">', $txt['from'], ': ', $message['member']['link'], ', ', $txt['to'], ': ';
-
-				// Show the recipients.
-				// @todo This doesn't deal with the sent item searching quite right for bcc.
-				if (!empty($message['recipients']['to']))
-					echo implode(', ', $message['recipients']['to']);
-				// Otherwise, we're just going to say "some people"...
-				elseif ($context['folder'] != 'sent')
-					echo '(', $txt['pm_undisclosed_recipients'], ')';
-
-					echo '
-				</h3>
-			</div>
 			<div class="windowbg', $alternate ? '2': '', '">
-				<div class="content">
-					', $message['body'], '
-					<p class="pm_reply righttext">';
+				<div class="postarea2">
+					<h5>
+						<span class="floatright">', $txt['search_on'], ': ', $message['time'], '</span>
+						<span class="floatleft">', $message['counter'], '&nbsp;&nbsp;<a href="', $message['href'], '">', $message['subject'], '</a></span>
+					</h5>
+					<h5 class="clear">', $txt['from'], ': ', $message['member']['link'], ', ', $txt['to'], ': ';
 
-				if ($context['can_send_pm'])
-				{
-					$quote_button = create_button('quote.png', 'reply_quote', 'reply_quote', 'class="centericon"');
-					$reply_button = create_button('im_reply.png', 'reply', 'reply', 'class="centericon"');
+					// Show the recipients.
+					// @todo This doesn't deal with the sent item searching quite right for bcc.
+					if (!empty($message['recipients']['to']))
+						echo implode(', ', $message['recipients']['to']);
+					// Otherwise, we're just going to say "some people"...
+					elseif ($context['folder'] != 'sent')
+						echo '(', $txt['pm_undisclosed_recipients'], ')';
 
-					// You can only reply if they are not a guest...
-					if (!$message['member']['is_guest'])
 						echo '
-								<a href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';quote;u=', $context['folder'] == 'sent' ? '' : $message['member']['id'], '">', $quote_button , '</a>
-								<a href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';u=', $message['member']['id'], '">', $reply_button , '</a> ';
+					</h5>
+					<div class="inner">
+						', $message['body'], '
+					</div>';
+
+			if ($context['can_send_pm'])
+			{
+			echo '
+					<ul class="quickbuttons">';
+
+			// You can only reply if they are not a guest...
+			if (!$message['member']['is_guest'])
+				echo '
+						<li class="listlevel1 quote"><a class="linklevel1 quote_button" href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';quote;u=', $context['folder'] == 'sent' ? '' : $message['member']['id'], '">', $txt['quote'], '</a></li>
+						<li class="listlevel1 reply"><a class="linklevel1 reply_button" href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';u=', $message['member']['id'], '">', $txt['reply'], '</a></li>';
 					// This is for "forwarding" - even if the member is gone.
 					else
 						echo '
-								<a href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';quote">', $quote_button , '</a>';
-				}
+						<li class="listlevel1 quote"><a class="linklevel1 quote_button" href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';quote">', $txt['quote'], '</a></li>';
+			echo '
+					</ul>';
+			}
 
-				echo '
-					</p>
+		echo '
 				</div>
 			</div>';
 		}
@@ -936,16 +920,17 @@ function template_search_results()
 	// Finish off the page...
 	if (empty($context['search_params']['show_complete']) && !empty($context['personal_messages']))
 		echo '
-		</tbody>
-		</table>';
+				</tbody>
+			</table>';
 
 	// No results?
 	if (empty($context['personal_messages']))
 		echo '
-		<div class="windowbg">
-			<div class="content">
-				<p class="centertext">', $txt['pm_search_none_found'], '</p>
-			</div>
+			<div class="windowbg">
+				<p class="content centertext">', $txt['pm_search_none_found'], '</p>
+			</div>';
+
+	echo '
 		</div>';
 
 	template_pagesection();
@@ -1084,7 +1069,7 @@ function template_send()
 					<p>
 						<label for="outbox"><input type="checkbox" name="outbox" id="outbox" value="1" tabindex="', $context['tabindex']++, '"', $context['copy_to_outbox'] ? ' checked="checked"' : '', ' class="input_check" /> ', $txt['pm_save_outbox'], '</label>
 					</p>
-					<hr class="hrcolor" />
+					<hr />
 					<span id="post_confirm_strip" class="righttext">
 						', template_control_richedit_buttons($context['post_box_name']), '
 					</span>
@@ -1291,11 +1276,11 @@ function template_labels()
 		</div>
 		<table class="table_grid">
 		<thead>
-			<tr class="catbg">
-				<th class="lefttext first_th">
+			<tr class="table_head">
+				<th class="lefttext">
 					', $txt['pm_label_name'], '
 				</th>
-				<th class="centertext last_th" style="width:4%">';
+				<th style="width:4%">';
 
 	if (count($context['labels']) > 2)
 		echo '
@@ -1340,7 +1325,7 @@ function template_labels()
 
 	if (!count($context['labels']) < 2)
 		echo '
-		<div class="padding">
+		<div>
 			<input type="submit" name="save" value="', $txt['save'], '" class="button_submit" />
 			<input type="submit" name="delete" value="', $txt['quickmod_delete_selected'], '" onclick="return confirm(\'', $txt['pm_labels_delete'], '\');" class="button_submit" />
 		</div>';
@@ -1462,11 +1447,11 @@ function template_rules()
 		</div>
 		<table class="table_grid">
 		<thead>
-			<tr class="catbg">
-				<th class="lefttext first_th">
+			<tr class="table_head">
+				<th class="lefttext">
 					', $txt['pm_rule_title'], '
 				</th>
-				<th style="width:4%" class="centertext last_th">';
+				<th style="width:4%">';
 
 	if (!empty($context['rules']))
 		echo '
@@ -1756,7 +1741,7 @@ function template_showPMDrafts()
 	// No drafts? Just show an informative message.
 	if (empty($context['drafts']))
 		echo '
-		<div class="tborder windowbg2 padding centertext">
+		<div class="information centertext">
 			', $txt['draft_none'], '
 		</div>';
 	else

--- a/themes/default/Poll.template.php
+++ b/themes/default/Poll.template.php
@@ -128,9 +128,7 @@ function template_poll_edit()
 
 	if (!empty($context['form_url']))
 		echo '
-					<div class="padding flow_auto">
-						<input type="submit" name="post" value="', $txt['save'], '" onclick="return submitThisOnce(this);" accesskey="s" class="button_submit" />
-					</div>
+					<input type="submit" name="post" value="', $txt['save'], '" onclick="return submitThisOnce(this);" accesskey="s" class="button_submit" />
 				</div>
 			</div>
 			<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />

--- a/themes/default/Post.template.php
+++ b/themes/default/Post.template.php
@@ -28,7 +28,7 @@ function template_main()
 	// If this message has been edited in the past - display when it was.
 	if (isset($context['last_modified']))
 		echo '
-					<div class="padding smalltext">
+					<div class="smalltext">
 						', $context['last_modified_text'], '
 					</div>';
 
@@ -222,7 +222,7 @@ function template_topic_replies_below()
 	{
 		echo '
 		<div id="topic_summary" class="forumposts">
-			<h3 class="catbg">', $txt['topic_summary'], '</h3>
+			<h3 class="category_header">', $txt['topic_summary'], '</h3>
 			<span id="new_replies"></span>';
 
 		$ignored_posts = array();
@@ -234,7 +234,7 @@ function template_topic_replies_below()
 
 			echo '
 			<div class="', $post['alternate'] == 0 ? 'windowbg' : 'windowbg2', '">
-				<div class="postarea" id="msg', $post['id'], '">
+				<div class="postarea2" id="msg', $post['id'], '">
 					<div class="keyinfo">
 						<h5 class="floatleft">
 							<span>', $txt['posted_by'], '</span>&nbsp;', $post['poster'], '&nbsp;-&nbsp;', $post['time'], '
@@ -447,7 +447,6 @@ function template_postarea_below()
 
 	// Finally, the submit buttons.
 	echo '
-						<br class="clear_right" />
 						<span id="post_confirm_buttons">
 							', template_control_richedit_buttons($context['post_box_name']);
 
@@ -734,7 +733,7 @@ function template_spellcheck()
 	<body onload="nextWord(false);">
 		<form action="#" method="post" accept-charset="UTF-8" name="spellingForm" id="spellingForm" onsubmit="return false;" style="margin: 0;">
 			<div id="spellview">&nbsp;</div>
-			<table class="table_padding" style="width:100%">
+			<table class="table_grid">
 				<tr class="windowbg">
 					<td style="width:50%;vertical-align:top">
 						', $txt['spellcheck_change_to'], '<br />

--- a/themes/default/Profile.template.php
+++ b/themes/default/Profile.template.php
@@ -55,7 +55,7 @@ function template_showDrafts()
 	// No drafts? Just show an informative message.
 	if (empty($context['drafts']))
 		echo '
-		<div class="tborder windowbg2 padding centertext">
+		<div class="information centertext">
 			', $txt['draft_none'], '
 		</div>';
 	else
@@ -109,7 +109,7 @@ function template_profile_save()
 
 	echo '
 
-					<hr class="hrcolor clear" style="width: 100%; height: 1px" />';
+					<hr class="clear" />';
 
 	// Only show the password box if it's actually needed.
 	if ($context['require_password'])

--- a/themes/default/ProfileHistory.template.php
+++ b/themes/default/ProfileHistory.template.php
@@ -113,13 +113,11 @@ function template_trackIP()
 			<div class="title_bar">
 				<h3 class="titlebg">', $txt['whois_title'], ' ', $context['ip'], '</h3>
 			</div>
-			<div class="windowbg2">
-				<div class="padding">';
+			<div class="windowbg2">';
 			foreach ($context['whois_servers'] as $server)
 				echo '
 					<a href="', $server['url'], '" target="_blank" class="new_win"', isset($context['auto_whois_server']) && $context['auto_whois_server']['name'] == $server['name'] ? ' style="font-weight: bold;"' : '', '>', $server['name'], '</a><br />';
 			echo '
-				</div>
 			</div>';
 	}
 
@@ -136,9 +134,9 @@ function template_trackIP()
 		echo '
 		<table class="table_grid">
 			<thead>
-				<tr class="catbg">
-					<th class="first_th" scope="col">', $txt['ip_address'], '</th>
-					<th class="last_th" scope="col">', $txt['display_name'], '</th>
+				<tr class="table_head">
+					<th scope="col">', $txt['ip_address'], '</th>
+					<th scope="col">', $txt['display_name'], '</th>
 				</tr>
 			</thead>
 			<tbody>';

--- a/themes/default/ProfileInfo.template.php
+++ b/themes/default/ProfileInfo.template.php
@@ -454,8 +454,8 @@ function template_action_showPermissions()
 					<table class="table_grid">
 						<thead>
 							<tr class="titlebg">
-								<th class="lefttext first_th" scope="col" style="width:50%">', $txt['showPermissions_permission'], '</th>
-								<th class="lefttext last_th" scope="col" style="width:50%">', $txt['showPermissions_status'], '</th>
+								<th class="lefttext" scope="col" style="width:50%">', $txt['showPermissions_permission'], '</th>
+								<th class="lefttext" scope="col" style="width:50%">', $txt['showPermissions_status'], '</th>
 							</tr>
 						</thead>
 						<tbody>';
@@ -521,8 +521,8 @@ function template_action_showPermissions()
 				<table class="table_grid">
 					<thead>
 						<tr class="titlebg">
-							<th class="lefttext first_th" scope="col" style="width:50%">', $txt['showPermissions_permission'], '</th>
-							<th class="lefttext last_th" scope="col" style="width:50%">', $txt['showPermissions_status'], '</th>
+							<th class="lefttext" scope="col" style="width:50%">', $txt['showPermissions_permission'], '</th>
+							<th class="lefttext" scope="col" style="width:50%">', $txt['showPermissions_status'], '</th>
 						</tr>
 					</thead>
 					<tbody>';

--- a/themes/default/ProfileOptions.template.php
+++ b/themes/default/ProfileOptions.template.php
@@ -31,16 +31,16 @@ function template_editBuddies()
 			</h3>
 		</div>
 		<table class="table_grid">
-			<tr class="catbg">
-				<th class="first_th" scope="col" style="width:20%">', $txt['name'], '</th>
-				<th class="centertext" scope="col">', $txt['status'], '</th>';
+			<tr class="table_head">
+				<th scope="col" style="width:20%">', $txt['name'], '</th>
+				<th scope="col">', $txt['status'], '</th>';
 
 	if ($context['can_send_email'])
 		echo '
-				<th class="centertext" scope="col">', $txt['email'], '</th>';
+				<th scope="col">', $txt['email'], '</th>';
 
 	echo '
-				<th class="last_th centertext" scope="col"></th>
+				<th scope="col"></th>
 			</tr>';
 
 	// If they don't have any buddies don't list them!
@@ -104,7 +104,7 @@ function template_editBuddies()
 					</dt>
 					<dd>
 						<input type="text" name="new_buddy" id="new_buddy" size="30" class="input_text" />
-						<input type="submit" value="', $txt['buddy_add_button'], '" class="button_submit floatnone" />
+						<input type="submit" value="', $txt['buddy_add_button'], '" class="button_submit" />
 					</dd>
 				</dl>';
 
@@ -148,16 +148,16 @@ function template_editIgnoreList()
 			</h3>
 		</div>
 		<table class="table_grid">
-			<tr class="catbg">
-				<th class="first_th" scope="col" style="width:20%">', $txt['name'], '</th>
-				<th class="centertext" scope="col">', $txt['status'], '</th>';
+			<tr class="table_head">
+				<th scope="col" style="width:20%">', $txt['name'], '</th>
+				<th scope="col">', $txt['status'], '</th>';
 
 	if ($context['can_send_email'])
 		echo '
-				<th class="centertext" scope="col">', $txt['email'], '</th>';
+				<th scope="col">', $txt['email'], '</th>';
 
 	echo '
-				<th class="centertext last_th" scope="col"></th>
+				<th scope="col"></th>
 			</tr>';
 
 	// If they don't have anyone on their ignore list, don't list it!
@@ -205,7 +205,7 @@ function template_editIgnoreList()
 					</dt>
 					<dd>
 						<input type="text" name="new_ignore" id="new_ignore" size="25" class="input_text" />
-						<input type="submit" value="', $txt['ignore_add_button'], '" class="button_submit floatnone" />
+						<input type="submit" value="', $txt['ignore_add_button'], '" class="button_submit" />
 					</dd>
 				</dl>';
 
@@ -290,7 +290,7 @@ function template_edit_options()
 		{
 			echo '
 					</dl>
-					<hr class="hrcolor clear" style="width: 100%; height: 1px" />
+					<hr class="clear" />
 					<dl>';
 		}
 		elseif ($field['type'] == 'callback')
@@ -378,7 +378,7 @@ function template_edit_options()
 	{
 		if ($lastItem != 'hr')
 			echo '
-					<hr class="hrcolor clear" style="width: 100%; height: 1px" />';
+					<hr class="clear" />';
 
 		echo '
 					<dl>';
@@ -850,7 +850,7 @@ function template_action_notification()
 							</select>
 						</dd>
 					</dl>
-					<hr class="hrcolor" />
+					<hr />
 					<div>
 						<input id="notify_submit" type="submit" value="', $txt['notify_save'], '" class="button_submit" />
 						<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />', !empty($context['token_check']) ? '
@@ -916,11 +916,11 @@ function template_groupMembership()
 	else
 	{
 		echo '
-			<table style="width:100%" class="table_padding">
+			<table class="table_grid">
 				<thead>
-					<tr class="catbg">
-						<th class="first_th" scope="col" ', $context['can_edit_primary'] ? ' colspan="2"' : '', '>', $txt['current_membergroups'], '</th>
-						<th class="last_th" scope="col"></th>
+					<tr class="table_head">
+						<th scope="col" ', $context['can_edit_primary'] ? ' colspan="2"' : '', '>', $txt['current_membergroups'], '</th>
+						<th scope="col"></th>
 					</tr>
 				</thead>
 				<tbody>';
@@ -966,13 +966,13 @@ function template_groupMembership()
 		{
 			echo '
 			<br />
-			<table style="width:100%" class="table_padding">
+			<table class="table_grid">
 				<thead>
-					<tr class="catbg">
-						<th class="first_th" scope="col">
+					<tr class="table_head">
+						<th scope="col">
 							', $txt['available_groups'], '
 						</th>
-						<th class="last_th" scope="col"></th>
+						<th scope="col"></th>
 					</tr>
 				</thead>
 				<tbody>';
@@ -1544,7 +1544,7 @@ function template_authentication_method()
 
 	if ($context['require_password'])
 		echo '
-					<hr class="hrcolor clear" style="width: 100%; height: 1px" />
+					<hr class="clear" />
 					<dl>
 						<dt>
 							<strong', isset($context['modify_error']['bad_password']) || isset($context['modify_error']['no_password']) ? ' class="error"' : '', '>', $txt['current_password'], ': </strong><br />
@@ -1556,7 +1556,7 @@ function template_authentication_method()
 					</dl>';
 
 	echo '
-					<hr class="hrcolor" />';
+					<hr />';
 
 	if (!empty($context['token_check']))
 		echo '

--- a/themes/default/Register.template.php
+++ b/themes/default/Register.template.php
@@ -476,7 +476,7 @@ function template_coppa_form()
 
 	// Show the form (As best we can)
 	echo '
-		<table class="tborder centertext" style="width:100%" >
+		<table class="table_grid">
 			<tr>
 				<td class="lefttext">', $context['forum_contacts'], '</td>
 			</tr>
@@ -499,8 +499,7 @@ function template_coppa_form()
 					', $context['coppa_body'], '
 				</td>
 			</tr>
-		</table>
-		<br />';
+		</table>';
 }
 
 /**
@@ -808,7 +807,7 @@ function template_contact_form()
 
 			echo '
 				</dl>
-				<hr class="hrcolor" />
+				<hr />
 				<div class="flow_auto" >
 					<input type="submit" value="', $txt['sendtopic_send'], '" name="send" tabindex="', $context['tabindex']++, '" style="margin: 1ex;" class="button_submit" />
 					<input type="hidden" name="sa" value="reservednames" />

--- a/themes/default/Reports.template.php
+++ b/themes/default/Reports.template.php
@@ -86,7 +86,7 @@ function template_main()
 		if (!empty($table['title']))
 			echo '
 			<thead>
-				<tr class="catbg">
+				<tr class="table_head">
 					<th scope="col" colspan="', $table['column_count'], '">', $table['title'], '</th>
 				</tr>
 			</thead>
@@ -181,11 +181,11 @@ function template_print()
 	{
 		echo '
 		<div style="overflow: visible;', $table['max_width'] != 'auto' ? ' width:' . $table['max_width'] . 'px;' : '', '">
-			<table style="width:100%" class="table_padding bordercolor">';
+			<table class="table_grid">';
 
 		if (!empty($table['title']))
 			echo '
-				<tr class="catbg">
+				<tr class="table_head">
 					<td colspan="', $table['column_count'], '">
 						', $table['title'], '
 					</td>

--- a/themes/default/Search.template.php
+++ b/themes/default/Search.template.php
@@ -22,12 +22,10 @@ function template_main()
 	global $context, $settings, $txt, $scripturl, $modSettings;
 
 	echo '
-				<form action="', $scripturl, '?action=search2" method="post" accept-charset="UTF-8" name="searchform" id="searchform">
-					<div class="cat_bar">
-						<h3 class="catbg">
+				<form action="', $scripturl, '?action=search2" method="post" accept-charset="UTF-8" name="searchform" id="searchform" class="standard_category">
+					<h2 class="category_header">
 							', !empty($settings['use_buttons']) ? '<img src="' . $settings['images_url'] . '/buttons/search_hd.png" alt="" class="icon" />' : ' ', $txt['set_parameters'], '
-						</h3>
-					</div>';
+					</h2>';
 
 	if (!empty($context['search_errors']))
 		echo '
@@ -37,183 +35,171 @@ function template_main()
 	if ($context['simple_search'] && (empty($context['minmax_preferences']['asearch']) || isset($_GET['basic'])))
 	{
 		echo '
-					<fieldset id="simple_search">
-						<div class="roundframe">
-							<div id="search_term_input">
-								<strong>', $txt['search_for'], ':</strong>
-								<input type="text" name="search"', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' maxlength="', $context['search_string_limit'], '" size="40" class="input_text" placeholder="' . $txt['search'] . '" required="required" autofocus="autofocus" />
-								', $context['require_verification'] ? '' : '&nbsp;<input type="submit" name="s_search" value="' . $txt['search'] . '" class="button_submit floatnone" />
-							</div>';
+					<fieldset id="simple_search" class="content">
+						<div id="search_term_input">
+							<strong>', $txt['search_for'], ':</strong>
+							<input type="text" name="search"', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' maxlength="', $context['search_string_limit'], '" size="40" class="input_text" placeholder="' . $txt['search'] . '" required="required" autofocus="autofocus" />
+							', $context['require_verification'] ? '' : '&nbsp;<input type="submit" name="s_search" value="' . $txt['search'] . '" class="button_submit" />
+						</div>';
 
 		if (empty($modSettings['search_simple_fulltext']))
 			echo '
-							<p class="smalltext">', $txt['search_example'], '</p>';
+						<p class="smalltext">', $txt['search_example'], '</p>';
 
 		if ($context['require_verification'])
 			echo '
-							<div class="verification>
-								<strong>', $txt['search_visual_verification_label'], ':</strong>
-								<br />', template_control_verification($context['visual_verification_id'], 'all'), '<br />
-								<input id="submit" type="submit" name="s_search" value="' . $txt['search'] . '" class="button_submit floatnone"/>
-							</div>';
+						<div class="verification>
+							<strong>', $txt['search_visual_verification_label'], ':</strong>
+							<br />', template_control_verification($context['visual_verification_id'], 'all'), '<br />
+							<input id="submit" type="submit" name="s_search" value="' . $txt['search'] . '" class="button_submit"/>
+						</div>';
 
 		// Show the button to enable advanced search
 		echo '
-							<a class="button_link" href="', $scripturl, '?action=search;advanced" onclick="elk_setThemeOption(\'minmax_preferences\', \'1\', null, elk_session_id, elk_session_var, \';minmax_key=asearch\');this.href += \';search=\' + escape(document.forms.searchform.search.value);">', $txt['search_advanced'], '</a>
-							<input type="hidden" name="advanced" value="0" />
-						</div>
+						<a class="button_link" href="', $scripturl, '?action=search;advanced" onclick="elk_setThemeOption(\'minmax_preferences\', \'1\', null, elk_session_id, elk_session_var, \';minmax_key=asearch\');this.href += \';search=\' + escape(document.forms.searchform.search.value);">', $txt['search_advanced'], '</a>
+						<input type="hidden" name="advanced" value="0" />
 					</fieldset>';
 	}
 	// Advanced search!
 	else
 	{
 		echo '
-					<fieldset id="advanced_search">
-						<div class="roundframe">
-							<dl class="settings" id="search_options">
-								<dt class="righttext">
-									<strong><label for="searchfor">', $txt['search_for'], ':</label></strong>
-								</dt>
-								<dd>
-									<input type="text" name="search" id="searchfor" ', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' maxlength="', $context['search_string_limit'], '" size="40" class="input_text" placeholder="' . $txt['search'] . '" required="required" autofocus="autofocus" />';
+					<fieldset id="advanced_search" class="content">
+						<dl class="settings" id="search_options">
+							<dt class="righttext">
+								<strong><label for="searchfor">', $txt['search_for'], ':</label></strong>
+							</dt>
+							<dd>
+								<input type="text" name="search" id="searchfor" ', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' maxlength="', $context['search_string_limit'], '" size="40" class="input_text" placeholder="' . $txt['search'] . '" required="required" autofocus="autofocus" />';
 
 		if (empty($modSettings['search_simple_fulltext']))
 			echo '
-									<em class="smalltext">', $txt['search_example'], '</em>';
+								<em class="smalltext">', $txt['search_example'], '</em>';
 
 		echo '
-								</dd>
-								<dt class="righttext"><label for="searchtype">',
-									$txt['search_match'], ':</label>
-								</dt>
-								<dd>
-									<select name="searchtype" id="searchtype">
-										<option value="1"', empty($context['search_params']['searchtype']) ? ' selected="selected"' : '', '>', $txt['all_words'], '</option>
-										<option value="2"', !empty($context['search_params']['searchtype']) ? ' selected="selected"' : '', '>', $txt['any_words'], '</option>
-									</select>
-								</dd>
-								<dt class="righttext"><label for="userspec">',
-									$txt['by_user'], ':</label>
-								</dt>
-								<dd>
-									<input id="userspec" type="text" name="userspec" value="', empty($context['search_params']['userspec']) ? '*' : $context['search_params']['userspec'], '" size="40" class="input_text" />
-								</dd>
-								<dt class="righttext"><label for="sort">',
-									$txt['search_order'], ':</label>
-								</dt>
-								<dd>
-									<select id="sort" name="sort">
-										<option value="relevance|desc">', $txt['search_orderby_relevant_first'], '</option>
-										<option value="num_replies|desc">', $txt['search_orderby_large_first'], '</option>
-										<option value="num_replies|asc">', $txt['search_orderby_small_first'], '</option>
-										<option value="id_msg|desc">', $txt['search_orderby_recent_first'], '</option>
-										<option value="id_msg|asc">', $txt['search_orderby_old_first'], '</option>
-									</select>
-								</dd>
-								<dt class="righttext options">',
-									$txt['search_options'], ':
-								</dt>
-								<dd class="options">
-									<label for="show_complete">', $txt['search_show_complete_messages'], '
-										<input type="checkbox" name="show_complete" id="show_complete" value="1"', !empty($context['search_params']['show_complete']) ? ' checked="checked"' : '', ' class="input_check" />
-									</label><br />
-									<label for="subject_only">', $txt['search_subject_only'], '
-										<input type="checkbox" name="subject_only" id="subject_only" value="1"', !empty($context['search_params']['subject_only']) ? ' checked="checked"' : '', ' class="input_check" />
-									</label>
-								</dd>
-								<dt class="righttext between">',
-									$txt['search_post_age'], ':
-								</dt>
-								<dd><label for="minage">',
-									$txt['search_between'], '</label><input type="text" name="minage" id="minage" value="', empty($context['search_params']['minage']) ? '0' : $context['search_params']['minage'], '" size="5" maxlength="4" class="input_text" />&nbsp;<label for="maxage">', $txt['search_and'], '&nbsp;</label><input type="text" name="maxage" id="maxage" value="', empty($context['search_params']['maxage']) ? '9999' : $context['search_params']['maxage'], '" size="5" maxlength="4" class="input_text" /> ', $txt['days_word'], '
-								</dd>
-								<dt>
-								</dt>
-								<dd>
-									<a href="', $scripturl, '?action=search;basic" onclick="elk_setThemeOption(\'minmax_preferences\', \'0\', null, elk_session_id, elk_session_var, \';minmax_key=asearch\');this.href += \';search=\' + escape(document.forms.searchform.search.value);" class="button_link floatnone">', $txt['search_simple'], '</a>
-								</dd>
-							</dl>
-							<input type="hidden" name="advanced" value="1" />';
+							</dd>
+							<dt class="righttext"><label for="searchtype">',
+								$txt['search_match'], ':</label>
+							</dt>
+							<dd>
+								<select name="searchtype" id="searchtype">
+									<option value="1"', empty($context['search_params']['searchtype']) ? ' selected="selected"' : '', '>', $txt['all_words'], '</option>
+									<option value="2"', !empty($context['search_params']['searchtype']) ? ' selected="selected"' : '', '>', $txt['any_words'], '</option>
+								</select>
+							</dd>
+							<dt class="righttext"><label for="userspec">',
+								$txt['by_user'], ':</label>
+							</dt>
+							<dd>
+								<input id="userspec" type="text" name="userspec" value="', empty($context['search_params']['userspec']) ? '*' : $context['search_params']['userspec'], '" size="40" class="input_text" />
+							</dd>
+							<dt class="righttext"><label for="sort">',
+								$txt['search_order'], ':</label>
+							</dt>
+							<dd>
+								<select id="sort" name="sort">
+									<option value="relevance|desc">', $txt['search_orderby_relevant_first'], '</option>
+									<option value="num_replies|desc">', $txt['search_orderby_large_first'], '</option>
+									<option value="num_replies|asc">', $txt['search_orderby_small_first'], '</option>
+									<option value="id_msg|desc">', $txt['search_orderby_recent_first'], '</option>
+									<option value="id_msg|asc">', $txt['search_orderby_old_first'], '</option>
+								</select>
+							</dd>
+							<dt class="righttext options">',
+								$txt['search_options'], ':
+							</dt>
+							<dd class="options">
+								<label for="show_complete">', $txt['search_show_complete_messages'], '
+									<input type="checkbox" name="show_complete" id="show_complete" value="1"', !empty($context['search_params']['show_complete']) ? ' checked="checked"' : '', ' class="input_check" />
+								</label><br />
+								<label for="subject_only">', $txt['search_subject_only'], '
+									<input type="checkbox" name="subject_only" id="subject_only" value="1"', !empty($context['search_params']['subject_only']) ? ' checked="checked"' : '', ' class="input_check" />
+								</label>
+							</dd>
+							<dt class="righttext between">',
+								$txt['search_post_age'], ':
+							</dt>
+							<dd><label for="minage">',
+								$txt['search_between'], '</label><input type="text" name="minage" id="minage" value="', empty($context['search_params']['minage']) ? '0' : $context['search_params']['minage'], '" size="5" maxlength="4" class="input_text" />&nbsp;<label for="maxage">', $txt['search_and'], '&nbsp;</label><input type="text" name="maxage" id="maxage" value="', empty($context['search_params']['maxage']) ? '9999' : $context['search_params']['maxage'], '" size="5" maxlength="4" class="input_text" /> ', $txt['days_word'], '
+							</dd>
+						</dl>
+						<input type="hidden" name="advanced" value="1" />';
 
 		// Require an image to be typed to save spamming?
 		if ($context['require_verification'])
 		{
 			echo '
-							<p>
-								<strong>', $txt['verification'], ':</strong>
-								', template_control_verification($context['visual_verification_id'], 'all'), '
-							</p>';
+						<p>
+							<strong>', $txt['verification'], ':</strong>
+							', template_control_verification($context['visual_verification_id'], 'all'), '
+						</p>';
 		}
 
 		// If $context['search_params']['topic'] is set, that means we're searching just one topic.
 		if (!empty($context['search_params']['topic']))
 			echo '
-							<p>', $txt['search_specific_topic'], ' &quot;', $context['search_topic']['link'], '&quot;.</p>
-							<input type="hidden" name="topic" value="', $context['search_topic']['id'], '" />';
+						<p>', $txt['search_specific_topic'], ' &quot;', $context['search_topic']['link'], '&quot;.</p>
+						<input type="hidden" name="topic" value="', $context['search_topic']['id'], '" />';
 
 		echo '
-						</div>
-					</fieldset>
-		';
+					</fieldset>';
 
 		if (empty($context['search_params']['topic']))
 		{
 			echo '
-					<fieldset class="flow_hidden">
-						<div class="roundframe">
-							<div class="title_bar">
-								<h4 class="titlebg">
-									<img id="advanced_panel_toggle" class="panel_toggle" style="display: none;" src="', $settings['images_url'], '/', empty($context['minmax_preferences']['search']) ? 'collapse' : 'expand', '.png"  alt="*" /><a href="#" id="advanced_panel_link">', $txt['choose_board'], '</a>
-								</h4>
-							</div>
-							<div class="flow_auto" id="advanced_panel_div"', $context['boards_check_all'] ? '' : ' style="display: none;"', '>
-								<ul class="ignoreboards floatleft">';
+					<fieldset class="content">
+						<h3 class="secondary_header">
+								<img id="advanced_panel_toggle" class="panel_toggle" style="display: none;" src="', $settings['images_url'], '/', empty($context['minmax_preferences']['search']) ? 'collapse' : 'expand', '.png"  alt="*" /><a href="#" id="advanced_panel_link">', $txt['choose_board'], '</a>
+						</h3>
+						<div id="advanced_panel_div"', $context['boards_check_all'] ? '' : ' style="display: none;"', '>
+							<ul class="ignoreboards floatleft">';
 
 			$i = 0;
 			$limit = ceil($context['num_boards'] / 2);
 			foreach ($context['categories'] as $category)
 			{
 				echo '
-									<li class="category">
-										<a href="javascript:void(0);" onclick="selectBoards([', implode(', ', $category['child_ids']), '], \'searchform\'); return false;">', $category['name'], '</a>
-										<ul>';
+								<li class="category">
+									<a href="javascript:void(0);" onclick="selectBoards([', implode(', ', $category['child_ids']), '], \'searchform\'); return false;">', $category['name'], '</a>
+									<ul>';
 
 				foreach ($category['boards'] as $board)
 				{
 					if ($i == $limit)
 						echo '
-										</ul>
-									</li>
-								</ul>
-								<ul class="ignoreboards floatright">
-									<li class="category">
-										<ul>';
+									</ul>
+								</li>
+							</ul>
+							<ul class="ignoreboards floatright">
+								<li class="category">
+									<ul>';
 
 					echo '
-											<li class="board" style="margin-', $context['right_to_left'] ? 'right' : 'left', ': ', $board['child_level'], 'em;">
-												<label for="brd', $board['id'], '">
-													<input type="checkbox" id="brd', $board['id'], '" name="brd[', $board['id'], ']" value="', $board['id'], '"', $board['selected'] ? ' checked="checked"' : '', ' class="input_check" /> ', $board['name'], '
-												</label>
-											</li>';
+										<li class="board" style="margin-', $context['right_to_left'] ? 'right' : 'left', ': ', $board['child_level'], 'em;">
+											<label for="brd', $board['id'], '">
+												<input type="checkbox" id="brd', $board['id'], '" name="brd[', $board['id'], ']" value="', $board['id'], '"', $board['selected'] ? ' checked="checked"' : '', ' class="input_check" /> ', $board['name'], '
+											</label>
+										</li>';
 
 					$i ++;
 				}
 
 				echo '
-										</ul>
-									</li>';
+									</ul>
+								</li>';
 			}
 
 			echo '
-								</ul>
-							</div>';
+							</ul>
+						</div>';
 
 			echo '
-							<div class="padding flow_auto">
-								<input type="checkbox" name="all" id="check_all" value=""', $context['boards_check_all'] ? ' checked="checked"' : '', ' onclick="invertAll(this, this.form, \'brd\');" class="input_check floatleft" />
-								<label for="check_all" class="floatleft"><em>', $txt['check_all'], '</em></label>
-								<input type="submit" name="b_search" value="', $txt['search'], '" class="button_submit" />
-							</div>
+						<div class="submit_buttons_wrap">
+							<span class="floatleft">
+								<input type="checkbox" name="all" id="check_all" value=""', $context['boards_check_all'] ? ' checked="checked"' : '', ' onclick="invertAll(this, this.form, \'brd\');" class="input_check" />
+								<label for="check_all"><em> ', $txt['check_all'], '</em></label>
+							</span>
+							<input type="submit" name="b_search" value="', $txt['search'], '" class="button_submit" />
 						</div>
 					</fieldset>';
 		}

--- a/themes/default/SplitTopics.template.php
+++ b/themes/default/SplitTopics.template.php
@@ -46,7 +46,7 @@ function template_ask()
 								<input type="radio" id="selective" name="step2" value="selective" class="input_radio" /> <label for="selective">', $txt['select_split_posts'], '</label>
 							</li>
 						</ul>
-						<hr class="hrcolor" />
+						<hr />
 						<label for="messageRedirect"><input type="checkbox" name="messageRedirect" id="messageRedirect" onclick="document.getElementById(\'reasonArea\').style.display = this.checked ? \'block\' : \'none\';" class="input_check" /> ', $txt['splittopic_notification'], '.</label>
 						<fieldset id="reasonArea" style="margin-top: 1ex; display: none;', '">
 							<dl class="settings">

--- a/themes/default/Themes.template.php
+++ b/themes/default/Themes.template.php
@@ -556,7 +556,7 @@ function template_set_settings()
 			</div>
 			<div class="windowbg">
 				<div class="content">
-					<dl class="settings flow_auto">';
+					<dl class="settings">';
 
 	foreach ($context['settings'] as $setting)
 	{
@@ -565,8 +565,8 @@ function template_set_settings()
 		{
 			echo '
 					</dl>
-					<hr class="hrcolor" />
-					<dl class="settings flow_auto">';
+					<hr />
+					<dl class="settings">';
 		}
 		// A checkbox?
 		elseif ($setting['type'] == 'checkbox')
@@ -682,7 +682,7 @@ function template_pick()
 			</div>
 			<div class="', $theme['selected'] ? 'windowbg' : 'windowbg2', '">
 				<div class="flow_hidden content">
-					<div class="floatright"><a href="', $scripturl, '?action=theme;sa=pick;u=', $context['current_member'], ';theme=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], '" id="theme_thumb_preview_', $theme['id'], '" title="', $txt['theme_preview'], '"><img src="', $theme['thumbnail_href'], '" id="theme_thumb_', $theme['id'], '" alt="" class="padding" /></a></div>
+					<div class="floatright"><a href="', $scripturl, '?action=theme;sa=pick;u=', $context['current_member'], ';theme=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], '" id="theme_thumb_preview_', $theme['id'], '" title="', $txt['theme_preview'], '"><img src="', $theme['thumbnail_href'], '" id="theme_thumb_', $theme['id'], '" alt="" /></a></div>
 					<p>', $theme['description'], '</p>';
 
 		if (!empty($theme['variants']))
@@ -882,10 +882,10 @@ function template_browse()
 	<div id="admincenter">
 		<table class="table_grid tborder">
 		<thead>
-			<tr class="catbg">
-				<th class="lefttext first_th" scope="col" style="width:50%">', $txt['themeadmin_edit_filename'], '</th>
+			<tr class="table_head">
+				<th class="lefttext" scope="col" style="width:50%">', $txt['themeadmin_edit_filename'], '</th>
 				<th scope="col" style="width:35%">', $txt['themeadmin_edit_modified'], '</th>
-				<th class="last_th" scope="col" style="width:15%">', $txt['themeadmin_edit_size'], '</th>
+				<th scope="col" style="width:15%">', $txt['themeadmin_edit_size'], '</th>
 			</tr>
 		</thead>
 		<tbody>';

--- a/themes/default/Who.template.php
+++ b/themes/default/Who.template.php
@@ -23,7 +23,7 @@ function template_main()
 
 	// Display the table header and linktree.
 	echo '
-	<div class="main_section" id="whos_online">
+	<div id="whos_online">
 		<form action="', $scripturl, '?action=who" method="post" id="whoFilter" accept-charset="UTF-8">
 			<div class="title_bar">
 				<h4 class="titlebg margin_lower">', $txt['who_title'], '</h4>
@@ -49,8 +49,8 @@ function template_main()
 			<div class="topic_table" id="mlist">
 				<table class="table_grid" >
 					<thead>
-						<tr class="catbg">
-							<th scope="col" class="lefttext first_th" style="width:40%">
+						<tr class="table_head">
+							<th scope="col" class="lefttext" style="width:40%">
 								<a href="', $scripturl, '?action=who;start=', $context['start'], ';show=', $context['show_by'], ';sort=user', $context['sort_direction'] != 'down' && $context['sort_by'] == 'user' ? '' : ';asc', '" rel="nofollow">', $txt['who_user'], $context['sort_by'] == 'user' ? '<img class="sort" src="' . $settings['images_url'] . '/sort_' . $context['sort_direction'] . '.png" alt="" />' : '', '</a>
 							</th>
 							<th scope="col" class="lefttext" style="width:10%">
@@ -130,7 +130,7 @@ function template_credits()
 
 	// The most important part - the credits :P.
 	echo '
-	<div class="main_section" id="credits">
+	<div id="credits">
 		<div class="cat_bar">
 			<h3 class="catbg">', $txt['credits'], '</h3>
 		</div>';

--- a/themes/default/css/admin.css
+++ b/themes/default/css/admin.css
@@ -1085,9 +1085,6 @@ ul.moderation_notes li {
 	.dropmenu li li a {
 		line-height: 3.2em;
 	}
-	#menu_toggle {
-		display: none;
-	}
 	h3.catbg #quick_search form {
 		margin: 0 0 8px 0;
 		padding: 0;

--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -97,23 +97,30 @@ table {
 /* IMPORTANT: Do not declare div here (borks jQuery menus). */
 /* Default most elements to zero padding and margin. */
 /* Declare these separately to divs to avoid padding and margin problems. */
-p, ul, ol, li, dl, dd ,dt, fieldset, form,
-input, button, select, textarea, .editor {
-	-moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;
+h1, h2, h3, h4, h5, h6, ul, ol, li, dl, dd ,dt,
+p, fieldset, form, input, button, select, textarea, .editor {
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
 	padding: 0;
 	margin: 0;
+	font-weight: normal;
+	font-size: 1em;
 }
-/* Declarations for specific divs. @todo - Maybe simplify - test. */
+/* Declarations for specific elements. @todo - Maybe simplify - test. */
 .wrapper, .user, .news, .navigate_section, div.windowbg, div.windowbg2,
 .roundframe, .description, .information, .infobox, .noticebox,
 .signature, .attachments, .custom_fields_above_signature,
-.category_header, .generic_list_wrapper, #gotop, #gobottom {
-	-moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;
+.category_header, .generic_list_wrapper, .submit_buttons_wrap,
+#gotop, #gobottom {
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 /* Collection of pseudo element clearfixes. */
 /* @todo - Clean up old catbg and titlebg stuff. */
-h3.catbg:after, h3.titlebg:after, h4.titlebg:after, h4.catbg:after,
+.category_header:after, h3.catbg:after, h3.titlebg:after, h4.titlebg:after, h4.catbg:after,
 #main_menu:after, .wrapper:after, #upper_section:after, #inner_wrap:after,
 #main_content_section:after, #main_container:after, .attachments_bot:after,
 .editor_wrapper:after {
@@ -133,7 +140,8 @@ ul, ol {
 }
 
 /* No image should have a border when linked. */
-/* @todo - I'm sure this would be better done with specific classes rather than global tag name. */
+/* @todo - I'm sure this would be better done with specific classes
+/* rather than global tag name. */
 a img {
 	border: 0;
 }
@@ -153,15 +161,18 @@ input, button, select, textarea, .editor {
 	border: 1px solid #bbb;
 	border-radius: 2px;
 	background: #fff;
-	color: #555;
 	vertical-align: middle;
 	font: 83.33%/150% "Segoe UI", "Helvetica Neue", "Liberation Sans", "Nimbus Sans L", Arial, sans-serif;
+	color: #444;
 }
 /* The following is necessary. */
 /* @todo - Chase down SCEditor colours n stuff. Bleh. :P */
 textarea, .editor {
 	border-radius: 4px;
 	font-size: 1em;
+}
+.sceditor-container {
+	margin: 0 0 12px 0;
 }
 /* Apply the font only to these elements. */
 input, button, select {
@@ -185,14 +196,16 @@ input:focus, textarea:focus, button:focus, select:focus, .editor:focus {
 }
 
 /* All input elements that are checkboxes or radio buttons shouldn't have a border around them. */
+/* @todo - Why all vertical-align: top; ? */
 .input_check, .input_radio {
 	border: none;
 	background: none;
-	vertical-align: top;
+	vertical-align: middle;
 }
 /* @todo - Another trap for themers. */
+/* @todo - Will see what happens when .catbg is deprecated. */
 h3.catbg .input_check {
-	margin: 0 7px 0 7px;
+	margin: 0 7px;
 }
 /* Give disabled text input elements a different background color. */
 input[disabled].input_text {
@@ -215,20 +228,19 @@ input[disabled].input_text {
 	float: none;
 	margin-left: inherit;
 }
+/* @todo - Save code by amalgamating common button background declarations. */
 .button_submit, .button_reset, .button_link {
 	float: right;
+	/* @todo - Why all 12px left margin? */
 	margin: 0 0 0 12px;
-	padding: 2px 4px;
+	padding: 2px 5px;
 	border: 1px solid #afafaf;
 	border-top: 1px solid #bbb;
 	background: #fcfcfc;
 	background-image: linear-gradient(to bottom, #fcfcfc 0%, #e5e5e5 100%);
-	color: #555;
 }
 .button_link {
 	margin: 0;
-	padding: 2px 5px;
-	color: #555;
 	font-size: 0.857em;
 }
 .button_submit:hover, .button_reset:hover, .button_link:hover {
@@ -237,13 +249,8 @@ input[disabled].input_text {
 	border-left: 1px solid #bbb;
 	background: #f0f0f0;
 	box-shadow: 1px 1px 1px rgba(0,0,0,0.07) inset;
-	color: #555;
 	text-decoration: none;
 	cursor: pointer;
-}
-/* @todo - WTF? :P */
-.selectbox select {
-	margin: 0;
 }
 
 /* the new "button" */
@@ -267,37 +274,22 @@ a span.new_posts:hover {
 }
 
 /* Standard horizontal rule.. ([hr], etc.) */
-/* @todo - Check for a better way of doing this. */
-hr, .hrcolor {
+hr {
 	margin: 12px 0;
-	height: 2px;
-	border: none;
-	background: #fff;
-	background-color: #fff;
-	box-shadow: 0 1px 0 #bbb inset;
-}
-
-/* Default these tags to normal. */
-h1, h2, h3, h4, h5, h6 {
-	margin: 0;
-	padding: 0;
-	color: #555;
-	font-weight: normal;
-	font-size: 1em;
+	height: 1px;
+	border-top: 1px solid #bbb;
+	background: #eee;
+	background-color: #eee;
 }
 
 /* Fieldsets are used to group elements. */
-/* @todo - Can we do this by class? */
+/* @todo - Can we do this by class? What about default styling? Needed? */
+/* Declaring as overflow: auto; is probably a good idea. Test for teh bugz. */
 fieldset {
-	margin: 0 0 6px 0;
-	padding: 18px;
-	border: 1px solid #ccc;
-	border-radius: 3px;
+	overflow: auto;
+	border: none;
 }
 fieldset legend {
-	border: none;
-	box-shadow: none;
-	color: #555;
 	font-weight: bold;
 }
 .content fieldset {
@@ -331,15 +323,37 @@ em {
 	text-decoration: underline;
 }
 
+/* @todo - A common, tag-agnostic class to hold submit buttons, etc. */
+/* Old markup had crud like <div class="smalltext righttext padding ffs zomg"> */
+/* Use new class that is defined to suit, and with a sensible name. */
+.submit_buttons_wrap {
+	text-align: right;
+	padding: 8px;
+	overflow: auto;
+	width: 100%;
+}
+/* @todo - Test this everywhere. */
+.standard_category {
+	clear: both;
+	margin: 1em 0 0 0;
+	border-radius: 4px 4px 0 0;
+	background: #e4e4e4;
+	box-shadow: 1px 2px 4px #eee;
+}
+/* @todo - Test this everywhere. */
+.standard_category>.content {
+	border: 1px solid #ddd;
+	margin: 4px 0 0 0;
+	background: #fff;
+	overflow: auto;
+}
+
 /* Floats, overflows, clears. @todo */
 .floatright {
 	float: right;
 }
 .floatleft {
 	float: left;
-}
-.floatnone {
-	float: none;
 }
 .flow_auto {
 	overflow: auto;
@@ -357,8 +371,10 @@ em {
 	clear: right;
 }
 
-/* Default font sizes: small (9pt), normal (10pt), and large (14pt). */
-/* @todo - th shouldn't be required. Are margins required? */
+/* Default font sizes (defined in em, so IE can resize): small (12px default),
+/* normal (14px default), and large (16px default).
+/* Since these are purely presentational classes, they should be used sparingly. */
+/* @todo - th shouldn't be required. */
 .smalltext, .smalltext th {
 	font-size: 0.857em;
 }
@@ -366,47 +382,28 @@ em {
 	font-size: 1.286em;
 }
 .centertext {
-	margin: 0 auto;
 	text-align: center;
 }
 .righttext {
-	margin-left: auto;
-	margin-right: 0;
 	text-align: right;
 }
 .lefttext {
-	margin-left: 0;
-	margin-right: auto;
 	text-align: left;
 }
 .double_height {
 	line-height: 2em;
 }
 
-/* Some common padding styles */
-/* @todo - Oh si, this makes a whole lot of sense. */
-.padding {
-	padding: 8px;
-}
-.main_section, .lower_padding {
-	padding-bottom: 6px;
-}
-
-/* Generic header bars. */
-.titlebg, .titlebg th, .titlebg td,
-.catbg, .catbg td .catbg th {
+/* Generic header bars. @todo - To be deprecated. */
+.titlebg, .catbg {
 	padding: 0 6px;
 	background: #ebebeb;
 	background-image: linear-gradient(to bottom, #ebebeb 0%, #c6c6c6 100%);
 	color: #555;
 	font-size: 1.1em;
 }
-.catbg, .catbg td, .catbg th {
+.catbg {
 	font-size: 1.2em;
-}
-/* @todo -Ditch th? */
-.titlebg th a:link, .titlebg th a:visited, .catbg th a:link, .catbg th a:visited {
-	color: #555;
 }
 .catbg select {
 	margin-top: -1px;
@@ -415,8 +412,9 @@ em {
 	font-size: 0.857em;
 }
 
-/* Styles for rounded headers. */
+/* Styles for main headers. */
 .category_header,
+/* Generic header bars. @todo - To be deprecated. */
 h3.catbg, h3.titlebg, h4.titlebg, h4.catbg {
 	padding: 4px 12px 2px 12px;
 	border: 1px solid #ccc;
@@ -429,9 +427,21 @@ h3.catbg, h3.titlebg, h4.titlebg, h4.catbg {
 	font-size: 1.214em;
 	line-height: 1.8em;
 }
+/* Styles for subsection headers. */
+.secondary_header {
+	margin: 12px 0 0 0;
+	padding: 4px 12px 2px 12px;
+	border: 1px solid #ccc;
+	border-top: 1px solid #dfdfdf;
+	background: #fafafa;
+	background-image: linear-gradient(to bottom, #fafafa 0%, #ebebeb 100%);
+	text-shadow: 1px 1px 0 #fff;
+	font-size: 1.143em;
+	line-height: 1.8em;
+}
 
 h3.catbg a:link, h3.catbg a:visited, h4.catbg a:link, h4.catbg a:visited,
-h3.titlebg a, h3.titlebg, h4.titlebg, h4.titlebg a, .table_list .header td, .table_list .header td a {
+h3.titlebg a, h3.titlebg, h4.titlebg, h4.titlebg a {
 	color: #555;
 }
 h3.catbg a:hover, h4.catbg a:hover, h3.titlebg a:hover, h4.titlebg a:hover {
@@ -441,13 +451,13 @@ h3.catbg a:hover, h4.catbg a:hover, h3.titlebg a:hover, h4.titlebg a:hover {
 h3.catbg .icon {
 	margin: 0 5px 0 0;
 }
-h4.catbg .toggle img {
-	margin: 0 5px 0 5px;
-	vertical-align: middle;
-}
 h4.titlebg .icon {
 	float: left;
 	margin: 0 5px 0 0;
+}
+.category_header .icon {
+	margin: 0 5px 0 0;
+	vertical-align: middle;
 }
 
 /* Upshrinks in cat and title bars. */
@@ -462,14 +472,7 @@ h4.titlebg .icon {
 }
 
 /* Alternating backgrounds for posts, and several other sections of the forum. */
-.windowbg, #preview_body {
-	color: #555;
-}
-.windowbg2 {
-	color: #555;
-}
-/* @todo - Is this still necessary? */
-.windowbg3 {
+.windowbg, #preview_body, .windowbg2 {
 	color: #555;
 }
 
@@ -528,43 +531,35 @@ div.windowbg, div.windowbg2 {
 .warn_watch, .success {
 	color: green;
 }
-
 .moderation_link, .moderation_link:visited {
 	color: red;
 	font-weight: bold;
 }
 
-/* Descriptive boxes. */
-.description, .information {
+/* Lotsa boxes. */
+.description, .information, .noticebox, .infobox {
 	margin: 0 0 12px 0;
 	padding: 6px 12px;
 	border: 1px solid #ccc;
+	background: #fff;
 	font-size: 0.857em;
 }
 /* Information boxes. */
 .information {
-	margin: 2px 1px 12px 1px;
 	background: #f0f6f0;
 }
 .information p {
-	margin: 0;
 	padding: 12px;
 }
-.para2 {
-	margin: 0;
-	padding: 12px 0 44px 0;
-}
-/* More little boxes on a hillside. :D */
-.noticebox, .infobox {
-	margin-bottom: 12px;
-	padding: 7px 10px 7px 35px;
+/* More little boxes on a hillside. */
+.noticebox {
+	padding-left: 35px;
 	border-top: 1px solid #ffd324;
 	border-bottom: 1px solid #ffd324;
 	background: #fff6ca url(../images/profile/warning_moderate.png) 10px 50% no-repeat;
-	color: #555;
-	text-align: left;
 }
 .infobox {
+	padding-left: 35px;
 	border-top: 1px solid green;
 	border-bottom: 1px solid green;
 	background: #efe url(../images/icons/field_valid.png) 10px 50% no-repeat;
@@ -579,9 +574,6 @@ div.windowbg, div.windowbg2 {
 	border: 1px solid #c5c5c5;
 	border-radius: 7px;
 	background: #f5f5f5;
-}
-.roundframe dl, .roundframe dt, .roundframe p {
-	margin: 0;
 }
 .roundframe p {
 	padding: 6px;
@@ -1215,6 +1207,7 @@ div.windowbg, div.windowbg2 {
 	float: left;
 	margin: 0 0 0 6px;
 }
+/* @todo - Save code by amalgamating common button background declarations. */
 .buttonlist li a {
 	display: block;
 	padding: 0 8px;
@@ -1270,6 +1263,7 @@ div.windowbg, div.windowbg2 {
 	border-radius: 4px;
 	font-size: 1em;
 }
+/* @todo - Save code by amalgamating common button background declarations. */
 .quickbuttons .listlevel1 {
 	float: right;
 	margin: 3px 0;
@@ -1511,6 +1505,7 @@ div.windowbg, div.windowbg2 {
 /* Why not? Because it has a well-known quirk. It's white-space-dependent. */
 /* http://robertnyman.com/2010/02/24/css-display-inline-block-why-it-rocks-and-why-it-sucks/ */
 /* Specifically, the section titled "The enormous drawback". */
+/* @todo - Save code by amalgamating common button background declarations. */
 .pagelinks .navPages {
 	display: block;
 	float: left;
@@ -1621,7 +1616,7 @@ div.windowbg, div.windowbg2 {
 
 /* @todo */
 /* A general table class. */
-.table_grid, .table_padding {
+.table_grid {
 	margin: 0;
 	width: 100%;
 	border-spacing: 0;
@@ -1629,35 +1624,26 @@ div.windowbg, div.windowbg2 {
 	border: 1px solid #ddd;
 	border-top: none;
 }
-.table_grid .catbg, .table_grid .catbg th {
+.table_head>th {
 	font-size: 1em;
 	font-weight: 600;
 }
-.table_grid th {
-	padding: 4px;
+.table_head>th {
+	padding: 5px 8px;
 	border-top: 2px solid #ddd;
 	border-bottom: 2px solid #ddd;
 	background: #fff;
 	color: #555;
 }
-/* @todo- Eh wot? Hmmm. */
-.table_grid .catbg .stats {
-	white-space: nowrap;
-}
-.last_th .input_check {
-	margin: 4px 0 0 0;
-}
-/* @todo - Check out table_padding class in more detail. */
-/* @todo - Can probably deprecate. Just use table_grid everywhere. */
-.table_grid td, .table_padding td {
-	padding: 4px;
+.table_grid td {
+	padding: 5px 8px;
 	border-bottom: 1px solid #ccc;
 }
 /* Subtle zebra striping for rows. */
-.table_grid .standard_row, .table_padding .standard_row {
+.table_grid .standard_row {
 	background: #fff;
 }
-.table_grid .alternate_row, .table_padding .alternate_row {
+.table_grid .alternate_row {
 	background: #fafafa;
 }
 .table_grid  textarea {
@@ -1669,7 +1655,6 @@ div.windowbg, div.windowbg2 {
 .table_grid  textarea {
 	width: 100%;
 }
-
 /* GenericList */
 .additional_row {
 	padding: 6px 0;
@@ -1678,24 +1663,11 @@ div.windowbg, div.windowbg2 {
 	margin: 0 0 -4px 4px;
 }
 
-/* @todo - If keeping this, move to $PROFILE */
-/* Table_grid cells for Profile > Show Permissions. */
-#permissions .table_grid td {
-	padding: 5px 10px;
-	/* Why cursor on a table cell? */
-	cursor: default;
-}
-
-/* Styles for generic tables. @todo - Oh hell, not more of them. */
+/* For Errors.template.php. */
 /* ------------------------------------------------------- */
-.errorfile_table {
-	border-spacing: 3px;
-	border-collapse: collapse;
-	background: #f0f4f7;
-}
-.errorfile_table .current {
-	border: 1px solid black;
-	border-width: 1px 0 1px 1px;
+#errorfile_table .current {
+	border: 1px solid #444;
+	background: #fff5cd;
 	font-weight: bold;
 }
 
@@ -2116,10 +2088,7 @@ img.new_posts {
 	margin: 2px 4px;
 	padding: 1px 6px;
 }
-.approvetopic_row {
-	background: #fff5cd;
-}
-.approve_row {
+.approvetopic_row, .approve_row {
 	background: #fff5cd;
 }
 .sticky_row, .locked_row.sticky_row {
@@ -2277,13 +2246,12 @@ img.new_posts {
 	box-shadow: 1px 2px 4px #eee;
 }
 /* Topic information */
-.forumposts .catbg img {
-	padding: 5px 3px 0 0;
-}
-.forumposts .catbg span {
-	padding: 0 0 2px 0;
+.views_text, .nextlinks {
 	white-space: pre;
-	font-size: 0.857em;
+	font-size: 0.765em;
+}
+.nextlinks {
+	float: right;
 }
 #whoisviewing {
 	padding: 4px 1em;
@@ -2305,7 +2273,6 @@ img.new_posts {
 	background: #fff5cd;
 }
 
-/* @todo - Also, look at simplifying markup in posts < ETA: Mostly done, but poster area still needs some work. */
 /* Poster details and list of items */
 .poster {
 	float: left;
@@ -2317,7 +2284,6 @@ img.new_posts {
 }
 .poster.poster2 {
 	margin: 0;
-	max-width: 25em;
 	width: auto;
 	font-size: 1em;
 }
@@ -2327,7 +2293,7 @@ img.new_posts {
 	font-size: 1em;
 	line-height: 1.5em;
 }
-/* #todo - Add an h4 or h5 tag here for a11y. */ 
+/* #todo - Add an h3 for a11y? Breaks Stoopidfish. Bleh. :P */ 
 .poster .name {
 	display: block;
 	overflow: hidden;
@@ -2353,59 +2319,39 @@ img.new_posts {
 .poster .listlevel2 {
 	width: 14em;
 }
-.poster .linklevel2, .poster  .listlevel2:hover .linklevel2 {
-	padding: 0;
+.poster .linklevel2, .poster .linklevel2:focus,
+.poster .listlevel2:hover .linklevel2 {
 	border: 1px solid transparent;
 	background: none;
+	padding: 0;
 }
-.poster  .listlevel2:hover .linklevel2:hover {
+.poster .listlevel2:hover .linklevel2:hover {
 	text-decoration: underline;
 }
-.karma_allow .linklevel2 {
+.karma_allow>.linklevel2 {
 	display: inline-block;
 }
-.poster .listlevel2 ol {
-	float: left;
+.listlevel2>ol>li {
+	display: table-cell;
+}
+.report_seperator {
 	margin: 6px 0 0 0;
-	padding: 0 0 0 0;
-	width: 100%;
+	height: 1px;
+	background: #bbb;
+	border-bottom: 1px solid #eee;
 }
-.poster .menulevel2 ol li {
-	display: table-cell;
-}
-.poster .menulevel2 .report_link, .poster .menulevel2 .warning, .poster .menulevel2 .poster_ip {
-	float: left;
-	margin: 0;
-	padding: 0;
-	width: 100%;
-}
-.poster .menulevel2 .report_seperator {
-	height: 2px;
-	background: #ccc;
-	box-shadow: 0 -1px 0 #fff inset;
-}
-.poster .menulevel2 .warning a, .poster .menulevel2 .warning img {
-	display: table-cell;
-	padding: 0 4px;
-	width: auto;
+/* Icon tweaks for several areas. */
+.poster .icons>img, .poster .linklevel1>img, .poster .linklevel2>img {
 	vertical-align: middle;
 }
-.poster .listlevel2 hr {
-	margin: 4px 3px;
+.listlevel2>ol>li img, .listlevel2.warning img, .listlevel2.poster_ip img {
+	padding: 0 4px;
 }
-.poster .listlevel2.poster_ip a {
-	display: table-cell;
-}
-
 /* The visible stuff below the avatar. */
-.poster .icons, .poster .membergroup, .poster .title, .poster_online, .poster  .warning {
-	margin: 3px 0 0 0;
-	padding: 0;
-}
 .poster  .membergroup {
 	font-weight: bold;
 }
-/* @todo - Re-code this a bit to give background on anchor. */
+/* @todo - Save code by amalgamating common button background declarations. */
 .poster_online .linklevel1 {
 	display: block;
 	margin: 3px 1em;
@@ -2416,7 +2362,7 @@ img.new_posts {
 	background-image: linear-gradient(to bottom, #fcfcfc 0%, #e5e5e5 100%);
 	line-height: 2em;
 }
-.listlevel1.poster_online .linklevel1:hover {
+.poster_online .linklevel1:hover {
 	border: 1px solid #ccc;
 	border-top: 1px solid #aaa;
 	border-left: 1px solid #bbb;
@@ -2424,21 +2370,16 @@ img.new_posts {
 	box-shadow: 1px 1px 1px rgba(0,0,0,0.07) inset;
 	text-decoration: none;
 }
-.poster  .warning a img {
-	padding: 0 2px;
-	vertical-align: bottom;
-}
-.poster img {
-	vertical-align: middle;
-}
 /* End nifty new flyout. */
 
-.postarea {
+.postarea, .postarea2 {
 	margin: 0 0 0 12.2em;
 	padding: 0 1em;
 }
-#topic_summary .postarea {
+.postarea2 {
 	margin: 0;
+}
+#topic_summary .postarea2 {
 	font-size: 0.857em;
 }
 .post_subject {
@@ -2621,9 +2562,8 @@ dl.send_mail dd {
 	vertical-align: middle;
 }
 ul.post_options {
-	overflow: hidden;
+	overflow: auto;
 	margin: 0 0 0 12px;
-	padding: 0;
 }
 ul.post_options li {
 	float: left;
@@ -2631,13 +2571,14 @@ ul.post_options li {
 	width: 49%;
 }
 #postAdditionalOptionsHeader, #postDraftOptionsHeader {
-	margin: 1em  0 0 0;
+	margin: 1em 0 0 0;
 	background: #fafafa;
 	background-image: linear-gradient(to bottom, #fafafa 0%, #ebebeb 100%);
 	border-bottom: 1px solid #ccc;
 }
 #postAdditionalOptions, #postDraftOptions {
-	overflow: hidden;
+	margin: 0 0 1em 0;
+	overflow: auto;
 	border: 1px solid #ccc;
 	border-top: none;
 	border-radius: 0 0 4px 4px;
@@ -3677,12 +3618,8 @@ dl.merge_topic dd {
 /* ------------------------------------------------------- */
 
 /* The basic search section. */
-#simple_search p {
-	margin: 0;
-	padding: 6px;
-}
-#simple_search, #simple_search p, #advanced_search {
-	margin: 0;
+#simple_search, #advanced_search {
+	margin: 4px 0 0 0;
 	text-align: center;
 }
 #search_error {
@@ -3695,20 +3632,7 @@ dl.merge_topic dd {
 }
 
 /* The advanced search section. */
-#searchform fieldset {
-	padding: 0;
-	border: none;
-	text-align: left;
-}
-#searchform .roundframe {
-	overflow: auto;
-	margin: 8px 0 0 0;
-	padding: 32px;
-	border: 1px solid #ccc;
-	border-radius: 7px;
-	box-shadow: 0 -2px 2px rgba(0,0,0,0.1);
-}
-#advanced_search #search_options {
+#search_options {
 	overflow: hidden;
 	margin: 0 auto;
 	padding-top: 12px;
@@ -3728,9 +3652,6 @@ dl.merge_topic dd {
 	width: 80%;
 	text-align: left;
 }
-#searchform .clear {
-	clear: both;
-}
 
 /* The search results page.
 /* The search results page. @todo - Duplicated in the .table_grid code? */
@@ -3745,13 +3666,28 @@ dl.merge_topic dd {
 	padding: 5px 12px 0 0;
 }
 
-/* The memberlist search section. */
-#mlist_search {
-	overflow: hidden;
-	margin: auto;
-	width: 500px;
+/* The memberlist. */
+#memberlist {
+	margin: 6px 0 0 0;
 }
-#mlist_search .input_text {
+#memberlist>.content {
+	padding: 12px 0;
+}
+#memberlist_search, #memberlist>.content>.submit_buttons_wrap {
+	margin: 0 auto;
+	width: 32em;
+}
+#memberlist_search>dt, #memberlist_search>dd {
+	width: 12em;
+}
+#memberlist_search>dd {
+	width: 20em;
+}
+#memberlist_search .input_check {
+	margin: 4px 0 0 0;
+}
+#memberlist_search .input_text {
+	margin: 0 0 12px 0;
 	overflow: hidden;
 	width: 100%;
 }

--- a/themes/default/css/rtl.css
+++ b/themes/default/css/rtl.css
@@ -143,18 +143,6 @@ h4.titlebg img.icon {
 	background:  #e3e9ef url(../images/admin/subsection_rtl.png) no-repeat 1% 40%, url(../images/theme/lower_section.png) 0 0 repeat-x;
 }
 
-/* The dropdown menu toggle image */
-#menu_toggle {
-	float: left;
-	margin-right: 0;
-	margin-left: 10px;
-	padding-top: 3px;
-}
-#menu_toggle span {
-	position: relative;
-	left: 0;
-}
-
 li#collapse_button {
 	float: left;
 	position: relative;


### PR DESCRIPTION
Ugh. Old SMF 2.0.x markup. :P
This one started getting over the top, so I thought I should get it in now.
Have started on the stuff mentioned in https://github.com/elkarte/Elkarte/issues/624
Not completely done yet. Lots more crud to kill.
Other deprecated things (not mentioned in #624) are flow_auto class on dl.settings
(the .settings dl's already have overflow auto; in the css, so not needed in markup)
and the old .hrcolor class (just use plain hr everywhere)
and width="100%" or style="width: 100%;" on the table_grid class (again, set in css anyway).
Most of those should be gone now.
There are also some tweaks to markup and presentation for the search, and search memberlist, pages.
A bit of other minor tarting up too, but nothing radical. Hey ho.
Signed-off-by:Antechinus darthechidna@bigpond.com
