### PR TITLE
custom CSS

### DIFF
--- a/sources/Load.php
+++ b/sources/Load.php
@@ -1771,6 +1771,10 @@ function loadTemplate($template_name, $style_sheets = array(), $fatal = true)
 		loadCSSFile($sheets);
 	}
 
+	// Load a custom CSS file?
+	if (!empty($context['theme_variant']) && file_exists($settings['theme_dir'] . '/css/' . $context['theme_variant'] . '/custom' . $context['theme_variant'] . '.css'))
+		 loadCSSFile($context['theme_variant'] . '/custom' . $context['theme_variant'] . '.css');
+
 	// No template to load?
 	if ($template_name === false)
 		return true;


### PR DESCRIPTION
Need this for a customer (wanna use b2 + custom styling) and I'm too lazy for using diff patches against our standard CSS files..

idea: a user should be able to add thier own CSS declarations without modifying one of our files (makes an upgrade much easier)
Eman suggested a db base solution, however I think this is by far the easiest solution as it works per variant (that's a bit complicated if we place the custom css in the database)

Not sure if we should make it optional via $modSettings['load_custom_css']
could prevent an additional file_exists for those who don't use that "feature".
