### PR TITLE
php bug in some 5.4 returns an empty string during iconv //ignore

### DIFF
--- a/sources/subs/EmailParse.class.php
+++ b/sources/subs/EmailParse.class.php
@@ -1038,17 +1038,33 @@ class Email_Parse
 	{
 		// Lets assume we have one of the functions available to us
 		$this->_converted_utf8 = true;
+		$string_save = $string;
 
+		// Use iconv if its available
 		if (function_exists('iconv'))
-			return @iconv($from, $to . '//TRANSLIT//IGNORE', $string);
-		elseif (function_exists('mb_convert_encoding'))
-			return @mb_convert_encoding($string, $to, $from);
-		elseif (function_exists('recode_string'))
-			return @recode_string($from . '..' . $to, $string);
-		else
+			$string = @iconv($from, $to . '//TRANSLIT//IGNORE', $string);
+
+		// No iconv or a false response from it
+		if (!function_exists('iconv') || ($string == false))
 		{
-			$this->_converted_utf8 = false;
-			return $string;
+			// PHP (some 5.4 versions) mishandles //TRANSLIT//IGNORE and returns false: see https://bugs.php.net/bug.php?id=61484
+			if ($string == false)
+				$string = $string_save;
+
+			if (function_exists('mb_convert_encoding'))
+			{
+				// Replace unknown characters with a space
+				@ini_set('mbstring.substitute_character', "32");
+				$string = @mb_convert_encoding($string, $to, $from);
+			}
+			elseif (function_exists('recode_string'))
+				$string = @recode_string($from . '..' . $to, $string);
+			else
+				$this->_converted_utf8 = false;
 		}
+
+		unset($string_save);
+
+		return $string;
 	}
 }


### PR DESCRIPTION
Some versions of 5.4 return a null string instead of ignoring the out of set characters.  So we need to check for that condition and recover.
