### PR TITLE
Envelope fix

### DIFF
--- a/sources/subs/Mail.subs.php
+++ b/sources/subs/Mail.subs.php
@@ -290,7 +290,6 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 		// SMTP protocol it is
 		$mail_result = $mail_result && smtp_mail($to_array, $subject, $message, $headers, $priority, $message_id);
 	
-
 	// Clear out the stat cache.
 	trackStats();
 

--- a/sources/subs/Mail.subs.php
+++ b/sources/subs/Mail.subs.php
@@ -289,7 +289,7 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 	else
 		// SMTP protocol it is
 		$mail_result = $mail_result && smtp_mail($to_array, $subject, $message, $headers, $priority, $message_id);
-	
+
 	// Clear out the stat cache.
 	trackStats();
 

--- a/sources/subs/Mail.subs.php
+++ b/sources/subs/Mail.subs.php
@@ -227,7 +227,7 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 
 	// SMTP or sendmail?
 	if ($use_sendmail)
-	{		
+	{
 		$subject = strtr($subject, array("\r" => '', "\n" => ''));
 		if (!empty($modSettings['mail_strip_carriage']))
 		{
@@ -286,7 +286,8 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 			log_email($sent);
 		}
 	}
-	else// SMTP protocol it is
+	else
+		// SMTP protocol it is
 		$mail_result = $mail_result && smtp_mail($to_array, $subject, $message, $headers, $priority, $message_id);
 	
 

--- a/sources/subs/Mail.subs.php
+++ b/sources/subs/Mail.subs.php
@@ -141,7 +141,8 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 	}
 
 	// Return path, date, mailer
-	$return_path = (!empty($modSettings['maillist_sitename_address']) ? $modSettings['maillist_sitename_address'] : (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'])); //We'll need this later
+	//We'll need this later for the envelope fix, too, so keep it 
+	$return_path = (!empty($modSettings['maillist_sitename_address']) ? $modSettings['maillist_sitename_address'] : (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'])); 
 	$headers .= 'Return-Path: ' . $return_path . $line_break;
 	$headers .= 'Date: ' . gmdate('D, d M Y H:i:s') . ' -0000' . $line_break;
 	$headers .= 'X-Mailer: ELK' . $line_break;
@@ -271,7 +272,8 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 				if (!empty($modSettings['trackStats']))
 					trackStats(array('email' => '+'));
 			}
-			ini_set('sendmail_from', $old_return); //Put it back
+			//Put it back
+			ini_set('sendmail_from', $old_return); 
 			
 			// Wait, wait, I'm still sending here!
 			@set_time_limit(300);


### PR DESCRIPTION
webserver user@host for envelope sender instead of the address
defined in the maillist settings/webmaster adderss. Envelope should
now match the From: address, so DSNs and replies from e.g. gmail
are properly addressed.

The issue did not appear to exist when configured to connect to an
SMTP server.