### PR TITLE
Auto bounce detection

### DIFF
--- a/sources/admin/ManageMaillist.controller.php
+++ b/sources/admin/ManageMaillist.controller.php
@@ -1572,6 +1572,7 @@ class ManageMaillist_Controller extends Action_Controller
 				array('check', 'pbe_pm_enabled'),
 				array('check', 'pbe_no_mod_notices', 'subtext' => $txt['pbe_no_mod_notices_desc'], 'postinput' => $txt['recommended']),
 				array('check', 'pbe_bounce_detect', 'subtext'=>$txt['pbe_bounce_detect_desc'], 'postinput'=>$txt['experimental']),
+				array('check', 'pbe_bounce_record', 'subtext'=>$txt['pbe_bounce_record_desc'], 'postinput'=>$txt['experimental']),
 			array('title', 'maillist_outbound'),
 				array('desc', 'maillist_outbound_desc'),
 				array('check', 'maillist_group_mode'),

--- a/sources/admin/ManageMaillist.controller.php
+++ b/sources/admin/ManageMaillist.controller.php
@@ -1571,6 +1571,7 @@ class ManageMaillist_Controller extends Action_Controller
 				array('check', 'pbe_post_enabled'),
 				array('check', 'pbe_pm_enabled'),
 				array('check', 'pbe_no_mod_notices', 'subtext' => $txt['pbe_no_mod_notices_desc'], 'postinput' => $txt['recommended']),
+				array('check', 'pbe_bounce_detect', 'subtext'=>$txt['pbe_bounce_detect_desc'], 'postinput'=>$txt['experimental']),
 			array('title', 'maillist_outbound'),
 				array('desc', 'maillist_outbound_desc'),
 				array('check', 'maillist_group_mode'),

--- a/sources/controllers/Emailpost.controller.php
+++ b/sources/controllers/Emailpost.controller.php
@@ -71,15 +71,27 @@ class Emailpost_Controller extends Action_Controller
 			return false;
 
 		// Ask for an html version (if available) and some needed details
-		$email_message->read_email(true, $email_message->raw_message);
+		$email_message->read_email(true, $email_message->raw_message);		
 		$email_message->load_address();
 		$email_message->load_key($key);
 
-		//Check if it's a DSN
-		//Hopefully, this will eventually DO something but for now
-		//we'll just add it with a more specific error reason
+		//Check if it's a DSN, and handle it		
 		if ($email_message->_is_dsn){
-			return pbe_emailError('error_bounced',$email_message);
+			if (!empty($modSettings['pbe_bounce_detect'])){
+				pbe_disable_user_notify($email_message);
+				//[TODO] Notify the user				
+				if (!empty($modSettings['pbe_bounce_record'])){
+					//They can record the message anyway, if they so wish
+					return pbe_emailError('error_bounced',$email_message);
+				} 
+				//If they don't wish, then return false like recording the failure
+				//would do
+				return false;
+			} else {
+				//When the auto-disable function is not turned on, record the DSN
+				//In the failed email table for the admins to handle however
+				return pbe_emailError('error_bounced',$email_message);
+			}
 		}
 
 		// If the feature is on but the post/pm function is not enabled, just log the message.
@@ -231,6 +243,13 @@ class Emailpost_Controller extends Action_Controller
 		$email_message->message_type = 'x';
 		$email_message->message_key_id = '';
 		$email_message->message_id = 0;
+		
+		//Check if it's a DSN
+		//Hopefully, this will eventually DO something but for now
+		//we'll just add it with a more specific error reason
+		if ($email_message->_is_dsn){
+			return pbe_emailError('error_bounced',$email_message);
+		}
 
 		// If the feature is on but the post/pm function is not enabled, just log the message.
 		if (empty($modSettings['pbe_post_enabled']))

--- a/sources/controllers/Emailpost.controller.php
+++ b/sources/controllers/Emailpost.controller.php
@@ -71,7 +71,7 @@ class Emailpost_Controller extends Action_Controller
 			return false;
 
 		// Ask for an html version (if available) and some needed details
-		$email_message->read_email(true, $email_message->raw_message);		
+		$email_message->read_email(true, $email_message->raw_message);
 		$email_message->load_address();
 		$email_message->load_key($key);
 
@@ -248,7 +248,21 @@ class Emailpost_Controller extends Action_Controller
 		//Hopefully, this will eventually DO something but for now
 		//we'll just add it with a more specific error reason
 		if ($email_message->_is_dsn){
-			return pbe_emailError('error_bounced',$email_message);
+			if (!empty($modSettings['pbe_bounce_detect'])){
+				pbe_disable_user_notify($email_message);
+				//[TODO] Notify the user				
+				if (!empty($modSettings['pbe_bounce_record'])){
+					//They can record the message anyway, if they so wish
+					return pbe_emailError('error_bounced',$email_message);
+				} 
+				//If they don't wish, then return false like recording the failure
+				//would do
+				return false;
+			} else {
+				//When the auto-disable function is not turned on, record the DSN
+				//In the failed email table for the admins to handle however
+				return pbe_emailError('error_bounced',$email_message);
+			}
 		}
 
 		// If the feature is on but the post/pm function is not enabled, just log the message.

