### PR TITLE
Add new stale constant to ease rev changes

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -24,6 +24,9 @@ if (defined('ELK'))
 
 define('ELK', 'SSI');
 
+// Shortcut for the browser cache stale
+define('CACHE_STALE', '?beta10');
+
 // We're going to want a few globals... these are all set later.
 global $time_start, $maintenance, $msubject, $mmessage, $mbname, $language;
 global $boardurl, $webmaster_email, $cookiename;

--- a/index.php
+++ b/index.php
@@ -24,6 +24,9 @@ $forum_version = 'ElkArte 1.0 Beta';
 // First things first, but not necessarily in that order.
 define('ELK', 1);
 
+// Shortcut for the browser cache stale
+define('CACHE_STALE', '?beta10');
+
 if (function_exists('set_magic_quotes_runtime'))
 	@set_magic_quotes_runtime(0);
 error_reporting(E_ALL | E_STRICT);
@@ -192,7 +195,7 @@ function elk_main()
 	if (!empty($topic) && empty($board_info['cur_topic_approved']) && !allowedTo('approve_posts') && ($user_info['id'] != $board_info['cur_topic_starter'] || $user_info['is_guest']))
 		fatal_lang_error('not_a_topic', false);
 
-	$no_stat_actions = array('dlattach', 'findmember', 'jsoption', 'requestmembers', '.xml', 'xmlhttp', 'verificationcode', 'viewquery', 'viewadminfile');
+	$no_stat_actions = array('dlattach', 'findmember', 'jsoption', 'requestmembers', 'loadeditorlocale', 'xmlpreview', 'suggest', '.xml', 'xmlhttp', 'verificationcode', 'viewquery', 'viewadminfile');
 	call_integration_hook('integrate_pre_log_stats', array(&$no_stat_actions));
 
 	// Do some logging, unless this is an attachment, avatar, toggle of editor buttons, theme option, XML feed etc.

--- a/install/install.php
+++ b/install/install.php
@@ -2017,7 +2017,7 @@ function template_install_above()
 		<meta name="robots" content="noindex" />
 		<title>', $txt['installer'], '</title>
 		<link rel="stylesheet" href="themes/default/css/index.css?beta10" />
-		<link rel="stylesheet" href="themes/default/css/index_light.css?beta10" />
+		<link rel="stylesheet" href="themes/default/css/_light/index_light.css?beta10" />
 		<link rel="stylesheet" href="themes/default/css/install.css?beta10" />
 		<script src="themes/default/scripts/script.js"></script>
 	</head>

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -3416,7 +3416,7 @@ function template_upgrade_above()
 		<meta name="robots" content="noindex" />
 		<title>', $txt['upgrade_upgrade_utility'], '</title>
 		<link rel="stylesheet" href="', $settings['default_theme_url'], '/css/index.css?beta10" />
-		<link rel="stylesheet" href="', $settings['default_theme_url'], '/css/index_light.css?beta10" />
+		<link rel="stylesheet" href="', $settings['default_theme_url'], '/css/_light/index_light.css?beta10" />
 		<link rel="stylesheet" href="', $settings['default_theme_url'], '/css/install.css?beta10" />
 		<script src="', $settings['default_theme_url'], '/scripts/script.js"></script>
 		<script><!-- // --><![CDATA[

--- a/sources/Load.php
+++ b/sources/Load.php
@@ -1856,7 +1856,7 @@ function loadCSSFile($filenames, $params = array(), $id = '')
 		$filenames = array($filenames);
 
 	// Static values for all these settings
-	$params['stale'] = (!isset($params['stale']) || $params['stale'] === true) ? '?beta10' : (is_string($params['stale']) ? ($params['stale'] = $params['stale'][0] === '?' ? $params['stale'] : '?' . $params['stale']) : '');
+	$params['stale'] = (!isset($params['stale']) || $params['stale'] === true) ? CACHE_STALE : (is_string($params['stale']) ? ($params['stale'] = $params['stale'][0] === '?' ? $params['stale'] : '?' . $params['stale']) : '');
 	$params['fallback'] = (!empty($params['fallback']) && ($params['fallback'] === false)) ? false : true;
 
 	// Whoa ... we've done this before yes?
@@ -1941,7 +1941,7 @@ function loadJavascriptFile($filenames, $params = array(), $id = '')
 		$filenames = array($filenames);
 
 	// Static values for all these files
-	$params['stale'] = (!isset($params['stale']) || $params['stale'] === true) ? '?beta10' : (is_string($params['stale']) ? ($params['stale'] = $params['stale'][0] === '?' ? $params['stale'] : '?' . $params['stale']) : '');
+	$params['stale'] = (!isset($params['stale']) || $params['stale'] === true) ? CACHE_STALE : (is_string($params['stale']) ? ($params['stale'] = $params['stale'][0] === '?' ? $params['stale'] : '?' . $params['stale']) : '');
 	$params['fallback'] = (!empty($params['fallback']) && ($params['fallback'] === false)) ? false : true;
 
 	// Dejvu?

