### PR TITLE
Fix broken php info layout

### DIFF
--- a/themes/default/Admin.template.php
+++ b/themes/default/Admin.template.php
@@ -1364,7 +1364,7 @@ function template_php_info()
 	foreach ($context['pinfo'] as $area => $php_area)
 	{
 		echo '
-		<table id="', str_replace(' ', '_', $area), '" class="table_grid">
+		<table id="', str_replace(' ', '_', $area), '" class="table_grid wordbreak">
 			<thead>
 			<tr class="table_head three_column">
 				<th scope="col"></th>


### PR DESCRIPTION
Lines like pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,

in both col2+3 would mess-you-up, uh huh, thats right ...  the layout, so just let it wrap the line to fit.
