### PR TITLE
Standardize the integration hook "_modify_" settings

### DIFF
--- a/sources/admin/ManageAttachments.controller.php
+++ b/sources/admin/ManageAttachments.controller.php
@@ -128,8 +128,6 @@ class ManageAttachments_Controller extends Action_Controller
 	base_dir.addEventListener("change", toggleSubDir, false);
 	toggleSubDir();', true);
 
-		call_integration_hook('integrate_modify_attachment_settings', array(&$config_vars));
-
 		// These are very likely to come in handy! (i.e. without them we're doomed!)
 		require_once(SUBSDIR . '/Settings.class.php');
 		require_once(SUBSDIR . '/Attachments.subs.php');
@@ -204,10 +202,10 @@ class ManageAttachments_Controller extends Action_Controller
 	 */
 	private function _initAttachSettingsForm()
 	{
-		// instantiate the form
+		// Instantiate the form
 		$this->_attachSettingsForm = new Settings_Form();
 
-		// initialize settings
+		// Initialize settings
 		$config_vars = $this->_settings();
 
 		return $this->_attachSettingsForm->settings($config_vars);
@@ -306,6 +304,9 @@ class ManageAttachments_Controller extends Action_Controller
 				array('int', 'max_image_width', 'subtext' => $txt['zero_for_no_limit']),
 				array('int', 'max_image_height', 'subtext' => $txt['zero_for_no_limit']),
 		);
+
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_attachment_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageAvatars.controller.php
+++ b/sources/admin/ManageAvatars.controller.php
@@ -80,12 +80,10 @@ class ManageAvatars_Controller extends Action_Controller
 	{
 		global $txt, $context, $scripturl;
 
-		// initialize the form
+		// Initialize the form
 		$this->_initAvatarSettingsForm();
 
 		$config_vars = $this->_avatarSettings->settings();
-
-		call_integration_hook('integrate_modify_avatar_settings', array(&$config_vars));
 
 		// Saving avatar settings?
 		if (isset($_GET['save']))
@@ -198,6 +196,9 @@ class ManageAvatars_Controller extends Action_Controller
 				array('text', 'custom_avatar_dir', 40, 'subtext' => $txt['custom_avatar_dir_desc'], 'invalid' => !$context['valid_custom_avatar_dir']),
 				array('text', 'custom_avatar_url', 40),
 		);
+
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_avatar_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageBBC.controller.php
+++ b/sources/admin/ManageBBC.controller.php
@@ -84,8 +84,6 @@ class ManageBBC_Controller extends Action_Controller
 		addInlineJavascript('
 			toggleBBCDisabled(\'disabledBBC\', ' . (empty($modSettings['enableBBC']) ? 'true' : 'false') . ');', true);
 
-		call_integration_hook('integrate_modify_bbc_settings', array(&$config_vars));
-
 		// We'll need this forprepare_db() and save_db()
 		require_once(SUBSDIR . '/Settings.class.php');
 
@@ -156,6 +154,9 @@ class ManageBBC_Controller extends Action_Controller
 			'',
 				array('bbc', 'disabledBBC'),
 		);
+
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_bbc_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageBoards.controller.php
+++ b/sources/admin/ManageBoards.controller.php
@@ -754,8 +754,6 @@ class ManageBoards_Controller extends Action_Controller
 		addInlineJavascript('
 				document.getElementById("recycle_board").disabled = !document.getElementById("recycle_enable").checked;', true);
 
-		call_integration_hook('integrate_modify_board_settings', array(&$config_vars));
-
 		// Don't let guests have these permissions.
 		$context['post_url'] = $scripturl . '?action=admin;area=manageboards;save;sa=settings';
 		$context['permissions_excluded'] = array(-1);
@@ -832,7 +830,8 @@ class ManageBoards_Controller extends Action_Controller
 				array('check', 'deny_boards_access'),
 		);
 
-		call_integration_hook('integrate_boards_settings', array(&$config_vars));
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_board_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageCalendar.controller.php
+++ b/sources/admin/ManageCalendar.controller.php
@@ -275,8 +275,6 @@ class ManageCalendar_Controller extends Action_Controller
 
 		$config_vars = $this->_calendarSettings->settings();
 
-		call_integration_hook('integrate_modify_calendar_settings', array(&$config_vars));
-
 		// Get the settings template fired up.
 		require_once(SUBSDIR . '/Settings.class.php');
 