--- a/sources/subs/EmailParse.class.php
+++ b/sources/subs/EmailParse.class.php
@@ -535,12 +535,13 @@ class Email_Parse
 								}																
 								$dsn_body[trim(strtolower($field))] = array('type'=>trim($type), 'value'=>trim($val));								
 							}							
-							switch ($dsn_body['action']['value']){
-								case 'failed':
-								//No Break
-								//Remove this if we don't want to flag delayed delivery addresses as "dirty"
-								//May be caused by temporary net failures, e.g. DNS outage								
+							switch ($dsn_body['action']['value']){								
 								case 'delayed':
+									//Remove this if we don't want to flag delayed delivery addresses as "dirty"
+									//May be caused by temporary net failures, e.g. DNS outage
+									//Lack of break is intentional
+								case 'failed':
+									//The email failed to be delivered.
 									$this->_is_dsn = true;
 									$this->_dsn = array('headers'=>$this->_boundary_section[$i]->headers,
 									'body'=>$dsn_body

--- a/sources/subs/EmailParse.class.php
+++ b/sources/subs/EmailParse.class.php
@@ -540,11 +540,12 @@ class Email_Parse
 								//No Break
 								//Remove this if we don't want to flag delayed delivery addresses as "dirty"
 								//May be caused by temporary net failures, e.g. DNS outage								
-								case 'delayed':
+								case 'delayed':									
 									$this->_is_dsn = true;
 									$this->_dsn = array('headers'=>$this->_boundary_section[$i]->headers,
 									'body'=>$dsn_body
 									);
+									break;
 								default:
 									$this->_is_dsn = false;
 							}

--- a/sources/subs/EmailParse.class.php
+++ b/sources/subs/EmailParse.class.php
@@ -540,7 +540,7 @@ class Email_Parse
 								//No Break
 								//Remove this if we don't want to flag delayed delivery addresses as "dirty"
 								//May be caused by temporary net failures, e.g. DNS outage								
-								case 'delayed':									
+								case 'delayed':
 									$this->_is_dsn = true;
 									$this->_dsn = array('headers'=>$this->_boundary_section[$i]->headers,
 									'body'=>$dsn_body

--- a/sources/subs/Emailpost.subs.php
+++ b/sources/subs/Emailpost.subs.php
@@ -987,6 +987,43 @@ function pbe_prepare_text(&$message, &$subject = '', &$signature = '')
 }
 
 /**
+ * When a DSN (bounce) is received and the feature is enabled, update the settings
+ * For the user in question to disable Board and Post notifications. Do not clear
+ * Notification subscriptions.
+ *
+ * @package Maillist
+ * @param Email_Parse $email_message
+ */
+function pbe_disable_user_notify($email_message){
+	$db = database();
+
+	$email = $email_message->_dsn['body']['original-recipient']['value'];
+	$request = $db->query('', '
+		SELECT
+			id_member
+		FROM {db_prefix}members
+		WHERE email_address = {string:email}
+		LIMIT 1',
+		array('email' => $email)
+		);
+
+	if ($db->num_rows($request) !== 0)
+	{
+		list ($id_member) = $db->fetch_row($request);
+		$db->free_result($request);
+
+		//Once we have the member's ID, we can turn off notifications
+		//by setting notify_regularity->99 ("Never")
+		$db->query('','
+			UPDATE {db_prefix}members
+			SET
+				notify_regularity = 99
+			WHERE id_member = {int:id_member}'
+		,array('id_member'=>$id_member));
+	}
+}
+
+/**
  * Replace full bbc quote tags with an html blockquote version
  *
  * - Callback for pbe_prepare_text

--- a/themes/default/ProfileOptions.template.php
+++ b/themes/default/ProfileOptions.template.php
@@ -751,10 +751,11 @@ function template_action_notification()
 						</dt>
 						<dd>
 							<select name="notify_regularity" id="notify_regularity">
-								<option value="0"', $context['member']['notify_regularity'] == 0 ? ' selected="selected"' : '', '>', $txt['notify_regularity_instant'], '</option>
-								<option value="1"', $context['member']['notify_regularity'] == 1 ? ' selected="selected"' : '', '>', $txt['notify_regularity_first_only'], '</option>
-								<option value="2"', $context['member']['notify_regularity'] == 2 ? ' selected="selected"' : '', '>', $txt['notify_regularity_daily'], '</option>
-								<option value="3"', $context['member']['notify_regularity'] == 3 ? ' selected="selected"' : '', '>', $txt['notify_regularity_weekly'], '</option>
+								<option value="0"',  $context['member']['notify_regularity'] ==  0 ? ' selected="selected"' : '', '>', $txt['notify_regularity_instant'], '</option>
+								<option value="1"',  $context['member']['notify_regularity'] ==  1 ? ' selected="selected"' : '', '>', $txt['notify_regularity_first_only'], '</option>
+								<option value="2"',  $context['member']['notify_regularity'] ==  2 ? ' selected="selected"' : '', '>', $txt['notify_regularity_daily'], '</option>
+								<option value="3"',  $context['member']['notify_regularity'] ==  3 ? ' selected="selected"' : '', '>', $txt['notify_regularity_weekly'], '</option>
+								<option value="99"', $context['member']['notify_regularity'] == 99 ? ' selected="selected"' : '', '>', $txt['notify_regularity_none'], '</option>
 							</select>
 						</dd>
 						<dt>

--- a/themes/default/languages/english/Maillist.english.php
+++ b/themes/default/languages/english/Maillist.english.php
@@ -57,7 +57,11 @@ $txt['pbe_post_enabled'] = 'Allow posting to the forum by Email';
 $txt['pbe_pm_enabled'] = 'Allow replying to PMs by Email';
 $txt['pbe_no_mod_notices'] = 'Turn off moderation notices';
 $txt['pbe_no_mod_notices_desc'] = 'Do not send notifications of moved, locked, deleted, merged, etc.  These consume your email quota with no real purpose';
+$txt['pbe_bounce_detect'] = 'Turn on automatic bounce detection';
+$txt['pbe_bounce_detect_desc'] = 'Attempt to identify mail bounces and disable further notifications';
+
 $txt['saved'] = 'Information Saved';
+
 
 // General Sending Settings
 $txt['maillist_outbound'] = 'General Sending Settings';
@@ -112,6 +116,7 @@ $txt['maillist_newtopic_change'] = 'Allow the starting of a new topic by changin
 $txt['maillist_newtopic_needsapproval'] = 'Require New Topic approval';
 $txt['maillist_newtopic_needsapproval_desc'] = 'Require all new topics sent by email to be approved before they are posted to prevent email spoofing';
 $txt['recommended'] = 'This is recommended';
+$txt['experimental'] = 'This functionality is experimental';
 $txt['receiving_address'] = 'Receiving email addresses';
 $txt['receiving_board'] = 'Board to post new messages to';
 $txt['reply_add_more'] = 'Add another address';

--- a/themes/default/languages/english/Maillist.english.php
+++ b/themes/default/languages/english/Maillist.english.php
@@ -59,6 +59,8 @@ $txt['pbe_no_mod_notices'] = 'Turn off moderation notices';
 $txt['pbe_no_mod_notices_desc'] = 'Do not send notifications of moved, locked, deleted, merged, etc.  These consume your email quota with no real purpose';
 $txt['pbe_bounce_detect'] = 'Turn on automatic bounce detection';
 $txt['pbe_bounce_detect_desc'] = 'Attempt to identify mail bounces and disable further notifications';
+$txt['pbe_bounce_record'] = 'Record bounce messages in failed mail after auto processing';
+$txt['pbe_bounce_record_desc'] = 'Bounce messages will always be recorded if Bounce Detection is disabled';
 
 $txt['saved'] = 'Information Saved';
 

--- a/themes/default/languages/english/Maillist.english.php
+++ b/themes/default/languages/english/Maillist.english.php
@@ -64,7 +64,6 @@ $txt['pbe_bounce_record_desc'] = 'Bounce messages will always be recorded if Bou
 
 $txt['saved'] = 'Information Saved';
 
-
 // General Sending Settings
 $txt['maillist_outbound'] = 'General Sending Settings';
 $txt['maillist_outbound_desc'] = 'Use these settings to modify how outbound emails appear to the user and where a reply will be sent to.  ';

--- a/themes/default/languages/english/Profile.english.php
+++ b/themes/default/languages/english/Profile.english.php
@@ -101,6 +101,7 @@ $txt['notify_settings'] = 'Notification Settings:';
 $txt['notify_save'] = 'Save settings';
 $txt['notify_important_email'] = 'Receive forum newsletters, announcements and important notifications by email.';
 $txt['notify_regularity'] = 'For topics and boards I\'ve requested notification on, notify me';
+$txt['notify_regularity_none'] = "Never";
 $txt['notify_regularity_instant'] = 'Instantly';
 $txt['notify_regularity_first_only'] = 'Instantly - but only for the first unread reply';
 $txt['notify_regularity_daily'] = 'Daily';


### PR DESCRIPTION
Fixes the rebasing issues in #2027 

@Targren Hope you don't mind if I took the liberty of cleaning up the pull request removing all the unrelated commits. ;D


(Take 3)

Implemented new "Never" option for notifications (Magic Number 99)

Implemented code to automatically change notification_regularity to 99
on receipt of a DSN, with options to control the feature.

Outstanding needs:
Non-standard DSNs/bounces detection is still a stub
Member is not yet notified when emails are enabled