### PR TITLE
Search engine friendly URLs whitescreens the site if there is a tilde in the path.

### DIFF
--- a/sources/QueryString.php
+++ b/sources/QueryString.php
@@ -383,7 +383,7 @@ function ob_sessrewrite($buffer)
 	if (!empty($modSettings['queryless_urls']) && (!$context['server']['is_cgi'] || ini_get('cgi.fix_pathinfo') == 1 || @get_cfg_var('cgi.fix_pathinfo') == 1) && ($context['server']['is_apache'] || $context['server']['is_lighttpd'] || $context['server']['is_litespeed']))
 	{
 		// Let's do something special for session ids!
-		$buffer = preg_replace_callback('["' . preg_quote($scripturl, '/') . '\?((?:board|topic)=[^#"]+?)(#[^"]*?)?"]', 'buffer_callback', $buffer);
+		$buffer = preg_replace_callback('~"' . preg_quote($scripturl, '~') . '\?((?:board|topic)=[^#"]+?)(#[^"]*?)?"~', 'buffer_callback', $buffer);
 	}
 
 	// Return the changed buffer.


### PR DESCRIPTION
The base URL can contain a tilde which conflicts with the `queryless_urls` regex, causing `preg_replace_callback` to return `null`. Using bracket delimiters would be better.

Example `$scripturl` that causes this issue:

```
http://example.com/~username/index.php
```