@@ -374,6 +372,9 @@ class ManageCalendar_Controller extends Action_Controller
 				array('check', 'cal_allowspan'),
 				array('int', 'cal_maxspan', 6, 'postinput' => $txt['days_word']),
 		);
+
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_calendar_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageDrafts.controller.php
+++ b/sources/admin/ManageDrafts.controller.php
@@ -46,7 +46,7 @@ class ManageDrafts_Controller extends Action_Controller
 
 	/**
 	 * Modify any setting related to drafts.
-	 * 
+	 *
 	 * - Requires the admin_forum permission.
 	 * - Accessed from ?action=admin;area=managedrafts
 	 *
@@ -77,6 +77,8 @@ class ManageDrafts_Controller extends Action_Controller
 		if (isset($_GET['save']))
 		{
 			checkSession();
+
+			call_integration_hook('integrate_save_drafts_settings', array(&$config_vars));
 
 			// Protect them from themselves.
 			$_POST['drafts_autosave_frequency'] = $_POST['drafts_autosave_frequency'] < 30 ? 30 : $_POST['drafts_autosave_frequency'];
@@ -140,6 +142,8 @@ class ManageDrafts_Controller extends Action_Controller
 				array('check', 'drafts_autosave_enabled', 'subtext' => $txt['drafts_autosave_enabled_subnote']),
 				array('int', 'drafts_autosave_frequency', 'postinput' => $txt['manageposts_seconds'], 'subtext' => $txt['drafts_autosave_frequency_subnote']),
 		);
+
+		call_integration_hook('integrate_modify_drafts_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageFeatures.controller.php
+++ b/sources/admin/ManageFeatures.controller.php
@@ -1526,7 +1526,7 @@ class ManageFeatures_Controller extends Action_Controller
 				array('check', 'timeLoadPageEnable'),
 		);
 
-		call_integration_hook('integrate_layout_settings', array(&$config_vars));
+		call_integration_hook('integrate_modify_layout_settings', array(&$config_vars));
 
 		return $config_vars;
 	}
@@ -1562,7 +1562,7 @@ class ManageFeatures_Controller extends Action_Controller
 				array('text', 'karmaSmiteLabel'),
 		);
 
-		call_integration_hook('integrate_karma_settings', array(&$config_vars));
+		call_integration_hook('integrate_modify_karma_settings', array(&$config_vars));
 
 		return $config_vars;
 	}
@@ -1596,7 +1596,7 @@ class ManageFeatures_Controller extends Action_Controller
 				array('int', 'likeDisplayLimit', 6)
 		);
 
-		call_integration_hook('integrate_likes_settings', array(&$config_vars));
+		call_integration_hook('integrate_modify_likes_settings', array(&$config_vars));
 
 		return $config_vars;
 	}
@@ -1622,7 +1622,7 @@ class ManageFeatures_Controller extends Action_Controller
 				array('check', 'mentions_dont_notify_rlike'),
 		);
 
-		call_integration_hook('integrate_mention_settings', array(&$config_vars));
+		call_integration_hook('integrate_modify_mention_settings', array(&$config_vars));
 
 		return $config_vars;
 	}
@@ -1663,7 +1663,7 @@ class ManageFeatures_Controller extends Action_Controller
 				array('bbc', 'signature_bbc'),
 		);
 
-		call_integration_hook('integrate_signature_settings', array(&$config_vars));
+		call_integration_hook('integrate_modify_signature_settings', array(&$config_vars));
 
 		return $config_vars;
 	}
@@ -1700,7 +1700,7 @@ class ManageFeatures_Controller extends Action_Controller
 				array('callback', 'pm_limits'),
 		);
 
-		call_integration_hook('integrate_pmsettings_settings', array(&$config_vars));
+		call_integration_hook('integrate_modify_pmsettings_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageLanguages.controller.php
+++ b/sources/admin/ManageLanguages.controller.php
@@ -1019,7 +1019,6 @@ class ManageLanguages_Controller extends Action_Controller
 		{
 			checkSession();
 
-			// @todo review these hooks: do they need param and how else can we do this
 			call_integration_hook('integrate_save_language_settings', array(&$config_vars));
 
 			$this->_languageSettings->save();
@@ -1088,7 +1087,7 @@ class ManageLanguages_Controller extends Action_Controller
 			array('userLanguage', $txt['userLanguage'], 'db', 'check', null, 'userLanguage'),
 		);
 
-		call_integration_hook('integrate_language_settings', array(&$config_vars));
+		call_integration_hook('integrate_modify_language_settings', array(&$config_vars));
 
 		// Get our languages. No cache.
 		$languages = getLanguages(false);

--- a/sources/admin/ManageMail.controller.php
+++ b/sources/admin/ManageMail.controller.php
@@ -249,8 +249,6 @@ class ManageMail_Controller extends Action_Controller
 
 		$config_vars = $this->_mailSettings->settings();
 
-		call_integration_hook('integrate_modify_mail_settings', array(&$config_vars));
-
 		// Saving?
 		if (isset($_GET['save']))
 		{
@@ -361,6 +359,9 @@ class ManageMail_Controller extends Action_Controller
 				'birthday_subject' => array('var_message', 'birthday_subject', 'var_message' => $processedBirthdayEmails[empty($modSettings['birthday_email']) ? 'happy_birthday' : $modSettings['birthday_email']]['subject'], 'disabled' => true, 'size' => strlen($subject) + 3),
 				'birthday_body' => array('var_message', 'birthday_body', 'var_message' => nl2br($body), 'disabled' => true, 'size' => ceil(strlen($body) / 25)),
 		);
+
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_mail_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageMaillist.controller.php
+++ b/sources/admin/ManageMaillist.controller.php
@@ -904,6 +904,8 @@ class ManageMaillist_Controller extends Action_Controller
 		{
 			checkSession();
 
+			call_integration_hook('integrate_save_filter_settings', array(&$config_vars));
+
 			// Editing an entry?
 			$editid = (isset($_GET['edit'])) ? (int) $_GET['edit'] : -1;
 			$editname = (isset($_GET['edit'])) ? 'id_filter' : '';
@@ -991,6 +993,8 @@ class ManageMaillist_Controller extends Action_Controller
 			array('large_text', 'filter_from', 4, 'subtext' => $txt['filter_from_desc']),
 			array('text', 'filter_to', 25, 'subtext' => $txt['filter_to_desc']),
 		);
+
+		call_integration_hook('integrate_modify_maillist_filter_settings', array(&$config_vars));
 
 		return $this->_filtersSettings->settings($config_vars);
 	}
@@ -1296,6 +1300,8 @@ class ManageMaillist_Controller extends Action_Controller
 		{
 			checkSession();
 
+			call_integration_hook('integrate_save_parser_settings', array(&$config_vars));
+
 			// Editing a parser?
 			$editid = isset($_GET['edit']) ? (int) $_GET['edit'] : -1;
 			$editname = isset($_GET['edit']) ? 'id_filter' : '';
@@ -1384,6 +1390,8 @@ class ManageMaillist_Controller extends Action_Controller
 			array('large_text', 'filter_from', 4, 'subtext' => $txt['parser_from_desc']),
 		);
 
+		call_integration_hook('integrate_modify_maillist_parser_settings', array(&$config_vars));
+
 		return $this->_parsersSettings->settings($config_vars);
 	}
 
@@ -1442,6 +1450,8 @@ class ManageMaillist_Controller extends Action_Controller
 		if (isset($_GET['save']))
 		{
 			checkSession();
+
+			call_integration_hook('integrate_save_maillist_settings', array(&$config_vars));
 
 			$email_error = false;
 			$board_error = false;
@@ -1623,6 +1633,9 @@ class ManageMaillist_Controller extends Action_Controller
 						array('check', 'maillist_imap_cron', 20, 'subtext' => $txt['maillist_imap_cron_desc'], 'disabled' => !function_exists('imap_open')),
 				)
 			);
+
+		call_integration_hook('integrate_modify_maillist_settings', array(&$config_vars));
+
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageMembergroups.controller.php
+++ b/sources/admin/ManageMembergroups.controller.php
@@ -791,8 +791,6 @@ class ManageMembergroups_Controller extends Action_Controller
 
 		$config_vars = $this->_groupSettings->settings();
 
-		call_integration_hook('integrate_modify_membergroup_settings', array(&$config_vars));
-
 		if (isset($_REQUEST['save']))
 		{
 			checkSession();
@@ -836,6 +834,9 @@ class ManageMembergroups_Controller extends Action_Controller
 		$config_vars = array(
 			array('permissions', 'manage_membergroups'),
 		);
+
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_membergroup_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageNews.controller.php
+++ b/sources/admin/ManageNews.controller.php
@@ -852,8 +852,6 @@ class ManageNews_Controller extends Action_Controller
 			document.getElementById("xmlnews_maxlen").disabled = !document.getElementById("xmlnews_enable").checked;
 			document.getElementById("xmlnews_limit").disabled = !document.getElementById("xmlnews_enable").checked;', true);
 
-		call_integration_hook('integrate_modify_news_settings', array(&$config_vars));
-
 		$context['page_title'] = $txt['admin_edit_news'] . ' - ' . $txt['settings'];
 		$context['sub_template'] = 'show_settings';
 
@@ -913,6 +911,9 @@ class ManageNews_Controller extends Action_Controller
 				array('text', 'xmlnews_maxlen', 'subtext' => $txt['xmlnews_maxlen_note'], 10),
 				array('text', 'xmlnews_limit', 'subtext' => $txt['xmlnews_limit_note'], 10),
 		);
+
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_news_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManagePaid.controller.php
+++ b/sources/admin/ManagePaid.controller.php
@@ -158,6 +158,8 @@ class ManagePaid_Controller extends Action_Controller
 		{
 			checkSession();
 
+			call_integration_hook('integrate_save_subscription_settings', array(&$config_vars));
+
 			// Check that the entered email addresses are valid
 			if (!empty($_POST['paid_email_to']))
 			{
@@ -243,6 +245,8 @@ class ManagePaid_Controller extends Action_Controller
 				array('text', 'paid_currency_symbol', 'subtext' => $txt['paid_currency_symbol_desc'], 'size' => 8, 'force_div_id' => 'custom_currency_symbol_div'),
 				array('check', 'paidsubs_test', 'subtext' => $txt['paidsubs_test_desc'], 'onclick' => 'return document.getElementById(\'paidsubs_test\').checked ? confirm(\'' . $txt['paidsubs_test_confirm'] . '\') : true;'),
 		);
+
+		call_integration_hook('integrate_modify_subscription_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManagePermissions.controller.php
+++ b/sources/admin/ManagePermissions.controller.php
@@ -126,7 +126,7 @@ class ManagePermissions_Controller extends Action_Controller
 
 		// Load the subactions, call integrate_manage_permissions
 		$action->initialize($subActions);
-		
+
 		// Last items needed
 		$context['page_title'] = $txt['permissions_title'];
 		$context['sub_action'] = $subAction;
@@ -882,8 +882,7 @@ class ManagePermissions_Controller extends Action_Controller
 
 		$config_vars = $this->_permSettings->settings();
 
-		call_integration_hook('integrate_modify_permission_settings', array(&$config_vars));
-
+		// Some items for the template
 		$context['page_title'] = $txt['permission_settings_title'];
 		$context['sub_template'] = 'show_settings';
 
@@ -946,6 +945,9 @@ class ManagePermissions_Controller extends Action_Controller
 				array('check', 'permission_enable_deny', 0, $txt['permission_settings_enable_deny'], 'help' => 'permissions_deny'),
 				array('check', 'permission_enable_postgroups', 0, $txt['permission_settings_enable_postgroups'], 'help' => 'permissions_postgroups'),
 		);
+
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_permission_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManagePosts.controller.php
+++ b/sources/admin/ManagePosts.controller.php
@@ -218,8 +218,6 @@ class ManagePosts_Controller extends Action_Controller
 
 		$config_vars = $this->_postSettings->settings();
 
-		call_integration_hook('integrate_modify_post_settings', array(&$config_vars));
-
 		// Setup the template.
 		$context['page_title'] = $txt['manageposts_settings'];
 		$context['sub_template'] = 'show_settings';
@@ -305,6 +303,9 @@ class ManagePosts_Controller extends Action_Controller
 				array('select', 'message_index_preview', array($txt['message_index_preview_off'], $txt['message_index_preview_first'], $txt['message_index_preview_last'])),
 				array('int', 'preview_characters', 'subtext' => $txt['preview_characters_zero'], 'postinput' => $txt['preview_characters_units']),
 		);
+
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_post_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageRegistration.controller.php
+++ b/sources/admin/ManageRegistration.controller.php
@@ -315,8 +315,6 @@ class ManageRegistration_Controller extends Action_Controller
 
 		$config_vars = $this->_registerSettings->settings();
 
-		call_integration_hook('integrate_modify_registration_settings', array(&$config_vars));
-
 		// Setup the template
 		$context['sub_template'] = 'show_settings';
 		$context['page_title'] = $txt['registration_center'];
@@ -398,6 +396,9 @@ class ManageRegistration_Controller extends Action_Controller
 				array('text', 'coppaFax'),
 				array('text', 'coppaPhone'),
 		);
+
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_registration_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageSearch.controller.php
+++ b/sources/admin/ManageSearch.controller.php
@@ -118,8 +118,6 @@ class ManageSearch_Controller extends Action_Controller
 		if (!isset($context['settings_post_javascript']))
 			$context['settings_post_javascript'] = '';
 
-		call_integration_hook('integrate_modify_search_settings', array(&$config_vars));
-
 		// Perhaps the search method wants to add some settings?
 		require_once(SUBSDIR . '/Search.subs.php');
 		$searchAPI = findSearchAPI();
@@ -220,6 +218,9 @@ class ManageSearch_Controller extends Action_Controller
 				array('title', 'additional_search_engines'),
 				array('callback', 'external_search_engines'),
 		);
+
+		// Add new settings with a nice hook, makes them available for admin settings search as well
+		call_integration_hook('integrate_modify_search_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageSearchEngines.controller.php
+++ b/sources/admin/ManageSearchEngines.controller.php
@@ -87,9 +87,6 @@ class ManageSearchEngines_Controller extends Action_Controller
 		// Set up a message.
 		$context['settings_message'] = sprintf($txt['spider_settings_desc'], $scripturl . '?action=admin;area=logs;sa=pruning;' . $context['session_var'] . '=' . $context['session_id']);
 
-		// Notify the integration that we're preparing to mess up with search engine settings...
-		call_integration_hook('integrate_modify_search_engine_settings', array(&$config_vars));
-
 		require_once(SUBSDIR . '/SearchEngines.subs.php');
 		require_once(SUBSDIR . '/Membergroups.subs.php');
 
@@ -184,6 +181,9 @@ class ManageSearchEngines_Controller extends Action_Controller
 			'spider_group' => array('select', 'spider_group', 'subtext' => $txt['spider_group_note'], array($txt['spider_group_none'], $txt['membergroups_members'])),
 			array('select', 'show_spider_online', array($txt['show_spider_online_no'], $txt['show_spider_online_summary'], $txt['show_spider_online_detail'], $txt['show_spider_online_detail_admin'])),
 		);
+
+		// Notify the integration that we're preparing to mess up with search engine settings...
+		call_integration_hook('integrate_modify_search_engine_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageSecurity.controller.php
+++ b/sources/admin/ManageSecurity.controller.php
@@ -184,6 +184,8 @@ class ManageSecurity_Controller extends Action_Controller
 		{
 			checkSession();
 
+			call_integration_hook('integratesave_moderation_settings', array(&$config_vars));
+
 			// Make sure these don't have an effect.
 			if ($modSettings['warning_settings'][0] != 1)
 			{
@@ -436,7 +438,7 @@ class ManageSecurity_Controller extends Action_Controller
 			array('select', 'warning_show', 'subtext' => $txt['setting_warning_show_note'], array($txt['setting_warning_show_mods'], $txt['setting_warning_show_user'], $txt['setting_warning_show_all'])),
 		);
 
-		call_integration_hook('integrate_moderation_settings', array(&$config_vars));
+		call_integration_hook('integrate_modify_moderation_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageServer.controller.php
+++ b/sources/admin/ManageServer.controller.php
@@ -206,8 +206,6 @@ class ManageServer_Controller extends Action_Controller
 		// Initialize the form
 		$this->_initGeneralSettingsForm();
 
-		call_integration_hook('integrate_general_settings');
-
 		// Setup the template stuff.
 		$context['post_url'] = $scripturl . '?action=admin;area=serversettings;sa=general;save';
 		$context['settings_title'] = $txt['general_settings'];
@@ -260,8 +258,6 @@ class ManageServer_Controller extends Action_Controller
 		// Initialize the form
 		$this->_initDatabaseSettingsForm();
 
-		call_integration_hook('integrate_database_settings');
-
 		// Setup the template stuff.
 		$context['post_url'] = $scripturl . '?action=admin;area=serversettings;sa=database;save';
 		$context['settings_title'] = $txt['database_paths_settings'];
@@ -304,8 +300,6 @@ class ManageServer_Controller extends Action_Controller
 
 		// Initialize the form
 		$this->_initCookieSettingsForm();
-
-		call_integration_hook('integrate_cookie_settings');
 
 		$context['post_url'] = $scripturl . '?action=admin;area=serversettings;sa=cookie;save';
 		$context['settings_title'] = $txt['cookies_sessions_settings'];
@@ -392,8 +386,6 @@ class ManageServer_Controller extends Action_Controller
 			createEventListener(cache_type);
 			cache_type.addEventListener("change", toggleCache);
 			toggleCache();', true);
-
-		call_integration_hook('integrate_modify_cache_settings', array(&$config_vars));
 
 		// Saving again?
 		if (isset($_GET['save']))
@@ -574,6 +566,9 @@ class ManageServer_Controller extends Action_Controller
 				array('disableHostnameLookup', $txt['disableHostnameLookup'], 'db', 'check', null, 'disableHostnameLookup'),
 		);
 
+		// Notify the integration
+		call_integration_hook('integrate_modify_general_settings', array(&$config_vars));
+
 		return $config_vars;
 	}
 
@@ -613,6 +608,9 @@ class ManageServer_Controller extends Action_Controller
 				array('cachedir', $txt['cachedir'], 'file', 'text', 36),
 		);
 
+		// Notify the integration
+		call_integration_hook('integrate_modify_database_settings', array(&$config_vars));
+
 		return $config_vars;
 	}
 
@@ -647,6 +645,9 @@ class ManageServer_Controller extends Action_Controller
 				array('databaseSession_loose', $txt['databaseSession_loose'], 'db', 'check', false, 'databaseSession_loose'),
 				array('databaseSession_lifetime', $txt['databaseSession_lifetime'], 'db', 'int', false, 'databaseSession_lifetime', 'postinput' => $txt['seconds']),
 		);
+
+		// Notify the integration
+		call_integration_hook('integrate_modify_cookie_settings', array(&$config_vars));
 
 		// Set them vars for our settings form
 		return $config_vars;
@@ -699,6 +700,9 @@ class ManageServer_Controller extends Action_Controller
 			array('cache_memcached', $txt['cache_memcached'], 'file', 'text', $txt['cache_memcached'], 'cache_memcached'),
 			array('cachedir', $txt['cachedir'], 'file', 'text', 36, 'cache_cachedir'),
 		);
+
+		// Notify the integration that we're preparing to mess up with cache settings...
+		call_integration_hook('integrate_modify_cache_settings', array(&$config_vars));
 
 		return $config_vars;
 	}
@@ -760,6 +764,9 @@ class ManageServer_Controller extends Action_Controller
 			$value = !isset($modSettings[$name]) ? $value : $modSettings[$name];
 			$config_vars[] = array('text', $name, 'value' => $value, 'disabled' => $disabled);
 		}
+
+		// Notify the integration that we're preparing to mess with balancing settings...
+		call_integration_hook('integrate_modify_loadavg_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageSmileys.controller.php
+++ b/sources/admin/ManageSmileys.controller.php
@@ -135,8 +135,6 @@ class ManageSmileys_Controller extends Action_Controller
 
 		$config_vars = $this->_smileySettings->settings();
 
-		call_integration_hook('integrate_modify_smiley_settings', array(&$config_vars));
-
 		// For the basics of the settings.
 		require_once(SUBSDIR . '/Settings.class.php');
 		require_once(SUBSDIR . '/Smileys.subs.php');
@@ -216,6 +214,8 @@ class ManageSmileys_Controller extends Action_Controller
 				// Message icons.
 				array('check', 'messageIcons_enable', 'subtext' => $txt['setting_messageIcons_enable_note']),
 		);
+
+		call_integration_hook('integrate_modify_smiley_settings', array(&$config_vars));
 
 		return $config_vars;
 	}

--- a/sources/admin/ManageTopics.controller.php
+++ b/sources/admin/ManageTopics.controller.php
@@ -73,8 +73,6 @@ class ManageTopics_Controller extends Action_Controller
 		// Retrieve the current config settings
 		$config_vars = $this->_topicSettings->settings();
 
-		call_integration_hook('integrate_modify_topic_settings', array(&$config_vars));
-
 		// Setup the template.
 		$context['sub_template'] = 'show_settings';
 
@@ -150,6 +148,8 @@ class ManageTopics_Controller extends Action_Controller
 				array('check', 'disableCustomPerPage'),
 				array('check', 'enablePreviousNext'),
 		);
+
+		call_integration_hook('integrate_modify_topic_settings', array(&$config_vars));
 
 		return $config_vars;
 	}


### PR DESCRIPTION
This standardizes the hook location in the controllers to  allow for addons to be included in admin search

It adds in a few missing admin settings areas that did not have hooks

Update so all follow the "_modify_"  and "_save_"  naming patterns.  Some may have been left over from SMF (an more likely 2.1), but its more important that we be consistent for things like this.  Its unlikely any mods use them and if they were added in 2.1 even less.
