### PR TITLE
Adjust topic index listing

### DIFF
--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -1664,7 +1664,7 @@ dl.settings dt .styled-select select {
 }
 .board_avatar {
 	float: left;
-	margin-right: 5px;
+	margin: 4px 5px 0 0;
 }
 .board_avatar a {
 	width: 40px;
@@ -1673,8 +1673,8 @@ dl.settings dt .styled-select select {
 	vertical-align: middle;
 }
 .board_avatar .avatar {
-	max-width: 40px;
-	max-height: 40px;
+	max-width: 45px;
+	max-height: 45px;
 	display: block;
 	margin: auto;
 }
@@ -1922,6 +1922,7 @@ img.new_posts {
 .board_lastpost, .topic_lastpost {
 	min-width: 21em;
 	margin-left: 1em;
+	line-height: 1.5em;
 }
 .topic_stats {
 	text-align: right;
@@ -1930,6 +1931,7 @@ img.new_posts {
 	min-width: 14em;
 	box-sizing: border-box;
 	padding: 0 16px 0 16px;
+	line-height: 1.5em;
 }
 .topic_lastpost img {
 	float: right;


### PR DESCRIPTION
This was discussed on the board, so here is one suggestion.  The current layout is as below, and it leaves the avatar section a bit mis aligned to the stats section.
![current](https://f.cloud.github.com/assets/1181042/2375131/5daf36e4-a868-11e3-8e8a-f82e8eb96e1a.jpg)
Below is what it looks like by adding line-height to the stats section and then allowing the avatar to grow a bit in size, the attempt was to balance the two sides and the white space somewhat .... thoughts?
![new](https://f.cloud.github.com/assets/1181042/2375359/cfb9e5ac-a86a-11e3-8949-4fa3ebb89157.jpg)
