### PR TITLE
Use sceditors toolbarContainer option to make editor textarea more consi...

### DIFF
--- a/themes/default/GenericControls.template.php
+++ b/themes/default/GenericControls.template.php
@@ -29,6 +29,7 @@ function template_control_richedit($editor_id, $smileyContainer = null, $bbcCont
 	$editor_context = &$context['controls']['richedit'][$editor_id];
 
 	echo '
+		<div id="editor_toolbar_container"></div>
 		<textarea class="editor', isset($context['post_error']['errors']['no_message']) || isset($context['post_error']['errors']['long_message']) ? ' border_error' : '', '" name="', $editor_id, '" id="', $editor_id, '" tabindex="', $context['tabindex']++, '" style="width:', $editor_context['width'], ';height: ', $editor_context['height'], ';" required="required">', $editor_context['value'], '</textarea>
 		<input type="hidden" name="', $editor_id, '_mode" id="', $editor_id, '_mode" value="0" />
 		<script><!-- // --><![CDATA[
@@ -40,6 +41,7 @@ function template_control_richedit($editor_id, $smileyContainer = null, $bbcCont
 				$("#', $editor_id, '").sceditor({
 					style: "', $settings['theme_url'], '/css/', $context['theme_variant_url'], 'jquery.sceditor.elk_wiz', $context['theme_variant'], '.css",
 					width: "100%",
+					toolbarContainer: $("#editor_toolbar_container"),
 					resizeWidth: false,
 					resizeMaxHeight: -1,
 					emoticonsCompat: true,


### PR DESCRIPTION
Editor textarea height is much smaller on mobile because editor_height includes the toolbar which takes more vertical space on a narrow screen.  By using the toolbarContainer option of sceditor we can avoid this.  Now the text area is much closer to the value set in editor_context['height'].   The various margins, padding, and the grip size are still subtracted but at least those are consistent at different screen widths.

Signed-off-by: scripple github@scripple.org
