### PR TITLE
Template call

### DIFF
--- a/sources/Load.php
+++ b/sources/Load.php
@@ -1793,7 +1793,7 @@ function loadTemplate($template_name, $style_sheets = array(), $fatal = true)
 
 		// If they have specified an initialization function for this template, go ahead and call it now.
 		if (function_exists('template_' . $template_name . '_init'))
-			call_user_func('template_' . $template_name . '_init');
+			template_call('template_' . $template_name . '_init');
 	}
 	// Hmmm... doesn't exist?!  I don't suppose the directory is wrong, is it?
 	elseif (!file_exists($settings['default_theme_dir']) && file_exists(BOARDDIR . '/themes/default'))
@@ -1844,7 +1844,9 @@ function loadSubTemplate($sub_template_name, $fatal = false)
 	$theme_function = 'template_' . $sub_template_name;
 
 	if (function_exists($theme_function))
-		$theme_function();
+	{
+		template_call($theme_function);
+	}
 	elseif ($fatal === false)
 		fatal_lang_error('theme_template_error', 'template', array((string) $sub_template_name));
 	elseif ($fatal !== 'ignore')

--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -4188,3 +4188,35 @@ function removeScheduleTaskImmediate($task, $calculateNextTrigger = true)
 		}
 	}
 }
+
+/**
+ * Call a template
+ * Should always be used to allow events
+ * 
+ * @param string $name
+ */
+function template_call($name)
+{
+	$args = func_get_args();
+	$name = array_shift($args);
+
+	if (empty($name))
+	{
+		throw new InvalidArgumentException('$name cannot be empty');
+	}
+
+	$return = null;
+	$hook = 'integrate_' . $name;
+
+	call_integration_hook($hook . '__pre', $args);
+
+	$do_execute = call_integration_hook($hook . '__execute', $args);
+	if (empty($do_execute))
+	{
+		$return = call_user_func_array($name, $args);
+	}
+
+	call_integration_hook($hook . '__post', $args);
+
+	return $return;
+}

--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -4205,7 +4205,6 @@ function template_call($name)
 		throw new InvalidArgumentException('$name cannot be empty');
 	}
 
-	$return = null;
 	$hook = 'integrate_' . $name;
 
 	call_integration_hook($hook . '__pre', $args);
@@ -4213,10 +4212,8 @@ function template_call($name)
 	$do_execute = call_integration_hook($hook . '__execute', $args);
 	if (empty($do_execute))
 	{
-		$return = call_user_func_array($name, $args);
+		call_user_func_array($name, $args);
 	}
 
 	call_integration_hook($hook . '__post', $args);
-
-	return $return;
 }

--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -4192,17 +4192,18 @@ function removeScheduleTaskImmediate($task, $calculateNextTrigger = true)
 /**
  * Call a template
  * Should always be used to allow events
+ * This does not check if the function is callable. It will error if it isn't callable
  * 
- * @param string $name
+ * @throws \InvalidArgumentException if the first parameter is empty()
  */
-function template_call($name)
+function template_call()
 {
 	$args = func_get_args();
 	$name = array_shift($args);
 
-	if (empty($name))
+	if (empty($name) || !is_string($name))
 	{
-		throw new InvalidArgumentException('$name cannot be empty');
+		throw new \InvalidArgumentException('$name cannot be empty');
 	}
 
 	$hook = 'integrate_' . $name;

--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -4209,7 +4209,7 @@ function template_call($name)
 
 	call_integration_hook($hook . '__pre', $args);
 
-	$skip_execute = true;
+	$skip_execute = false;
 
 	$execute_result = call_integration_hook($hook . '__execute', $args);
 	foreach ($execute_result as $hook_result)

--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -4209,8 +4209,20 @@ function template_call($name)
 
 	call_integration_hook($hook . '__pre', $args);
 
-	$do_execute = call_integration_hook($hook . '__execute', $args);
-	if (empty($do_execute))
+	$skip_execute = true;
+
+	$execute_result = call_integration_hook($hook . '__execute', $args);
+	foreach ($execute_result as $hook_result)
+	{
+		if (!empty($hook_result))
+		{
+			$skip_execute = true;
+			break;
+		}
+					
+	}
+
+	if (empty($skip_execute))
 	{
 		call_user_func_array($name, $args);
 	}

--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -2447,7 +2447,7 @@ function obExit($header = null, $do_footer = null, $from_index = false, $from_fa
 			}
 
 		// Display the screen in the logical order.
-		template_header();
+		template_call('template_header');
 		$header_done = true;
 	}
 
