### PR TITLE
Relative Time change

### DIFF
--- a/sources/Load.php
+++ b/sources/Load.php
@@ -1584,21 +1584,23 @@ function loadTheme($id_theme = 0, $initialize = true)
 	}
 
 	if (!empty($modSettings['todayMod']) && $modSettings['todayMod'] > 2)
-		$context['javascript_vars'] += array(
-			'rt_now' => JavaScriptEscape($txt['rt_now']),
-			'rt_minute' => JavaScriptEscape($txt['rt_minute']),
-			'rt_minutes' => JavaScriptEscape($txt['rt_minutes']),
-			'rt_hour' => JavaScriptEscape($txt['rt_hour']),
-			'rt_hours' => JavaScriptEscape($txt['rt_hours']),
-			'rt_day' => JavaScriptEscape($txt['rt_day']),
-			'rt_days' => JavaScriptEscape($txt['rt_days']),
-			'rt_week' => JavaScriptEscape($txt['rt_week']),
-			'rt_weeks' => JavaScriptEscape($txt['rt_weeks']),
-			'rt_month' => JavaScriptEscape($txt['rt_month']),
-			'rt_months' => JavaScriptEscape($txt['rt_months']),
-			'rt_year' => JavaScriptEscape($txt['rt_year']),
-			'rt_years' => JavaScriptEscape($txt['rt_years']),
-		);
+		addInlineJavascript('
+		var oRttime = ({
+			now : ' . JavaScriptEscape($txt['rt_now']) . ',
+			minute : ' . JavaScriptEscape($txt['rt_minute']) . ',
+			minutes : ' . JavaScriptEscape($txt['rt_minutes']) . ',
+			hour : ' . JavaScriptEscape($txt['rt_hour']) . ',
+			hours : ' . JavaScriptEscape($txt['rt_hours']) . ',
+			day : ' . JavaScriptEscape($txt['rt_day']) . ',
+			days : ' . JavaScriptEscape($txt['rt_days']) . ',
+			week : ' . JavaScriptEscape($txt['rt_week']) . ',
+			weeks : ' . JavaScriptEscape($txt['rt_weeks']) . ',
+			month : ' . JavaScriptEscape($txt['rt_month']) . ',
+			months : ' . JavaScriptEscape($txt['rt_months']) . ',
+			year : ' . JavaScriptEscape($txt['rt_year']) . ',
+			years : ' . JavaScriptEscape($txt['rt_years']) . ',
+		});
+		updateRelativeTime();', true);
 
 	// Queue our Javascript
 	loadJavascriptFile(array('elk_jquery_plugins.js', 'script.js', 'theme.js'));
@@ -2540,7 +2542,7 @@ function loadDatabase()
 	$db = database();
 	if (ELK == 'SSI')
 		$db_prefix = $db->fix_prefix($db_prefix, $db_name);
-	
+
 	// Case sensitive database? Let's define a constant.
 	if ($db->db_case_sensitive())
 		DEFINE('DB_CASE_SENSITIVE', '1');

--- a/themes/default/scripts/script.js
+++ b/themes/default/scripts/script.js
@@ -1852,6 +1852,7 @@ function updateRelativeTime()
 {
 	// In any other case no more than one hour
 	relative_time_refresh = 3600000;
+
 	$('time').each(function() {
 		var oRelativeTime = new relativeTime($(this).attr('datetime')),
 			postdate = new Date($(this).attr('datetime')),
@@ -1861,42 +1862,42 @@ function updateRelativeTime()
 
 		if (oRelativeTime.seconds())
 		{
-			$(this).text(rt_now);
+			$(this).text(oRttime.now);
 			relative_time_refresh = Math.min(relative_time_refresh, 10000);
 		}
 		else if (oRelativeTime.minutes())
 		{
-			time_text = oRelativeTime.deltaTime > 1 ? rt_minutes : rt_minute;
+			time_text = oRelativeTime.deltaTime > 1 ? oRttime.minutes : oRttime.minute;
 			$(this).text(time_text.replace('%s', oRelativeTime.deltaTime));
 			relative_time_refresh = Math.min(relative_time_refresh, 60000);
 		}
 		else if (oRelativeTime.hours())
 		{
-			time_text = oRelativeTime.deltaTime > 1 ? rt_hours : rt_hour;
+			time_text = oRelativeTime.deltaTime > 1 ? oRttime.hours : oRttime.hour;
 			$(this).text(time_text.replace('%s', oRelativeTime.deltaTime));
 			relative_time_refresh = Math.min(relative_time_refresh, 3600000);
 		}
 		else if (oRelativeTime.days())
 		{
-			time_text = oRelativeTime.deltaTime > 1 ? rt_days : rt_day;
+			time_text = oRelativeTime.deltaTime > 1 ? oRttime.days : oRttime.day;
 			$(this).text(time_text.replace('%s', oRelativeTime.deltaTime));
 			relative_time_refresh = Math.min(relative_time_refresh, 3600000);
 		}
 		else if (oRelativeTime.weeks())
 		{
-			time_text = oRelativeTime.deltaTime > 1 ? rt_weeks : rt_week;
+			time_text = oRelativeTime.deltaTime > 1 ? oRttime.weeks : oRttime.week;
 			$(this).text(time_text.replace('%s', oRelativeTime.deltaTime));
 			relative_time_refresh = Math.min(relative_time_refresh, 3600000);
 		}
 		else if (oRelativeTime.months())
 		{
-			time_text = oRelativeTime.deltaTime > 1 ? rt_months : rt_month;
+			time_text = oRelativeTime.deltaTime > 1 ? oRttime.months : oRttime.month;
 			$(this).text(time_text.replace('%s', oRelativeTime.deltaTime));
 			relative_time_refresh = Math.min(relative_time_refresh, 3600000);
 		}
 		else if (oRelativeTime.years())
 		{
-			time_text = oRelativeTime.deltaTime > 1 ? rt_years : rt_year;
+			time_text = oRelativeTime.deltaTime > 1 ? oRttime.years : oRttime.year;
 			$(this).text(time_text.replace('%s', oRelativeTime.deltaTime));
 			relative_time_refresh = Math.min(relative_time_refresh, 3600000);
 		}

--- a/themes/default/scripts/theme.js
+++ b/themes/default/scripts/theme.js
@@ -60,7 +60,6 @@ $(document).ready(function() {
 	$('.spoilerheader').click(function(){
 		$(this).next().children().slideToggle("fast");
 	});
-	updateRelativeTime();
 });
 
 // Toggles the element height and width styles of an image.
@@ -307,5 +306,5 @@ elk_mentions.prototype.init = function ()
 
 function revalidateMentions()
 {
-	
+
 }


### PR DESCRIPTION
Calling relative time outside of the $modsettings conditional will cause JS errors due to undefined strings (rt_xys language was not defined) which halts other JS from running in some browsers

I move the text strings to an js object, not sure why but I did, and then called the relative time function after that.
Also moved it to a addInline using deferred vs $context{'javascript_vars'] I don't think that will cause any problems!

@emanuele45  thats for you to check over, not sure I broke something else :innocent: 

Signed-off-by: Spuds spuds@spudsdesign.com
