### PR TITLE
Adding  $adminActions to integrate_actions hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Packages/temp
 .project
 .settings/
 /site
+nbproject/*

--- a/sources/Dispatcher.class.php
+++ b/sources/Dispatcher.class.php
@@ -200,7 +200,7 @@ class Site_Dispatcher
 		$adminActions = array('admin', 'jsoption', 'theme', 'viewadminfile', 'viewquery');
 
 		// Allow to extend or change $actionArray through a hook
-		call_integration_hook('integrate_actions', array(&$actionArray));
+		call_integration_hook('integrate_actions', array(&$actionArray, &$adminActions));
 
 		// Is it in core legacy actions?
 		if (isset($actionArray[$_GET['action']]))


### PR DESCRIPTION
Allows mods to keep Admin source files in the sources/admin folder. Merge if you agree. :)

Signed-off-by: ichbin ichbin@ichbin.us
