### PR TITLE
Addon Install Error

### DIFF
--- a/sources/admin/Packages.controller.php
+++ b/sources/admin/Packages.controller.php
@@ -894,7 +894,7 @@ class Packages_Controller extends Action_Controller
 		$context['install_finished'] = false;
 
 		// We're gonna be needing the table db functions! ...Sometimes.
-		$table = db_table();
+		$elk_table = db_table();
 
 		// @todo Make a log of any errors that occurred and output them?
 		if (!empty($install_log))
@@ -1010,7 +1010,7 @@ class Packages_Controller extends Action_Controller
 			if (!$context['uninstalling'])
 			{
 				// Any db changes from older version?
-				$table_log = $table->package_log();
+				$table_log = $elk_table->package_log();
 				if (!empty($old_db_changes))
 					$db_package_log = empty($table_log) ? $old_db_changes : array_merge($old_db_changes, $table_log);
 
@@ -1069,11 +1069,11 @@ class Packages_Controller extends Action_Controller
 			foreach ($package_installed['db_changes'] as $change)
 			{
 				if ($change[0] == 'remove_table' && isset($change[1]))
-					$table->db_drop_table($change[1]);
+					$elk_table->db_drop_table($change[1]);
 				elseif ($change[0] == 'remove_column' && isset($change[2]))
-					$table->db_remove_column($change[1], $change[2]);
+					$elk_table->db_remove_column($change[1], $change[2]);
 				elseif ($change[0] == 'remove_index' && isset($change[2]))
-					$table->db_remove_index($change[1], $change[2]);
+					$elk_table->db_remove_index($change[1], $change[2]);
 			}
 		}
 


### PR DESCRIPTION
First I admit I have not traced this one done fully ...

When installing a package (that makes use of db_table(), and uses a var $table as part of its database install code)  the $table object in the controller is getting overwritten.

This results in calling an object on a non object fatal error ... honestly not sure if this is from using the $table var in the addon db installer or if its happening inside the package.controller, etc ... Anyway this is a workaround since I needed something quick so I can keep working.  In some ways we may want a naming convention for object vars ($obj_elk_blabla ?) to help avoid collisions, don't know.
