### PR TITLE
Small Screen tweaks

### DIFF
--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -4264,11 +4264,18 @@ dl.no_members {
 	.postarea {
 		margin: 0 0 0 6em;
 	}
+	.poster .name {
+		padding: 0;
+	}
 	.avatar, .avatar.avatarresize {
-		max-width: 7em;
+		max-width: 80px;
 	}
 	.poster_avatar a {
 		padding: 0;
+	}
+	.poster .membergroup {
+		word-break: normal;
+		word-wrap: break-word;
 	}
 	.quickbuttons .modified {
 		display: block;


### PR DESCRIPTION
the width set as em on the avatar class acted differently across browsers/devices.  I've set that to 80px which seems to be more consistent.

Gave a little extra room for the user name before it wraps or clips

Tried to allow title to break on a word space
