### PR TITLE
Fix sceditor to use editor height settings

### DIFF
--- a/themes/default/GenericControls.template.php
+++ b/themes/default/GenericControls.template.php
@@ -39,7 +39,6 @@ function template_control_richedit($editor_id, $smileyContainer = null, $bbcCont
 				$("#', $editor_id, '").sceditor({
 					style: "', $settings['theme_url'], '/css/', $context['theme_variant_url'], 'jquery.sceditor.elk_wiz', $context['theme_variant'], '.css",
 					width: "100%",
-					height: "100%",
 					resizeWidth: false,
 					resizeMaxHeight: -1,
 					emoticonsCompat: true,


### PR DESCRIPTION
Signed-off-by: scripple github@scripple.org

It turns out that setting height:100% on sceditor makes it ignore the existing size of the textarea so changing the height setting in the context doesn't do anything.  However not passing a height tells sceditor to take the height of the existing textarea.

Although the size is the TOTAL size including the toolbar and grip, so really the textarea is quite a bit smaller than the specified height.
