### PR TITLE
Adding textarea option for theme settings.

### DIFF
--- a/themes/default/ManageThemes.template.php
+++ b/themes/default/ManageThemes.template.php
@@ -573,6 +573,23 @@ function template_set_settings()
 							<input type="checkbox" name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="', $setting['id'], '"', !empty($setting['value']) ? ' checked="checked"' : '', ' value="1" class="input_check" />
 						</dd>';
 		}
+		// A textarea?
+		elseif ($setting['type'] == 'textarea')
+		{
+			echo '
+						<dt id="dt_', $setting['id'], '">
+							<label for="', $setting['id'], '">', $setting['label'], '</label>:';
+
+			if (isset($setting['description']))
+				echo '<br />
+							<span class="smalltext">', $setting['description'], '</span>';
+
+			echo '
+						</dt>
+						<dd id="dd_', $setting['id'], '">
+							<textarea name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="', $setting['id'], '"class="input_textarea">', $setting['value'], '</textarea>
+						</dd>';
+		}
 		// A list with options?
 		elseif ($setting['type'] == 'list')
 		{


### PR DESCRIPTION
Signed-off-by: ichbin ichbin@ichbin.us

In light of this request - http://www.elkarte.net/index.php?topic=863 it got me thinking.

I was looking at the theme options, and noticed we can only have a textbox to insert custom code into a theme. Any reason we couldn't allow a textarea so that someone could use the box to insert some custom code into a theme, without them having to edit the theme? I realize that a textbox can do the same thing, but you can't see all the code and you can't resize the textbox to view it like a textarea. :)
