### PR TITLE
Fix logo in rss feeds to use theme_url instead of theme_dir

### DIFF
--- a/sources/controllers/News.controller.php
+++ b/sources/controllers/News.controller.php
@@ -241,7 +241,7 @@ class News_Controller extends Action_Controller
 			<generator>ElkArte</generator>
 			<ttl>30</ttl>
 			<image>
-				<url>', $settings['default_theme_dir'], '/images/logo.png</url>
+				<url>', $settings['default_theme_url'], '/images/logo.png</url>
 				<title>', $feed_title, '</title>
 				<link>', $scripturl, '</link>
 			</image>';


### PR DESCRIPTION
Signed-off-by: scripple github@scripple.org
