### PR TITLE
Auto bounce detection - Preliminary

### DIFF
--- a/sources/controllers/Emailpost.controller.php
+++ b/sources/controllers/Emailpost.controller.php
@@ -75,6 +75,13 @@ class Emailpost_Controller extends Action_Controller
 		$email_message->load_address();
 		$email_message->load_key($key);
 
+		//Check if it's a DSN
+		//Hopefully, this will eventually DO something but for now
+		//we'll just add it with a more specific error reason
+		if ($email_message->_is_dsn){
+			return pbe_emailError('error_bounced',$email_message);
+		}
+
 		// If the feature is on but the post/pm function is not enabled, just log the message.
 		if (empty($modSettings['pbe_post_enabled']) && empty($modSettings['pbe_pm_enabled']))
 			return pbe_emailError('error_email_notenabled', $email_message);

--- a/sources/subs/EmailParse.class.php
+++ b/sources/subs/EmailParse.class.php
@@ -523,8 +523,7 @@ class Email_Parse
 							//These sections often have extra blank lines, so cannot be counted on to be
 							//fully accessible in ->headers. The "body" of this section contains values
 							//formatted by FIELD: [TYPE;] VALUE
-							$dsn_body = array();
-							$body = (str_replace("\r\n", "\n", $this->_boundary_section[$i]->body));
+							$dsn_body = array();							
 							foreach(explode("\n",str_replace("\r\n", "\n", $this->_boundary_section[$i]->body)) as $l){
 								$field = $type = $val = "";
 								
@@ -538,15 +537,16 @@ class Email_Parse
 							}							
 							switch ($dsn_body['action']['value']){
 								case 'failed':
+								//No Break
 								//Remove this if we don't want to flag delayed delivery addresses as "dirty"
-								//May be caused by temporary net failures, e.g. DNS outage
+								//May be caused by temporary net failures, e.g. DNS outage								
 								case 'delayed':
 									$this->_is_dsn = true;
 									$this->_dsn = array('headers'=>$this->_boundary_section[$i]->headers,
 									'body'=>$dsn_body
 									);
 								default:
-									$this->is_dsn = false;
+									$this->_is_dsn = false;
 							}
 							
 						}

--- a/sources/subs/EmailParse.class.php
+++ b/sources/subs/EmailParse.class.php
@@ -192,7 +192,7 @@ class Email_Parse
 	 * @var string
 	 */
 	private $_header_block = null;
-	
+
 	/**
 	 * Loads an email message from stdin, file or from a supplied string
 	 *
@@ -275,14 +275,14 @@ class Email_Parse
 		// Main, will read, split, parse, decode an email
 		$this->read_data($data, $location);
 		if ($this->raw_message)
-		{			
-			$this->_split_headers();			
-			$this->_parse_headers();			
-			$this->_parse_content_headers();			
+		{
+			$this->_split_headers();
+			$this->_parse_headers();
+			$this->_parse_content_headers();
 			$this->_parse_body($html);
 			$this->load_subject();
 			$this->_is_dsn = $this->_check_dsn();
-		}		
+		}
 	}
 
 	/**
@@ -299,14 +299,14 @@ class Email_Parse
 
 		// Do we even start with a header in this boundary section?
 		if (!preg_match('~^[\w-]+:[ ].*?\r?\n~i', $this->raw_message))
-			return;		
+			return;
 
 		// The header block ends based on condition (1) or (2)
 		if (!preg_match('~^(.*?)\r?\n(?:\r?\n|(?!(\t|[\w-]+:|[ ])))(.*)~s', $this->raw_message, $match))
 			return;
 
 		$this->_header_block = $match[1];
-		$this->body = $match[3];		
+		$this->body = $match[3];
 	}
 
 	/**
@@ -493,13 +493,13 @@ class Email_Parse
 
 				// Some multi-part messages ... are singletons :P
 				if ($this->_boundary_section_count === 1)
-				{					
+				{
 					$this->body = $this->_boundary_section[0]->body;
 					$this->headers['x-parameters'] = $this->_boundary_section[0]->headers['x-parameters'];
 				}
 				// We found multiple sections, lets go through each
 				elseif ($this->_boundary_section_count > 1)
-				{					
+				{
 					$html_ids = array();
 					$text_ids = array();
 					$this->body = '';
@@ -550,7 +550,6 @@ class Email_Parse
 							}
 							
 						}
-						
 
 						// Attachments, we love em
 						if ($this->_boundary_section[$i]->headers['content-disposition'] === 'attachment' || $this->_boundary_section[$i]->headers['content-disposition'] === 'inline' || isset($this->_boundary_section[$i]->headers['content-id']))
@@ -798,7 +797,6 @@ class Email_Parse
 		
 		/** Add non-header-based detection **/
 	}
-	
 
 	/**
 	 * Find the message return_path and well return it
@@ -837,7 +835,6 @@ class Email_Parse
 
 		return $this->subject;
 	}
-
 
 	/**
 	 * Check for the message security key in common headers, in-reply-to and references

--- a/themes/default/languages/english/Maillist.english.php
+++ b/themes/default/languages/english/Maillist.english.php
@@ -41,6 +41,8 @@ $txt['error_in_maintenance_mode_short'] = 'In Maintenance';
 $txt['error_email_notenabled_short'] = 'Not Enabled';
 $txt['error_email_notenabled'] = 'The post by email function was not enabled, the email could not be processed';
 $txt['error_permission'] = 'The poster does not have post by email permissions on this board';
+$txt['error_bounced'] = 'The message was refused by the destination mail server';
+$txt['error_bounced_short'] = 'The message could not be delivered';
 
 // Maillist page items
 $txt['ml_admin_configuration'] = 'Maillist Configuration';


### PR DESCRIPTION
Post-By-Email address detects DSN (bounces), records in failed PBE table with a new, bounce-specific failure case. (Previous req Closed to fix a stupid bug)