@@ -2460,7 +2460,7 @@ function obExit($header = null, $do_footer = null, $from_index = false, $from_fa
 		if (!$footer_done)
 		{
 			$footer_done = true;
-			template_footer();
+			template_call('template_footer');
 
 			// (since this is just debugging... it's okay that it's after </html>.)
 			if (!isset($_REQUEST['xml']))

--- a/themes/default/Admin.template.php
+++ b/themes/default/Admin.template.php
@@ -897,7 +897,7 @@ function template_show_settings()
 		if (is_array($config_var) && $config_var['type'] == 'callback')
 		{
 			if (function_exists('template_callback_' . $config_var['name']))
-				call_user_func('template_callback_' . $config_var['name']);
+				template_call('template_callback_' . $config_var['name']);
 
 			continue;
 		}

--- a/themes/default/BadBehavior.template.php
+++ b/themes/default/BadBehavior.template.php
@@ -24,7 +24,11 @@ function template_badbehavior_log()
 			<h3 class="category_header">
 				<a class="hdicon cat_img_helptopics help" href="', $scripturl, '?action=quickhelp;help=badbehaviorlog" onclick="return reqOverlayDiv(this.href);" title="', $txt['help'], '"></a> ', $txt['badbehaviorlog_log'], '
 			</h3>
-			', template_pagesection(), '
+			';
+
+	template_call('template_pagesection');
+
+	echo '
 			<table class="table_grid" id="error_log">';
 
 	if ($context['has_filter'])
@@ -105,7 +109,7 @@ function template_badbehavior_log()
 			<div class="flow_auto">
 				<div class="floatleft">';
 
-	template_pagesection();
+	template_call('template_pagesection');
 
 	echo '
 				</div>

--- a/themes/default/BoardIndex.template.php
+++ b/themes/default/BoardIndex.template.php
@@ -57,7 +57,7 @@ function template_boards_list()
 
 		// Assuming the category hasn't been collapsed...
 		if (!$category['is_collapsed'])
-			template_list_boards($category['boards'], 'category_' . $category['id'] . '_boards');
+			template_call('template_list_boards', $category['boards'], 'category_' . $category['id'] . '_boards');
 
 		echo '
 		</div>';
@@ -94,8 +94,12 @@ function template_boardindex_outer_below()
 
 	// Show the mark all as read button?
 	if ($settings['show_mark_read'] && !$context['user']['is_guest'] && !empty($context['categories']))
+	{
 		echo '
-			', template_button_strip($context['mark_read_button'], 'right');
+			';
+
+		template_call('template_button_strip', $context['mark_read_button'], 'right');
+	}
 
 	if ($context['user']['is_logged'])
 		echo '
@@ -107,7 +111,7 @@ function template_boardindex_outer_below()
 		</div>';
 
 	if (!empty($context['info_center_callbacks']))
-		template_info_center();
+		template_call('template_info_center');
 }
 
 /**
@@ -132,7 +136,7 @@ function template_info_center()
 	{
 		$func = 'template_ic_' . $callback;
 		if (function_exists($func))
-			$func();
+			template_call($func);
 	}
 
 	echo '

--- a/themes/default/Calendar.template.php
+++ b/themes/default/Calendar.template.php
@@ -33,18 +33,25 @@ function template_show_calendar()
 	echo '
 		<div id="calendar">
 			<div id="month_grid">
-				', template_show_month_grid('prev'), '
-				', template_show_month_grid('current'), '
-				', template_show_month_grid('next'), '
+				';
+	template_call('template_show_month_grid', 'prev');
+	echo '
+				';
+	template_call('template_show_month_grid', 'current');
+	echo '
+				';
+	template_call('template_show_month_grid', 'next');
+	echo '
 			</div>
 			<div id="main_grid">
-				', $context['view_week'] ? template_show_week_grid('main') : template_show_month_grid('main');
+				';
+	$context['view_week'] ? template_call('template_show_week_grid', 'main') : template_call('template_show_month_grid', 'main');
 
 	// Show some controls to allow easy calendar navigation.
 	echo '
 				<form id="calendar_navigation" action="', $scripturl, '?action=calendar" method="post" accept-charset="UTF-8">';
 
-	template_button_strip($context['calendar_buttons'], 'right');
+	template_call('template_button_strip', $context['calendar_buttons'], 'right');
 
 	echo '
 					<div class="styled-select">
@@ -183,7 +190,9 @@ function template_unlinked_event_post()
 							<input type="checkbox" class="input_check" id="link_to_board" name="link_to_board" checked="checked" onclick="toggleLinked(this.form);" />
 						</li>
 						<li>
-							', template_select_boards('board', $txt['calendar_post_in'], 'onchange="this.form.submit();"'), '
+							';
+		template_call('template_select_boards', 'board', $txt['calendar_post_in'], 'onchange="this.form.submit();"');
+		echo '
 						</li>';
 	}
 

--- a/themes/default/Display.template.php
+++ b/themes/default/Display.template.php
@@ -128,13 +128,24 @@ function template_messages()
 
 		// Showing the sidebar posting area?
 		if (empty($options['hide_poster_area']))
+		{
 			echo '
-					<ul class="poster">', template_build_poster_div($message, $ignoring), '</ul>';
+					<ul class="poster">';
+			template_call('template_build_poster_div', $message, $ignoring);
+			echo '</ul>';
+		}
 
 		echo '
 					<div class="postarea', empty($options['hide_poster_area']) ? '' : '2', '">
 						<div class="keyinfo">
-						', (!empty($options['hide_poster_area']) ? '<ul class="poster poster2">' . template_build_poster_div($message, $ignoring) . '</ul>' : '');
+						';
+
+		if (!empty($options['hide_poster_area']))
+		{
+			echo '<ul class="poster poster2">';
+			template_call('template_build_poster_div', $message, $ignoring);
+			echo '</ul>';
+		}
 
 		if (!empty($context['follow_ups'][$message['id']]))
 		{
@@ -185,7 +196,7 @@ function template_messages()
 
 		// Assuming there are attachments...
 		if (!empty($message['attachment']))
-			template_display_attachments($message, $ignoring);
+			template_call('template_display_attachments', $message, $ignoring);
 
 		// Show the quickbuttons, for various operations on posts.
 		echo '
@@ -407,8 +418,10 @@ function template_quickreply_below()
 
 		// Is visual verification enabled?
 		if ($context['require_verification'])
-			template_control_verification($context['visual_verification_id'], '
+		{
+			template_call('template_control_verification', $context['visual_verification_id'], '
 							<strong>' . $txt['verification'] . ':</strong>', '<br />');
+		}
 
 		// Using the full editor or a plain text box?
 		if (empty($options['use_editor_quick_reply']))
@@ -431,7 +444,8 @@ function template_quickreply_below()
 							<div id="smileyBox_message"></div>';
 
 			echo '
-							', template_control_richedit($context['post_box_name'], 'smileyBox_message', 'bbcBox_message');
+							';
+			template_call('template_control_richedit', $context['post_box_name'], 'smileyBox_message', 'bbcBox_message');
 		}
 
 		echo '
@@ -715,7 +729,7 @@ function template_display_poll_above()
 			</div>
 			<div id="pollmoderation">';
 
-	template_button_strip($context['poll_buttons']);
+	template_call('template_button_strip', $context['poll_buttons']);
 
 	echo '
 			</div>';
@@ -760,7 +774,7 @@ function template_pages_and_buttons_above()
 			<a id="msg', $context['first_message'], '"></a>', $context['first_new_message'] ? '<a name="new" id="new"></a>' : '';
 
 	// Show the page index... "Pages: [1]".
-	template_pagesection('normal_buttons', 'right');
+	template_call('template_pagesection', 'normal_buttons', 'right');
 }
 
 /**
@@ -771,10 +785,10 @@ function template_pages_and_buttons_below()
 	global $context;
 
 	// Show the page index... "Pages: [1]".
-	template_pagesection('normal_buttons', 'right');
+	template_call('template_pagesection', 'normal_buttons', 'right');
 
 	// Show the lower breadcrumbs.
-	theme_linktree();
+	template_call('theme_linktree');
 
 	echo '
 			<div id="moderationbuttons">', template_button_strip($context['mod_buttons'], 'bottom', array('id' => 'moderationbuttons_strip')), '</div>';

--- a/themes/default/Emailuser.template.php
+++ b/themes/default/Emailuser.template.php
@@ -36,7 +36,7 @@ function template_send_topic()
 {
 	global $context, $settings, $txt, $scripturl;
 
-	template_show_error('sendtopic_error');
+	template_call('template_show_error', 'sendtopic_error');
 
 	echo '
 	<div id="send_topic">
@@ -101,7 +101,7 @@ function template_custom_email()
 {
 	global $context, $settings, $txt, $scripturl;
 
-	template_show_error('sendemail_error');
+	template_call('template_show_error', 'sendtopic_error');
 
 	echo '
 	<div id="send_topic">
@@ -212,7 +212,7 @@ function template_report()
 				<div class="windowbg">
 					<div class="content">';
 
-	template_show_error('report_error');
+	template_call('template_show_error', 'report_error');
 
 	echo '
 						<p class="warningbox">', $txt['report_to_mod_func'], '</p>
@@ -240,7 +240,7 @@ function template_report()
 
 	if ($context['require_verification'])
 	{
-		template_control_verification($context['visual_verification_id'], '
+		template_call('template_control_verification', $context['visual_verification_id'], '
 							<dt>
 								' . $txt['verification'] . ':
 							</dt>

--- a/themes/default/Errors.template.php
+++ b/themes/default/Errors.template.php
@@ -53,7 +53,7 @@ function template_error_log()
 			<div class="flow_auto">
 				<div class="floatleft">';
 
-	template_pagesection();
+	template_call('template_pagesection');
 
 	echo '
 				</div>
@@ -166,7 +166,7 @@ function template_error_log()
 			<div class="flow_auto">
 				<div class="floatleft">';
 
-	template_pagesection();
+	template_call('template_pagesection');
 
 	echo '
 				</div>
@@ -235,7 +235,7 @@ function template_attachment_errors()
 		<div class="windowbg">';
 
 	foreach ($context['attachment_error_keys'] as $key)
-		template_show_error($key);
+		template_call('template_show_error', $key);
 
 	echo '
 		</div>

--- a/themes/default/GenericList.template.php
+++ b/themes/default/GenericList.template.php
@@ -47,7 +47,7 @@ function template_show_list($list_id = null)
 		echo '
 			<div class="information flow_hidden">';
 
-		template_additional_rows('after_title', $cur_list);
+		template_call('template_additional_rows', 'after_title', $cur_list);
 
 		echo '
 			</div>';
@@ -55,14 +55,16 @@ function template_show_list($list_id = null)
 
 	// Show some data above this list
 	if (isset($cur_list['additional_rows']['top_of_list']))
-		template_additional_rows('top_of_list', $cur_list);
+		template_call('template_additional_rows', 'top_of_list', $cur_list);
 
 	$close_div = false;
 	if (isset($cur_list['additional_rows']['above_column_headers']))
 	{
 		$close_div = true;
 		echo '
-			<div class="flow_auto">', template_additional_rows('above_column_headers', $cur_list);
+			<div class="flow_auto">';
+		
+		template_call('template_additional_rows', 'above_column_headers', $cur_list);
 	}
 
 	// These are the main tabs that is used all around the template.
@@ -74,7 +76,7 @@ function template_show_list($list_id = null)
 
 		$close_div = true;
 
-		template_create_list_menu($cur_list['list_menu']);
+		template_call('template_create_list_menu', $cur_list['list_menu']);
 	}
 
 		// Show the page index (if this list doesn't intend to show all items). @todo - Needs old top/bottom stuff cleaned up.
@@ -85,7 +87,9 @@ function template_show_list($list_id = null)
 			<div class="flow_auto">';
 
 		echo '
-				<div class="floatleft">', template_pagesection(false, false, array('page_index_markup' => $cur_list['page_index'])), '
+				<div class="floatleft">';
+		template_call('template_pagesection', false, false, array('page_index_markup' => $cur_list['page_index']));
+		echo '
 				</div>';
 		$close_div = true;
 	}
@@ -166,24 +170,25 @@ function template_show_list($list_id = null)
 		// Show the page index (if this list doesn't intend to show all items).
 		if (!empty($cur_list['items_per_page']) && !empty($cur_list['page_index']))
 			echo '
-				<div class="floatleft">',
-			template_pagesection(false, false, array('page_index_markup' => $cur_list['page_index'])), '
+				<div class="floatleft">';
+			template_call('template_pagesection', false, false, array('page_index_markup' => $cur_list['page_index']));
+			echo '
 				</div>';
 
 		if (isset($cur_list['additional_rows']['below_table_data']))
-			template_additional_rows('below_table_data', $cur_list);
+			template_call('template_additional_rows', 'below_table_data', $cur_list);
 	}
 
 	// Tabs at the bottom.  Usually bottom aligned.
 	if (isset($cur_list['list_menu'], $cur_list['list_menu']['show_on']) && ($cur_list['list_menu']['show_on'] == 'both' || $cur_list['list_menu']['show_on'] == 'bottom'))
-		template_create_list_menu($cur_list['list_menu']);
+		template_call('template_create_list_menu', $cur_list['list_menu']);
 
 	echo '
 			</div>';
 
 	// Last chance to show more data, like buttons and links
 	if (isset($cur_list['additional_rows']['bottom_of_list']))
-		template_additional_rows('bottom_of_list', $cur_list);
+		template_call('template_additional_rows', 'bottom_of_list', $cur_list);
 
 	if (isset($cur_list['form']))
 	{

--- a/themes/default/GenericMenu.template.php
+++ b/themes/default/GenericMenu.template.php
@@ -100,7 +100,7 @@ function template_generic_menu_sidebar_above()
 
 	// If there are any "tabs" setup, this is the place to shown them.
 	if (empty($context['force_disable_tabs']))
-		template('template_generic_menu_tabs', $menu_context);
+		template_generic_menu_tabs($menu_context);
 }
 
 /**
@@ -193,7 +193,7 @@ function template_generic_menu_dropdown_above()
 				<div id="admin_content">';
 
 	// It's possible that some pages have their own tabs they wanna force...
-	template('template_generic_menu_tabs', $menu_context);
+	template_generic_menu_tabs($menu_context);
 }
 
 /**

--- a/themes/default/GenericMenu.template.php
+++ b/themes/default/GenericMenu.template.php
@@ -100,7 +100,7 @@ function template_generic_menu_sidebar_above()
 
 	// If there are any "tabs" setup, this is the place to shown them.
 	if (empty($context['force_disable_tabs']))
-		template_generic_menu_tabs($menu_context);
+		template('template_generic_menu_tabs', $menu_context);
 }
 
 /**
@@ -193,7 +193,7 @@ function template_generic_menu_dropdown_above()
 				<div id="admin_content">';
 
 	// It's possible that some pages have their own tabs they wanna force...
-	template_generic_menu_tabs($menu_context);
+	template('template_generic_menu_tabs', $menu_context);
 }
 
 /**
@@ -303,7 +303,7 @@ function template_generic_menu_tabs(&$menu_context)
 		// The function is in Admin.template.php, but since this template is used elsewhere,
 		// we need to check if the function is available.
 		if (function_exists('template_admin_quick_search'))
-			template_admin_quick_search();
+			template_call('template_admin_quick_search');
 		echo '
 					</div>';
 	}

--- a/themes/default/Maintenance.template.php
+++ b/themes/default/Maintenance.template.php
@@ -175,7 +175,7 @@ function template_maintain_members()
 	<div id="manage_maintenance">';
 
 	// If maintenance has finished tell the user.
-	template_show_error('maintenance_finished');
+	template_call('template_show_error', 'maintenance_finished');
 
 	echo '
 		<h3 class="category_header">', $txt['maintain_reattribute_posts'], '</h3>
@@ -286,7 +286,7 @@ function template_maintain_topics()
 	global $scripturl, $txt, $context, $settings, $modSettings;
 
 	// If maintenance has finished tell the user.
-	template_show_error('maintenance_finished');
+	template_call('template_show_error', 'maintenance_finished');
 
 	// Bit of javascript for showing which boards to prune in an otherwise hidden list.
 	echo '
@@ -384,8 +384,8 @@ function template_maintain_topics()
 				<form action="', $scripturl, '?action=admin;area=maintain;sa=topics;activity=massmove" method="post" accept-charset="UTF-8">
 					<p>';
 
-	template_select_boards('id_board_from', $txt['move_topics_from']);
-	template_select_boards('id_board_to', $txt['move_topics_to']);
+	template_call('template_select_boards', 'id_board_from', $txt['move_topics_from']);
+	template_call('template_select_boards', 'id_board_to', $txt['move_topics_to']);
 
 	echo '
 					</p>

--- a/themes/default/ManageAttachments.template.php
+++ b/themes/default/ManageAttachments.template.php
@@ -267,7 +267,7 @@ function template_attach_paths()
 	global $modSettings;
 
 	if (!empty($modSettings['attachment_basedirectories']))
-		template_show_list('base_paths');
+		template_call('template_show_list', 'base_paths');
 
-	template_show_list('attach_paths');
+	template_call('template_show_list', 'attach_paths');
 }

--- a/themes/default/ManageBans.template.php
+++ b/themes/default/ManageBans.template.php
@@ -34,7 +34,7 @@ function template_ban_edit()
 			<div class="information">', $txt['ban_add_notes'], '</div>';
 
 	// If there were errors creating the ban, show them.
-	template_show_error('ban_errors');
+	template_call('template_show_error', 'ban_errors');
 
 	echo '
 			<div class="content">
@@ -178,7 +178,7 @@ function template_ban_edit()
 		echo '
 		<br />';
 
-		template_show_list('ban_items');
+		template_call('template_show_list', 'ban_items');
 	}
 
 	echo '

--- a/themes/default/ManageFeatures.template.php
+++ b/themes/default/ManageFeatures.template.php
@@ -21,7 +21,7 @@
 function template_show_custom_profile()
 {
 	// Standard fields.
-	template_show_list('standard_profile_fields');
+	template_call('template_show_list', 'standard_profile_fields');
 
 	// Disable the show on registration box if the profile field is not active
 	echo '
@@ -36,7 +36,7 @@ function template_show_custom_profile()
 	// ]]></script>';
 
 	// Custom fields.
-	template_show_list('custom_profile_fields');
+	template_call('template_show_list', 'custom_profile_fields');
 }
 
 /**

--- a/themes/default/ManageLanguages.template.php
+++ b/themes/default/ManageLanguages.template.php
@@ -61,7 +61,7 @@ function template_download_language()
 			</div>';
 
 	// Show the main files.
-	template_show_list('lang_main_files_list');
+	template_call('template_show_list', 'lang_main_files_list');
 
 	// Now, all the images and the likes, hidden via javascript 'cause there are so fecking many.
 	echo '
@@ -405,7 +405,7 @@ function template_add_language()
 		echo '
 			<div class="information">', $txt['add_language_elk_found'], '</div>';
 
-		template_show_list('languages');
+		template_call('template_show_list', 'languages');
 	}
 
 	echo '

--- a/themes/default/ManageMail.template.php
+++ b/themes/default/ManageMail.template.php
@@ -38,7 +38,7 @@ function template_mail_queue()
 			</div>
 		</div>';
 
-	template_show_list('mail_queue');
+	template_call('template_show_list', 'mail_queue');
 
 	echo '
 	</div>';

--- a/themes/default/ManageMembergroups.template.php
+++ b/themes/default/ManageMembergroups.template.php
@@ -20,11 +20,11 @@
  */
 function template_regular_membergroups_list()
 {
-	template_show_list('regular_membergroups_list');
+	template_call('template_show_list', 'regular_membergroups_list');
 
 	echo '<br /><br />';
 
-	template_show_list('post_count_membergroups_list');
+	template_call('template_show_list', 'post_count_membergroups_list');
 }
 
 /**
@@ -141,7 +141,7 @@ function template_new_group()
 						</dt>
 						<dd>';
 
-	template_add_edit_group_boards_list('new_group', false);
+	template_call('template_add_edit_group_boards_list', 'new_group', false);
 
 	echo '
 						</dd>
@@ -332,7 +332,7 @@ function template_edit_group()
 					</dt>
 					<dd>';
 
-		template_add_edit_group_boards_list('groupForm', true);
+		template_call('template_add_edit_group_boards_list', 'groupForm', true);
 
 		echo '
 					</dd>';
@@ -565,7 +565,9 @@ function template_group_members()
 				</div>
 			</div>
 			<h3 class="category_header">', $txt['membergroups_members_group_members'], '</h3>
-			', template_pagesection(), '
+			';
+	template_call('template_pagesection');
+	echo '
 			<table class="table_grid">
 				<thead>
 					<tr class="table_head">
@@ -650,7 +652,7 @@ function template_group_members()
 			<div class="flow_auto">
 				<div class="floatleft">';
 
-	template_pagesection();
+	template_call('template_pagesection');
 
 	echo '
 				</div>

--- a/themes/default/ManageMembers.template.php
+++ b/themes/default/ManageMembers.template.php
@@ -256,7 +256,7 @@ function template_admin_browse()
 	echo '
 	<div id="admincenter">';
 
-	template_show_list('approve_list');
+	template_call('template_show_list', 'approve_list');
 
 	// If we have lots of outstanding members try and make the admin's life easier.
 	if ($context['approve_list']['total_num_items'] > 10)

--- a/themes/default/ManageNews.template.php
+++ b/themes/default/ManageNews.template.php
@@ -52,7 +52,7 @@ function template_email_members()
 						</dt>
 						<dd>';
 
-	template_list_groups_collapsible('groups');
+	template_call('template_list_groups_collapsible', 'groups');
 
 	echo '
 						</dd>
@@ -101,7 +101,7 @@ function template_email_members()
 						</dt>
 						<dd>';
 
-	template_list_groups_collapsible('exclude_groups');
+	template_call('template_list_groups_collapsible', 'exclude_groups');
 
 	echo '
 						<dt>
@@ -252,7 +252,8 @@ function template_email_members_compose()
 
 	// Show BBC buttons, smileys and textbox.
 	echo '
-					', template_control_richedit($context['post_box_name'], 'smileyBox_message', 'bbcBox_message');
+					';
+	template_call('template_control_richedit', $context['post_box_name'], 'smileyBox_message', 'bbcBox_message');
 
 	echo '
 					<ul>
@@ -261,7 +262,9 @@ function template_email_members_compose()
 						<li><label for="parse_html"><input type="checkbox" name="parse_html" id="parse_html" checked="checked" disabled="disabled" class="input_check" /> ', $txt['email_parsed_html'], '</label></li>
 					</ul>
 					<div class="submitbutton">
-						', template_control_richedit_buttons($context['post_box_name']), '
+						';
+	template_call('template_control_richedit_buttons', $context['post_box_name']);
+	echo '
 					</div>
 				</div>
 				<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />

--- a/themes/default/ManagePermissions.template.php
+++ b/themes/default/ManagePermissions.template.php
@@ -40,10 +40,10 @@ function template_permission_index()
 		echo '
 			<h3 class="category_header">', $txt['permissions_title'], '</h3>';
 
-	template_show_list('regular_membergroups_list');
+	template_call('template_show_list', 'regular_membergroups_list');
 
 	if (!empty($context['post_count_membergroups_list']))
-		template_show_list('post_count_membergroups_list');
+		template_call('template_show_list', 'post_count_membergroups_list');
 
 	echo '
 			<br />';
@@ -484,7 +484,7 @@ function template_modify_group()
 			<div class="flow_hidden">';
 
 	// Draw out the main bits.
-	template_modify_group_classic($context['permission_type']);
+	template_call('template_modify_group_classic', $context['permission_type']);
 
 	echo '
 			</div>';
@@ -500,7 +500,7 @@ function template_modify_group()
 			</div>
 			<div class="flow_hidden">';
 
-		template_modify_group_classic('board');
+		template_call('template_modify_group_classic', 'board');
 
 		echo '
 			</div>';

--- a/themes/default/ManageScheduledTasks.template.php
+++ b/themes/default/ManageScheduledTasks.template.php
@@ -52,7 +52,7 @@ function template_view_scheduled_tasks()
 		}
 	}
 
-	template_show_list('scheduled_tasks');
+	template_call('template_show_list', 'scheduled_tasks');
 }
 
 /**

--- a/themes/default/ManageSearch.template.php
+++ b/themes/default/ManageSearch.template.php
@@ -384,7 +384,7 @@ function template_show_spider_logs()
 	<div id="admincenter">';
 
 	// Standard fields.
-	template_show_list('spider_logs');
+	template_call('template_show_list', 'spider_logs');
 
 	echo '
 		<form id="admin_form_wrapper" action="', $scripturl, '?action=admin;area=sengines;sa=logs" method="post" accept-charset="UTF-8">
@@ -414,7 +414,7 @@ function template_show_spider_stats()
 	<div id="admincenter">';
 
 	// Standard fields.
-	template_show_list('spider_stat_list');
+	template_call('template_show_list', 'spider_stat_list');
 
 	echo '
 		<form id="admin_form_wrapper" action="', $scripturl, '?action=admin;area=sengines;sa=stats" method="post" accept-charset="UTF-8">

--- a/themes/default/ManageSmileys.template.php
+++ b/themes/default/ManageSmileys.template.php
@@ -31,7 +31,7 @@ function template_editsets()
 	echo '
 	<div id="admincenter">';
 
-		template_show_list('smiley_set_list');
+		template_call('template_show_list', 'smiley_set_list');
 
 	echo '
 	</div>';
@@ -501,7 +501,9 @@ function template_editicon()
 						<dt>
 							<strong><label for="icon_board_select">', $txt['icons_board'], '</label>: </strong>
 						</dt>
-						<dd>', template_select_boards('icon_board', '', '', true), '
+						<dd>';
+	template_call('template_select_boards', 'icon_board', '', '', true);
+	echo '
 						</dd>
 						<dt>
 							<strong><label for="icon_location">', $txt['smileys_location'], '</label>: </strong>

--- a/themes/default/Memberlist.template.php
+++ b/themes/default/Memberlist.template.php
@@ -44,7 +44,7 @@ function template_mlsearch_above()
 		</ul>
 	</form>';
 
-	template_pagesection('memberlist_buttons', 'right', array('extra' => $extra));
+	template_call('template_pagesection', 'memberlist_buttons', 'right', array('extra' => $extra));
 
 	echo '
 	<script><!-- // --><![CDATA[
@@ -182,7 +182,7 @@ function template_mlsearch_below()
 		$extra = '';
 
 	// Show the page numbers again. (makes 'em easier to find!)
-	template_pagesection(false, false, array('extra' => $extra));
+	template_call('template_pagesection', false, false, array('extra' => $extra));
 
 	echo '
 	</div>';

--- a/themes/default/MergeTopics.template.php
+++ b/themes/default/MergeTopics.template.php
@@ -110,7 +110,9 @@ function template_merge()
 				</div>
 			</div><br />
 			<h3 class="category_header">', $txt['target_topic'], '</h3>
-			', template_pagesection(), '
+			';
+	template_call('template_pagesection');
+	echo '
 			<div class="windowbg2">
 				<div class="content">
 					<ul class="merge_topics">';
@@ -125,7 +127,9 @@ function template_merge()
 	echo '
 					</ul>
 				</div>
-			</div>', template_pagesection(), '
+			</div>';
+	template_call('template_pagesection');
+	echo '
 		</div>';
 }
 

--- a/themes/default/MessageIndex.template.php
+++ b/themes/default/MessageIndex.template.php
@@ -36,7 +36,7 @@ function template_display_child_boards_above()
 			', $txt['parent_boards'], '
 		</h2>';
 
-	template_list_boards($context['boards'], 'board_' . $context['current_board'] . '_children');
+	template_call('template_list_boards', $context['boards'], 'board_' . $context['current_board'] . '_children');
 
 	echo '
 	</div>';
@@ -55,7 +55,7 @@ function template_topic_listing_above()
 	if ($context['no_topic_listing'])
 		return;
 
-	template_pagesection('normal_buttons', 'right');
+	template_call('template_pagesection', 'normal_buttons', 'right');
 
 	if (!empty($context['description']) || !empty($context['moderators']))
 	{

--- a/themes/default/ModerationCenter.template.php
+++ b/themes/default/ModerationCenter.template.php
@@ -36,7 +36,12 @@ function template_moderation_center()
 		$block_function = 'template_' . $block;
 
 		echo '
-							<div class="modblock_', $alternate ? 'left' : 'right', '">', function_exists($block_function) ? $block_function() : '', '</div>';
+							<div class="modblock_', $alternate ? 'left' : 'right', '">';
+
+		if (function_exists($block_function))
+			template_call($block_function);
+
+		echo '</div>';
 
 		$alternate = !$alternate;
 	}
@@ -278,7 +283,7 @@ function template_reported_posts()
 						</h3>';
 
 	if (!empty($context['reports']))
-		template_pagesection();
+		template_call('template_pagesection');
 
 	$alternate = 0;
 	foreach ($context['reports'] as $report)
@@ -332,7 +337,7 @@ function template_reported_posts()
 							</div>
 						</div>';
 	else
-		template_pagesection(false, false, array('extra' => !$context['view_closed'] ? '<input type="submit" name="close_selected" value="' . $txt['mc_reportedp_close_selected'] . '" class="right_submit" />' : ''));
+		template_call('template_pagesection', false, false, array('extra' => !$context['view_closed'] ? '<input type="submit" name="close_selected" value="' . $txt['mc_reportedp_close_selected'] . '" class="right_submit" />' : ''));
 
 	echo '
 						<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
@@ -347,7 +352,7 @@ function template_unapproved_posts()
 {
 	global $options, $context, $txt, $scripturl;
 
-	template_pagesection();
+	template_call('template_pagesection');
 
 	// Just a big div of it all really...
 	echo '
@@ -426,7 +431,7 @@ function template_unapproved_posts()
 						</noscript>
 					</div>';
 
-	template_pagesection(false, false, array('extra' => $quick_mod));
+	template_call('template_pagesection', false, false, array('extra' => $quick_mod));
 
 	echo '
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
@@ -492,7 +497,7 @@ function template_viewmodreport()
 								</div>
 							</div>';
 
-	template_show_list('moderation_actions_list');
+	template_call('template_show_list', 'moderation_actions_list');
 
 	echo '
 							<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />

--- a/themes/default/MoveTopic.template.php
+++ b/themes/default/MoveTopic.template.php
@@ -41,7 +41,9 @@ function template_move_topic()
 							<dt>
 								<strong>', $txt['move_to'], ':</strong>
 							</dt>
-							<dd>', template_select_boards('toboard'), '
+							<dd>';
+	template_call('template_select_boards', 'toboard');
+	echo '
 							</dd>';
 
 	// Disable the reason textarea when the postRedirect checkbox is unchecked...

--- a/themes/default/PackageServers.template.php
+++ b/themes/default/PackageServers.template.php
@@ -33,7 +33,7 @@ function template_servers()
 		<h2 class="category_header">', $txt['package_servers'], '</h2>';
 
 	if ($context['package_download_broken'])
-		template_ftp_required();
+		template_call('template_ftp_required');
 
 	echo '
 		<div class="windowbg2">
@@ -345,7 +345,7 @@ function template_upload()
 
 	if ($context['package_download_broken'])
 	{
-		template_ftp_required();
+		template_call('template_ftp_required');
 
 		echo '
 			<h3 class="category_header">' . $txt['package_upload_title'] . '</h3>';

--- a/themes/default/Packages.template.php
+++ b/themes/default/Packages.template.php
@@ -330,7 +330,9 @@ function template_view_package()
 			<h3 class="category_header">', $txt['package_ftp_necessary'], '</h3>
 
 			<div>
-				', template_control_chmod(), '
+				';
+		template_call('template_control_chmod');
+		echo '
 			</div>';
 	}
 
@@ -467,7 +469,7 @@ function template_extract_package()
 	if (function_exists('template_show_list') && !empty($context['restore_file_permissions']['rows']))
 	{
 		echo '<br />';
-		template_show_list('restore_file_permissions');
+		template_call('template_show_list', 'restore_file_permissions');
 	}
 
 	echo '
@@ -537,7 +539,7 @@ function template_browse()
 	{
 		if (!empty($context['available_' . $type]))
 		{
-			template_show_list('packages_lists_' . $type);
+			template_call('template_show_list', 'packages_lists_' . $type);
 			$adds_available = true;
 		}
 	}
@@ -786,7 +788,9 @@ function template_ftp_required()
 				', $txt['package_ftp_necessary'], '
 			</legend>
 			<div class="ftp_details">
-				', template_control_chmod(), '
+				';
+		template_call('template_control_chmod');
+		echo '
 			</div>
 		</fieldset>';
 }
@@ -1130,7 +1134,9 @@ function template_file_permissions()
 				<p>
 					', $txt['package_file_perms_ftp_details'], ':
 				</p>
-				', template_control_chmod(), '
+				';
+		template_call('template_control_chmod');
+		echo '
 				<div class="information">', $txt['package_file_perms_ftp_retain'], '</div>';
 
 	echo '
@@ -1206,7 +1212,7 @@ function template_permission_show_contents($ident, $contents, $level, $has_more 
 				<tr id="insert_div_loc_' . $cur_ident . '" style="display: none;"><td colspan="7"></td></tr>';
 
 			if (!empty($dir['contents']))
-				template_permission_show_contents($ident . '/' . $name, $dir['contents'], $level + 1, !empty($dir['more_files']));
+				template_call('template_permission_show_contents', $ident . '/' . $name, $dir['contents'], $level + 1, !empty($dir['more_files']));
 		}
 	}
 

--- a/themes/default/PersonalMessage.template.php
+++ b/themes/default/PersonalMessage.template.php
@@ -111,13 +111,17 @@ function template_folder()
 
 			// Showing the sidebar posting area?
 			if (empty($options['hide_poster_area']))
+			{
 				echo '
-							<ul class="poster">', template_build_poster_div($message), '</ul>';
+							<ul class="poster">';
+				template_call('template_build_poster_div', $message);
+				echo '</ul>';
+			}
 
 			echo '
 							<div class="postarea', empty($options['hide_poster_area']) ? '' : '2', '">
 								<div class="keyinfo">
-									', (!empty($options['hide_poster_area']) ? '<ul class="poster poster2">' . template_build_poster_div($message) . '</ul>' : ''), '
+									', (!empty($options['hide_poster_area']) ? '<ul class="poster poster2">' . template_call('template_build_poster_div', $message) . '</ul>' : ''), '
 									<span id="post_subject_', $message['id'], '" class="post_subject">', $message['subject'], '</span>
 									<h5 id="info_', $message['id'], '">';
 
@@ -336,9 +340,9 @@ function template_pm_pages_and_buttons_above()
 
 	// Show a few buttons if we are in conversation mode and outputting the first message.
 	if ($context['display_mode'] == 2)
-		template_pagesection('conversation_buttons', 'right', array('page_index' => false));
+		template_call('template_pagesection', 'conversation_buttons', 'right', array('page_index' => false));
 	else
-		template_pagesection();
+		template_call('template_pagesection');
 }
 
 /**
@@ -349,10 +353,10 @@ function template_pm_pages_and_buttons_below()
 	global $context, $txt;
 
 	if (empty($context['display_mode']))
-		template_pagesection(false, false, array('extra' => '<input type="submit" name="del_selected" value="' . $txt['quickmod_delete_selected'] . '" style="font-weight: normal;" onclick="if (!confirm(\'' . $txt['delete_selected_confirm'] . '\')) return false;" class="right_submit" />'));
+		template_call('template_pagesection', false, false, array('extra' => '<input type="submit" name="del_selected" value="' . $txt['quickmod_delete_selected'] . '" style="font-weight: normal;" onclick="if (!confirm(\'' . $txt['delete_selected_confirm'] . '\')) return false;" class="right_submit" />'));
 	// Show a few buttons if we are in conversation mode and outputting the first message.
 	elseif ($context['display_mode'] == 2 && isset($context['conversation_buttons']))
-		template_pagesection('conversation_buttons', 'right', array('page_index' => false));
+		template_call('template_pagesection', 'conversation_buttons', 'right', array('page_index' => false));
 }
 
 /**
@@ -366,7 +370,7 @@ function template_subject_list_above()
 	// If we are not in single display mode show the subjects on the top! @todo - Horrible markup here.
 	if ($context['display_mode'] != 1)
 	{
-		template_subject_list();
+		template_call('template_subject_list');
 
 		echo '
 					<hr class="clear" />';
@@ -386,7 +390,7 @@ function template_subject_list_below()
 		echo '
 					<br />';
 
-		template_subject_list();
+		template_call('template_subject_list');
 	}
 }
 
@@ -522,7 +526,7 @@ function template_subject_list()
 	$extra .= '
 					</ul>';
 
-	template_pagesection(false, false, array('extra' => $extra));
+	template_call('template_pagesection', false, false, array('extra' => $extra));
 }
 
 /**
@@ -726,7 +730,7 @@ function template_search_results()
 	global $context, $scripturl, $txt;
 
 	echo '
-		', template_pagesection(), '
+		', template_call('template_pagesection'), '
 		<div class="forumposts">
 			<h2 class="category_header">
 				', $txt['pm_search_results'], '
@@ -831,7 +835,7 @@ function template_search_results()
 	echo '
 		</div>';
 
-	template_pagesection();
+	template_call('template_pagesection');
 }
 
 /**
@@ -889,7 +893,7 @@ function template_send()
 				<div class="editor_wrapper">';
 
 	// If there were errors for sending the PM, show them.
-	template_show_error('post_error');
+	template_call('template_show_error', 'post_error');
 
 	if (!empty($modSettings['drafts_pm_enabled']))
 		echo '
@@ -954,11 +958,11 @@ function template_send()
 
 	// Show BBC buttons, smileys and textbox.
 	echo '
-					', template_control_richedit($context['post_box_name'], 'smileyBox_message', 'bbcBox_message');
+					', template_call('template_control_richedit', $context['post_box_name'], 'smileyBox_message', 'bbcBox_message');
 
 	// Require an image to be typed to save spamming?
 	if ($context['require_verification'])
-		template_control_verification($context['visual_verification_id'], '
+		template_call('template_control_verification', $context['visual_verification_id'], '
 					<div class="post_verification">
 						<strong>' . $txt['pm_visual_verification_label'] . ':</strong>
 						', '
@@ -967,7 +971,7 @@ function template_send()
 	// Send, Preview, spellchecker buttons.
 	echo '
 					<div id="post_confirm_buttons" class="submitbutton">
-						', template_control_richedit_buttons($context['post_box_name']), '
+						', template_call('template_control_richedit_buttons', $context['post_box_name']), '
 					</div>
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 					<input type="hidden" name="seqnum" value="', $context['form_sequence_number'], '" />
@@ -1564,7 +1568,7 @@ function template_showPMDrafts()
 		<h2 class="category_header hdicon cat_img_talk">
 			', $txt['drafts_show'], '
 		</h2>';
-	template_pagesection();
+	template_call('template_pagesection');
 
 	// No drafts? Just show an informative message.
 	if (empty($context['drafts']))
@@ -1608,5 +1612,5 @@ function template_showPMDrafts()
 	}
 
 	// Show page numbers.
-	template_pagesection();
+	template_call('template_pagesection');
 }

--- a/themes/default/Poll.template.php
+++ b/themes/default/Poll.template.php
@@ -40,7 +40,7 @@ function template_poll_edit()
 			<div>
 				<div class="roundframe">';
 
-	template_show_error('poll_error');
+	template_call('template_show_error', 'poll_error');
 
 	if (!empty($context['poll']['id']))
 		echo '

--- a/themes/default/Post.template.php
+++ b/themes/default/Post.template.php
@@ -76,9 +76,9 @@ function template_postarea_above()
 					<div class="editor_wrapper">';
 
 	// If an error occurred, explain what happened.
-	template_show_error('post_error');
+	template_call('template_show_error', 'post_error');
 	if (!empty($context['attachment_error_keys']))
-		template_attachment_errors();
+		template_call('template_attachment_errors');
 
 	// If this won't be approved let them know!
 	// @todo why not use the template_show_error above?
@@ -160,7 +160,7 @@ function template_postarea_above()
 							<dt class="clear_left">
 								<label for="post_in_board">', $txt['post_in_board'], '</label>:
 							</dt>
-							<dd>', template_select_boards('post_in_board'), '
+							<dd>', template_call('template_select_boards', 'post_in_board'), '
 							</dd>';
 
 	echo '
@@ -176,7 +176,7 @@ function template_poll_edit_above()
 					<hr class="clear" />
 					<div id="edit_poll">';
 
-	template_poll_edit();
+	template_call('template_poll_edit');
 
 	echo '
 					</div>';
@@ -265,7 +265,7 @@ function template_make_event_above()
 		{
 			echo '
 								<li>
-									', template_select_boards('board', $txt['calendar_post_in']), '
+									', template_call('template_select_boards', 'board', $txt['calendar_post_in']), '
 								</li>';
 		}
 
@@ -291,7 +291,7 @@ function template_post_page()
 
 	// Show the actual posting area...
 	echo '
-					', template_control_richedit($context['post_box_name'], 'smileyBox_message', 'bbcBox_message');
+					', template_call('template_control_richedit_buttons', $context['post_box_name'], 'smileyBox_message', 'bbcBox_message');
 
 	// A placeholder for our mention box if needed
 	if (!empty($context['member_ids']))
@@ -317,7 +317,7 @@ function template_post_page()
 	// Show our submit buttons before any more options
 	echo '
 						<div id="post_confirm_buttons" class="submitbutton">
-							', template_control_richedit_buttons($context['post_box_name']);
+							', template_call('template_control_richedit_buttons', $context['post_box_name']);
 
 	// Option to delete an event if user is editing one.
 	if ($context['make_event'] && !$context['event']['new'])
@@ -641,7 +641,7 @@ function template_postarea_below()
 	// Is visual verification enabled?
 	if ($context['require_verification'])
 	{
-		template_control_verification($context['visual_verification_id'], '
+		template_call('template_control_verification', $context['visual_verification_id'], '
 						<div class="post_verification">
 							<span' . (!empty($context['post_error']['need_qr_verification']) ? ' class="error"' : '') . '>
 								<strong>' . $txt['verification'] . ':</strong>
@@ -733,7 +733,7 @@ function template_postarea_below()
 	echo '
 		// ]]></script>';
 
-	template_topic_replies_below();
+	template_call('template_topic_replies_below');
 }
 
 /**

--- a/themes/default/Profile.template.php
+++ b/themes/default/Profile.template.php
@@ -28,7 +28,7 @@ function template_profile_above()
 
 	// If an error occurred while trying to save previously, give the user a clue!
 	echo '
-					', template_error_message();
+					', template_call('template_error_message');
 
 	// If the profile was update successfully, let the user know this.
 	if (!empty($context['profile_updated']))
@@ -49,7 +49,7 @@ function template_showDrafts()
 		<h3 class="category_header">
 			', $txt['drafts'], ' - ', $context['member']['name'], '
 		</h3>',
-	template_pagesection();
+	template_call('template_pagesection');
 
 	// No drafts? Just show an informative message.
 	if (empty($context['drafts']))
@@ -96,7 +96,7 @@ function template_showDrafts()
 	}
 
 	// Show page numbers.
-	template_pagesection();
+	template_call('template_pagesection');
 }
 
 /**

--- a/themes/default/ProfileAccount.template.php
+++ b/themes/default/ProfileAccount.template.php
@@ -22,7 +22,7 @@ function template_issueWarning()
 {
 	global $context, $scripturl, $txt;
 
-	template_load_warning_variables();
+	template_call('template_load_warning_variables');
 
 	echo '
 	<script><!-- // --><![CDATA[

--- a/themes/default/ProfileHistory.template.php
+++ b/themes/default/ProfileHistory.template.php
@@ -71,7 +71,7 @@ function template_trackActivity()
 		<br />';
 
 	// Show the track user list.
-	template_show_list('track_name_user_list');
+	template_call('template_show_list', 'track_name_user_list');
 }
 
 /**
@@ -154,9 +154,9 @@ function template_trackIP()
 	</div>
 	<br />';
 
-	template_show_list('track_message_list');
+	template_call('template_show_list', 'track_message_list');
 
 	echo '<br />';
 
-	template_show_list('track_ip_user_list');
+	template_call('template_show_list', 'track_ip_user_list');
 }

--- a/themes/default/ProfileInfo.template.php
+++ b/themes/default/ProfileInfo.template.php
@@ -83,14 +83,14 @@ function template_action_summary()
 					foreach ($templates as $template)
 					{
 						$block = 'template_profile_block_' . $template;
-						$block();
+						template_call($block);
 					}
 				}
 				// Or just a single template is fine
 				else
 				{
 					$block = 'template_profile_block_' . $templates;
-					$block();
+					template_call($block);
 				}
 
 				echo '
@@ -117,7 +117,7 @@ function template_action_showPosts()
 {
 	global $context, $scripturl, $txt;
 
-	template_pagesection();
+	template_call('template_pagesection');
 
 	echo '
 		<div class="forumposts">
@@ -185,7 +185,7 @@ function template_action_showPosts()
 		}
 	}
 	else
-		template_show_list('attachments');
+		template_call('template_show_list', 'attachments');
 
 	// No posts? Just end the table with a informative message.
 	if ((isset($context['attachments']) && empty($context['attachments'])) || (!isset($context['attachments']) && empty($context['posts'])))
@@ -200,7 +200,7 @@ function template_action_showPosts()
 		</div>';
 
 	// Show more page numbers.
-	template_pagesection();
+	template_call('template_pagesection');
 }
 
 /**
@@ -520,7 +520,7 @@ function template_viewWarning()
 {
 	global $context, $txt;
 
-	template_load_warning_variables();
+	template_call('template_load_warning_variables');
 
 	echo '
 		<h2 class="category_header hdicon cat_img_profile">
@@ -565,7 +565,7 @@ function template_viewWarning()
 			</div>
 		</div>';
 
-	template_show_list('view_warnings');
+	template_call('template_show_list', 'view_warnings');
 }
 
 /**

--- a/themes/default/ProfileOptions.template.php
+++ b/themes/default/ProfileOptions.template.php
@@ -287,7 +287,7 @@ function template_edit_options()
 			if (isset($field['callback_func']) && function_exists('template_profile_' . $field['callback_func']))
 			{
 				$callback_func = 'template_profile_' . $field['callback_func'];
-				$callback_func();
+				template_call($callback_func);
 			}
 		}
 		else
@@ -1051,7 +1051,7 @@ function template_ignoreboards()
 				</ul>';
 
 	// Show the standard "Save Settings" profile button.
-	template_profile_save();
+	template_call('template_profile_save');
 
 	echo '
 			</div>

--- a/themes/default/Recent.template.php
+++ b/themes/default/Recent.template.php
@@ -22,7 +22,7 @@ function template_recent()
 {
 	global $context, $txt, $scripturl;
 
-	template_pagesection();
+	template_call('template_pagesection');
 
 	echo '
 		<div id="recentposts" class="forumposts">
@@ -77,7 +77,7 @@ function template_recent()
 	echo '
 		</div>';
 
-	template_pagesection();
+	template_call('template_pagesection');
 }
 
 /**
@@ -89,7 +89,7 @@ function template_unread()
 
 	if (!empty($context['topics']))
 	{
-		template_pagesection('recent_buttons', 'right');
+		template_call('template_pagesection', 'recent_buttons', 'right');
 
 		if ($context['showCheckboxes'])
 			echo '
@@ -195,7 +195,7 @@ function template_unread()
 			echo '
 					</form>';
 
-		template_pagesection('recent_buttons', 'right');
+		template_call('template_pagesection', 'recent_buttons', 'right');
 
 		echo '
 					<div id="topic_icons" class="description">
@@ -230,7 +230,7 @@ function template_replies()
 
 	if (!empty($context['topics']))
 	{
-		template_pagesection('recent_buttons', 'right');
+		template_call('template_pagesection', 'recent_buttons', 'right');
 
 		if ($context['showCheckboxes'])
 			echo '
@@ -338,7 +338,7 @@ function template_replies()
 			echo '
 					</form>';
 
-		template_pagesection('recent_buttons', 'right');
+		template_call('template_pagesection', 'recent_buttons', 'right');
 
 		echo '
 					<div id="topic_icons" class="description">

--- a/themes/default/Register.template.php
+++ b/themes/default/Register.template.php
@@ -249,7 +249,7 @@ function template_registration_form()
 				if (isset($field['callback_func']) && function_exists('template_profile_' . $field['callback_func']))
 				{
 					$callback_func = 'template_profile_' . $field['callback_func'];
-					$callback_func();
+					template_call($callback_func);
 				}
 			}
 			else
@@ -349,7 +349,7 @@ function template_registration_form()
 
 	if ($context['visual_verification'])
 	{
-		template_control_verification($context['visual_verification_id'], '
+		template_call('template_control_verification', $context['visual_verification_id'], '
 			<h3 class="category_header">' . $txt['verification'] . '</h3>
 			<div class="windowbg2">
 				<fieldset class="content centertext">
@@ -790,7 +790,7 @@ function template_contact_form()
 
 	if ($context['require_verification'])
 	{
-		template_control_verification($context['visual_verification_id'], '
+		template_call('template_control_verification', $context['visual_verification_id'], '
 					<dt>
 							' . $txt['verification'] . ':
 					</dt>

--- a/themes/default/Reports.template.php
+++ b/themes/default/Reports.template.php
@@ -69,7 +69,7 @@ function template_generate_report()
 		<div id="report_buttons">';
 
 	if (!empty($context['report_buttons']))
-		template_button_strip($context['report_buttons'], 'right');
+		template_call('template_button_strip', $context['report_buttons'], 'right');
 
 	echo '
 		</div>

--- a/themes/default/Search.template.php
+++ b/themes/default/Search.template.php
@@ -51,7 +51,7 @@ function template_searchform()
 	// Does the search require a visual verification screen to annoy them?
 	if ($context['require_verification'])
 	{
-			template_control_verification($context['visual_verification_id'], '
+			template_call('template_control_verification', $context['visual_verification_id'], '
 						<div class="verification">
 							<strong>' . $txt['search_visual_verification_label'] . ':</strong>
 							<br />', '
@@ -369,7 +369,7 @@ function template_results()
 
 		// Was anything even found?
 		if (!empty($context['topics']))
-			template_pagesection();
+			template_call('template_pagesection');
 		else
 			echo '
 					<div class="roundframe">', $txt['find_no_results'], '</div>';
@@ -461,7 +461,7 @@ function template_results()
 					<div class="flow_auto">
 						<div class="floatleft">';
 
-			template_pagesection();
+			template_call('template_pagesection');
 
 			echo '
 						</div>';
@@ -513,7 +513,7 @@ function template_results()
 					', $txt['mlist_search_results'], ':&nbsp;', $context['search_params']['search'], '
 				</h3>';
 
-		template_pagesection();
+		template_call('template_pagesection');
 
 		if (empty($context['topics']))
 			echo '
@@ -565,7 +565,7 @@ function template_results()
 			}
 		}
 
-		template_pagesection();
+		template_call('template_pagesection');
 	}
 
 	// Show a jump to box for easy navigation.

--- a/themes/default/SplitTopics.template.php
+++ b/themes/default/SplitTopics.template.php
@@ -69,7 +69,7 @@ function template_ask()
 	if (!empty($context['can_move']))
 		echo '
 						<p>
-							<label for="move_new_topic"><input type="checkbox" name="move_new_topic" id="move_new_topic" onclick="document.getElementById(\'board_list\').style.display = this.checked ? \'\' : \'none\';" class="input_check" /> ', $txt['splittopic_move'], '.</label>', template_select_boards('board_list'), '
+							<label for="move_new_topic"><input type="checkbox" name="move_new_topic" id="move_new_topic" onclick="document.getElementById(\'board_list\').style.display = this.checked ? \'\' : \'none\';" class="input_check" /> ', $txt['splittopic_move'], '.</label>', template_call('template_select_boards', 'board_list'), '
 							<script><!-- // --><![CDATA[
 								document.getElementById(\'board_list\').style.display = \'none\';
 							// ]]></script>
@@ -131,7 +131,7 @@ function template_select()
 					<h2 class="category_header">', $txt['split_topic'], ' - ', $txt['select_split_posts'], '</h2>
 					<div class="information">
 						', $txt['please_select_split'], '
-					</div>', template_pagesection(false, false, array('page_index_markup' => $context['not_selected']['page_index'], 'page_index_id' => 'pageindex_not_selected')), '
+					</div>', template_call('template_pagesection', false, false, array('page_index_markup' => $context['not_selected']['page_index'], 'page_index_id' => 'pageindex_not_selected')), '
 					<ul id="messages_not_selected" class="split_messages smalltext">';
 
 	foreach ($context['not_selected']['messages'] as $message)
@@ -157,7 +157,7 @@ function template_select()
 					</h3>
 					<div class="information">
 						', $txt['split_selected_posts_desc'], '
-					</div>', template_pagesection(false, false, array('page_index_markup' => $context['selected']['page_index'], 'page_index_id' => 'pageindex_selected')), '
+					</div>', template_call('template_pagesection', false, false, array('page_index_markup' => $context['selected']['page_index'], 'page_index_id' => 'pageindex_selected')), '
 					<ul id="messages_selected" class="split_messages smalltext">';
 
 	if (!empty($context['selected']['messages']))

--- a/themes/default/Stats.template.php
+++ b/themes/default/Stats.template.php
@@ -32,14 +32,14 @@ function template_statistics()
 	foreach ($context['statistics_callbacks'] as $callback)
 	{
 		$function = 'template_' . $callback;
-		$function();
+		template_call($function);
 	}
 
 	echo '
 		</ul>
 	</div>';
 
-	template_forum_history();
+	template_call('template_forum_history');
 }
 
 /**

--- a/themes/default/VerificationControls.template.php
+++ b/themes/default/VerificationControls.template.php
@@ -42,7 +42,7 @@ function template_control_verification($verify_id, $before = '', $after = '')
 		echo '
 			<div id="verification_control_', $i, '" class="verification_control">';
 
-		call_user_func('template_control_verification_' . $verification['template'], $verify_id, $verification['values']);
+		template_call('template_control_verification_' . $verification['template'], $verify_id, $verification['values']);
 
 		echo '
 			</div>';

--- a/themes/default/Who.template.php
+++ b/themes/default/Who.template.php
@@ -44,7 +44,7 @@ function template_whos_selection_above()
 				</noscript>
 			</div>';
 
-	template_pagesection(false, false, array('extra' => $extra));
+	template_call('template_pagesection', false, false, array('extra' => $extra));
 }
 
 /**
@@ -137,7 +137,7 @@ function template_whos_selection_below()
 				</noscript>
 			</div>';
 
-	template_pagesection(false, false, array('extra' => $extra));
+	template_call('template_pagesection', false, false, array('extra' => $extra));
 
 	echo '
 		</form>

--- a/themes/default/Xml.template.php
+++ b/themes/default/Xml.template.php
@@ -400,7 +400,7 @@ function template_generic_xml()
 	echo '<', '?xml version="1.0" encoding="UTF-8"?', '>';
 
 	// Show the data.
-	template_generic_xml_recursive($context['xml_data'], 'elk', '', -1);
+	template_call('template_generic_xml_recursive', $context['xml_data'], 'elk', '', -1);
 }
 
 /**
@@ -422,7 +422,7 @@ function template_generic_xml_recursive($xml_data, $parent_ident, $child_ident, 
 	{
 		// A group?
 		if (is_array($data) && isset($data['identifier']))
-			template_generic_xml_recursive($data['children'], $key, $data['identifier'], $level);
+			template_call('template_generic_xml_recursive', $data['children'], $key, $data['identifier'], $level);
 		// An item...
 		elseif (is_array($data) && isset($data['value']))
 		{

--- a/themes/default/index.template.php
+++ b/themes/default/index.template.php
@@ -118,7 +118,7 @@ function template_html_above()
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />';
 
 	// load in any css from addons or themes so they can overwrite if wanted
-	template_css();
+	template_call('template_css');
 
 	// Save some database hits, if a width for multiple wrappers is set in admin.
 	if (!empty($settings['forum_width']))
@@ -179,7 +179,7 @@ function template_html_above()
 	<link rel="index" href="', $scripturl, '?board=', $context['current_board'], '.0" />';
 
 	// load in any javascript files from addons and themes
-	template_javascript();
+	template_call('template_javascript');
 
 	// Output any remaining HTML headers. (from addons, maybe?)
 	echo $context['html_headers'];
@@ -326,7 +326,7 @@ function template_body_above()
 	// WAI-ARIA a11y tweaks have been applied here.
 	echo '
 		<div id="menu_nav" role="navigation">
-			', template_menu(), '
+			', template_call('template_menu'), '
 		</div>
 	</div>
 	<div id="wrapper" class="wrapper">
@@ -338,7 +338,7 @@ function template_body_above()
 		echo '
 			<div id="news">
 				<h2>', $txt['news'], '</h2>
-				', template_news_fader(), '
+				', template_call('template_news_fader'), '
 			</div>';
 	}
 
@@ -394,7 +394,7 @@ function template_html_below()
 	global $context;
 
 	// load in any javascript that could be deferred to the end of the page
-	template_javascript(true);
+	template_call('template_javascript', true);
 
 	// Anything special to put out?
 	if (!empty($context['insert_after_template']))
@@ -684,7 +684,7 @@ function template_pagesection($button_strip = false, $strip_direction = '', $opt
 	echo '
 			<div class="pagesection">
 				', $pages, '
-				', !empty($button_strip) && !empty($context[$button_strip]) ? template_button_strip($context[$button_strip], $strip_direction) : '',
+				', !empty($button_strip) && !empty($context[$button_strip]) ? template_call('template_button_strip', $context[$button_strip], $strip_direction) : '',
 	$options['extra'], '
 			</div>';
 }


### PR DESCRIPTION
This makes templates infinitely pluggable by adding in 3 events for every template: pre, execute, post. You can effectively add before/after or not even call any/every template which makes themes very extensible.

It changes all calls of every template to use template_call()
If a template doesn't use template_call() it doesn't break anything so there are no backwards compatibility issues.

Although it can be added at any time, I'd still recommend some testing and code review to make sure I didn't miss anything or break anything.

See http://www.elkarte.net/community/index.php?topic=1077 for the discussion

Resubmitted to development branch from: https://github.com/elkarte/Elkarte/pull/1403