--- a/sources/admin/AdminDebug.controller.php
+++ b/sources/admin/AdminDebug.controller.php
@@ -75,7 +75,7 @@ class AdminDebug_Controller extends Action_Controller
 <html', $context['right_to_left'] ? 'dir="rtl"' : '', '>
 	<head>
 		<title>', $context['forum_name_html_safe'], '</title>
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css?beta10" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', CACHE_STALE, '" />
 		<style>
 			body {
 				margin: 1ex;

--- a/ssi_examples.php
+++ b/ssi_examples.php
@@ -499,8 +499,8 @@ function template_ssi_above()
 <html>
 	<head>
 		<title>SSI.php Examples</title>
-		<link rel="stylesheet" href="', $settings['default_theme_url'], '/css/index.css?beta10" />
-		<link rel="stylesheet" href="', $settings['default_theme_url'], '/css/index_light.css?beta10" />
+		<link rel="stylesheet" href="', $settings['default_theme_url'], '/css/index.css', CACHE_STALE, '" />
+		<link rel="stylesheet" href="', $settings['default_theme_url'], '/css/_light/index_light.css' , CACHE_STALE, '" />
 		<script src="', $settings['default_theme_url'], '/scripts/script.js"></script>
 		<style>
 			#wrapper {

--- a/themes/default/Errors.template.php
+++ b/themes/default/Errors.template.php
@@ -12,7 +12,7 @@
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
  * @version 1.0 Beta
- * 
+ *
  */
 
 /**
@@ -151,6 +151,7 @@ function template_error_log()
 					<td class="checkbox_column">
 						<input type="checkbox" name="delete[]" value="', $error['id'], '" class="input_check" />
 					</td>
+					<td></td>
 				</tr>';
 	}
 
@@ -198,8 +199,7 @@ function template_show_file()
 	<head>
 		<title>', $context['file_data']['file'], '</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/admin.css?beta10" />
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css?beta10" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/admin.css', CACHE_STALE, '" />
 	</head>
 	<body>
 		<table id="errorfile_table" class="table_grid">';

--- a/themes/default/Help.template.php
+++ b/themes/default/Help.template.php
@@ -12,7 +12,7 @@
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
  * @version 1.0 Beta
- * 
+ *
  */
 
 /**
@@ -29,8 +29,8 @@ function template_popup()
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<meta name="robots" content="noindex" />
 		<title>', $context['page_title'], '</title>
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index.css?beta10" />
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css?beta10" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index.css', CACHE_STALE, '" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/', $context['theme_variant'], '/index', $context['theme_variant'], '.css', CACHE_STALE, '" />
 		<script src="', $settings['default_theme_url'], '/scripts/script.js"></script>
 	</head>
 	<body id="help_popup">

--- a/themes/default/Members.template.php
+++ b/themes/default/Members.template.php
@@ -29,7 +29,8 @@ function template_find_members()
 		<title>', $txt['find_members'], '</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<meta name="robots" content="noindex" />
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css?beta10" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', CACHE_STALE, '" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/', $context['theme_variant'], '/index', $context['theme_variant'], '.css', CACHE_STALE, '" />
 		<script src="', $settings['default_theme_url'], '/scripts/script.js"></script>
 		<script><!-- // --><![CDATA[
 			var membersAdded = [];

--- a/themes/default/ModerationCenter.template.php
+++ b/themes/default/ModerationCenter.template.php
@@ -610,8 +610,8 @@ function template_show_notice()
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<title>', $context['page_title'], '</title>
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index.css?beta10" />
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css?beta10" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index.css', CACHE_STALE, '" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/', $context['theme_variant'], '/index', $context['theme_variant'], '.css', CACHE_STALE, '" />
 	</head>
 	<body>
 		<h2 class="category_header">', $txt['show_notice'], '</h2>

--- a/themes/default/Packages.template.php
+++ b/themes/default/Packages.template.php
@@ -795,10 +795,10 @@ function template_view_operations()
 	<head>
 		<title>', $txt['operation_title'], '</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css?beta10" />
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/admin.css?beta10" />
-		<script src="', $settings['default_theme_url'], '/scripts/script.js?beta10"></script>
-		<script src="', $settings['default_theme_url'], '/scripts/theme.js?beta10"></script>
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/admin.css', CACHE_STALE, '" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/', $context['theme_variant'], '/index', $context['theme_variant'], '.css', CACHE_STALE, '" />
+		<script src="', $settings['default_theme_url'], '/scripts/script.js', CACHE_STALE, '"></script>
+		<script src="', $settings['default_theme_url'], '/scripts/theme.js', CACHE_STALE, '"></script>
 	</head>
 	<body>
 		<div class="windowbg">

--- a/themes/default/Post.template.php
+++ b/themes/default/Post.template.php
@@ -727,7 +727,8 @@ function template_spellcheck()
 	<head>
 		<title>', $txt['spell_check'], '</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css?beta10" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index.css', CACHE_STALE, '" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/', $context['theme_variant'], '/index', $context['theme_variant'], '.css', CACHE_STALE, '" />
 		<style>
 			body, td {
 				font-size: small;

--- a/themes/default/Register.template.php
+++ b/themes/default/Register.template.php
@@ -509,8 +509,8 @@ function template_verification_sound()
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<title>', $txt['visual_verification_sound'], '</title>
 		<meta name="robots" content="noindex" />
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index.css?beta10" />
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css?beta10" />';
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index.css', CACHE_STALE, '" />
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/', $context['theme_variant'], '/index', $context['theme_variant'], '.css', CACHE_STALE, '" />';
 
 	// Just show the help text and a "close window" link.
 	echo '


### PR DESCRIPTION
This adds a constant for use in the cache stale ?blaX we have on our js and css files.  Helps a bit during updates, although you will still have update all of the file headers etc, but this will help somewhat.  Did not do the install and upgrade scripts just yet.

Don't think I missed any but some of them are a bit buried in the code, hence the change !
