### PR TITLE
Prevent editor window from visaully clipping last line

### DIFF
--- a/themes/default/css/jquery.sceditor.css
+++ b/themes/default/css/jquery.sceditor.css
@@ -25,7 +25,7 @@
 	outline: none;
 	color: #444;
 	padding: 5px;
-	margin: 0 5px 18px;
+	margin: 0 0 23px;
 	resize: none;
 	display: block;
 }


### PR DESCRIPTION
This set the editor text area bottom margin to the same height as the grab-bar + border to prevent lower line clipping.  I think this fixes the issue discussed on the site, let me know :smile_cat: 
