### PR TITLE
bugfix for shortening URLs via CSS

### DIFF
--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -789,7 +789,7 @@ a.bbc_link {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	max-width: 24em;
+	max-width: 100%;
 	vertical-align: bottom;
 }
 
@@ -4228,10 +4228,6 @@ a.help .icon {
 	}
 	.postarea, .forumtitle {
 		padding: 2px;
-	}
-	a.bbc_link {
-		display: inline-block;
-		max-width: 16em;
 	}
 	.linktree .board_moderators, .linktree_last .board_moderators {
 		display: none;


### PR DESCRIPTION
- set the url shortening to a max-width of 100%, the old max-width value caused problems with embedded images. (Reported by Jorin)
