### PR TITLE
The large help icon was not centered in the headers

### DIFF
--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -3486,6 +3486,9 @@ div.labels {
 	opacity: 0.8;
 	cursor: help;
 }
+.hdicon.help:before {
+	margin: 2px 0;
+}
 .help .icon:hover, .hdicon.help:hover {
 	opacity: 1;
 }


### PR DESCRIPTION
However the rest of non linked hdicons in headers are fine, so some padding, height, box size, margin or something changed on them links.  This targets just those help icons.

Signed-off-by: Spuds spuds@spudsdesign.com
