### PR TITLE
[DISCUSSION] A simple way to support X-Frame-Options: ALLOW-FROM

### DIFF
--- a/sources/Security.php
+++ b/sources/Security.php
@@ -1514,7 +1514,15 @@ function frameOptionsHeader($override = null)
 		return;
 
 	// Finally set it.
-	header('X-Frame-Options: ' . $option);
+	if ($option != 'ALLOW-FROM')
+		header('X-Frame-Options: ' . $option);
+	// But if we want to allow some hosts then we need more work
+	else
+	{
+		$allowed = explode("\n", $modSetting['frame_security_allow_from']);
+		foreach ($allowed as $url)
+			header('X-Frame-Options: ALLOW-FROM ' . $url);
+	}
 }
 
 /**

--- a/sources/admin/ManageSearch.controller.php
+++ b/sources/admin/ManageSearch.controller.php
@@ -111,9 +111,6 @@ class ManageSearch_Controller extends Action_Controller
 
 		$config_vars = $this->_searchSettings->settings();
 
-		if (!isset($context['settings_post_javascript']))
-			$context['settings_post_javascript'] = '';
-
 		call_integration_hook('integrate_modify_search_settings', array(&$config_vars));
 
 		// Perhaps the search method wants to add some settings?

--- a/themes/default/Admin.template.php
+++ b/themes/default/Admin.template.php
@@ -1072,6 +1072,7 @@ function template_show_settings()
 		</form>
 	</div>';
 
+	// @deprecated since 1.0 use addInlineJavascript instead
 	if (!empty($context['settings_post_javascript']))
 		echo '
 	<script><!-- // --><![CDATA[

--- a/themes/default/languages/english/ManageSettings.english.php
+++ b/themes/default/languages/english/ManageSettings.english.php
@@ -460,5 +460,8 @@ $txt['languages_delete_confirm'] = 'Are you sure you want to delete this languag
 
 $txt['setting_frame_security'] = 'Frame Security Options';
 $txt['setting_frame_security_SAMEORIGIN'] = 'Allow Same Origin';
+$txt['setting_frame_security_ALLOW-FROM'] = 'Allow From Specified Origins';
 $txt['setting_frame_security_DENY'] = 'Deny all frames';
 $txt['setting_frame_security_DISABLE'] = 'Disabled';
+$txt['setting_frame_security_allow_from'] = 'URL of hosts allowed to include your site into frames';
+$txt['setting_frame_security_allow_from_desc'] = 'One address per line<br />This option may not be supported by all browsers.';

--- a/themes/default/scripts/admin.js
+++ b/themes/default/scripts/admin.js
@@ -1118,3 +1118,20 @@ function initEditProfileBoards()
 		);
 	});
 }
+
+function frame_security_toggle()
+{
+	elem = document.getElementById('frame_security');
+
+	if (elem.options[elem.selectedIndex].value == 'ALLOW-FROM')
+	{
+		$('#frame_security_allow_from').parent().fadeIn('fast');
+		$('#frame_security_allow_from').parent().prev().fadeIn('fast');
+	}
+	else
+	{
+		$('#frame_security_allow_from').parent().fadeOut('fast');
+		$('#frame_security_allow_from').parent().prev().fadeOut('fast');
+	}
+
+}


### PR DESCRIPTION
This evening I got a question on an Italian support site because a kind of stupid "social news" whatever website uses frames to show pages around the web and "promote" the websites (well, it's more promoting itself, but... heh)
So I googled a bit and discovered the ALLOW-FROM option:
http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
It's not yet supported by some browsers (probably only [Chrome](https://bugs.webkit.org/show_bug.cgi?id=94836) and Opera now I suppose), so it may be tricky.

Opinions? (Also on the implementation that is a bit lazy... :innocent: )
