### PR TITLE
Fix duplicate button id in profile menu

### DIFF
--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -3508,7 +3508,7 @@ function setupMenuContext()
 						'href' => $scripturl . '?action=profile;area=account',
 						'show' => allowedTo(array('profile_identity_any', 'profile_identity_own', 'manage_membergroups')),
 					),
-					'profile' => array(
+					'forumprofile' => array(
 						'title' => $txt['forumprofile'],
 						'href' => $scripturl . '?action=profile;area=forumprofile',
 						'show' => allowedTo(array('profile_extra_any', 'profile_extra_own')),


### PR DESCRIPTION
Signed-off-by: scripple github@scripple.org

Since child and grandchild buttons now get id's in the html this duplicate button name needed fixed.
