### PR TITLE
Encapsulate

### DIFF
--- a/sources/QueryString.php
+++ b/sources/QueryString.php
@@ -44,6 +44,9 @@ function cleanRequest()
 
 	// Parse the $_REQUEST and make sure things like board, topic don't have weird stuff
 	$req->parseRequest();
+
+	// Make the global interface class available
+	require_once(SUBSDIR . '/HttpRequest.class.php');
 }
 
 /**

--- a/sources/admin/AddonSettings.controller.php
+++ b/sources/admin/AddonSettings.controller.php
@@ -42,7 +42,7 @@ class AddonSettings_Controller extends Action_Controller
 	private $_req;
 
 	/**
-	 * Pre Dispatch, called before other methods.  Loads integration hooks
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
 	 */
 	public function pre_dispatch()
 	{

--- a/sources/admin/AddonSettings.controller.php
+++ b/sources/admin/AddonSettings.controller.php
@@ -36,6 +36,20 @@ class AddonSettings_Controller extends Action_Controller
 	protected $_addonSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	private $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads integration hooks
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * This, my friend, is for all the authors of addons out there.
 	 *
 	 * @see Action_Controller::action_index()
@@ -92,7 +106,7 @@ class AddonSettings_Controller extends Action_Controller
 		$config_vars = $this->_addonSettings->settings();
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
@@ -172,16 +186,16 @@ class AddonSettings_Controller extends Action_Controller
 		$context['sub_template'] = 'show_settings';
 
 		// By default do the basic settings.
-		if (isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]))
-			$_REQUEST['sa'] = $_REQUEST['sa'];
+		if (isset($this->_req->query->sa, $subActions[$this->_req->query->sa]))
+			$sa = $this->_req->query->sa;
 		elseif (!empty($defaultAction))
-			$_REQUEST['sa'] = $defaultAction;
+			$sa = $defaultAction;
 		else
 		{
 			$keys = array_keys($subActions);
-			$_REQUEST['sa'] = array_pop($keys);
+			$sa = array_pop($keys);
 		}
 
-		$context['sub_action'] = $_REQUEST['sa'];
+		$context['sub_action'] = $sa;
 	}
 }

--- a/sources/admin/Admin.controller.php
+++ b/sources/admin/Admin.controller.php
@@ -765,7 +765,7 @@ class Admin_Controller extends Action_Controller
 
 		// Setup for the template
 		$context['search_type'] = $subAction;
-		$context['search_term'] = $this->_req->getPost('search_term', 'Util::htmlspecialchars[ENT_QUOTES]');
+		$context['search_term'] = $this->_req->getPost('search_term', 'trim|Util::htmlspecialchars[ENT_QUOTES]');
 		$context['sub_template'] = 'admin_search_results';
 		$context['page_title'] = $txt['admin_search_results'];
 

--- a/sources/admin/Admin.controller.php
+++ b/sources/admin/Admin.controller.php
@@ -29,14 +29,23 @@ if (!defined('ELK'))
  *
  * @package Admin
  */
+
 class Admin_Controller extends Action_Controller
 {
+	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	private $_req;
+
 	/**
 	 * Pre Dispatch, called before other methods.  Loads integration hooks
 	 */
 	public function pre_dispatch()
 	{
 		Hooks::get()->loadIntegrationsSettings();
+
+		$this->_req = HttpReq::instance();
 	}
 
 	/**
@@ -756,7 +765,7 @@ class Admin_Controller extends Action_Controller
 
 		// Setup for the template
 		$context['search_type'] = $subAction;
-		$context['search_term'] = isset($_REQUEST['search_term']) ? Util::htmlspecialchars($_REQUEST['search_term'], ENT_QUOTES) : '';
+		$context['search_term'] = $this->_req->getPost('search_term', 'Util::htmlspecialchars[ENT_QUOTES]');
 		$context['sub_template'] = 'admin_search_results';
 		$context['page_title'] = $txt['admin_search_results'];
 
@@ -936,7 +945,7 @@ class Admin_Controller extends Action_Controller
 		// Clean any admin tokens as well.
 		cleanTokens(false, '-admin');
 
-		if (isset($_GET['redir']) && isset($_SERVER['HTTP_REFERER']))
+		if (isset($this->_req->query->redir, $this->_req->server->HTTP_REFERER))
 			redirectexit($_SERVER['HTTP_REFERER']);
 		else
 			redirectexit();

--- a/sources/admin/Admin.controller.php
+++ b/sources/admin/Admin.controller.php
@@ -40,6 +40,7 @@ class Admin_Controller extends Action_Controller
 
 	/**
 	 * Pre Dispatch, called before other methods.  Loads integration hooks
+	 * and HttpReq instance.
 	 */
 	public function pre_dispatch()
 	{

--- a/sources/admin/Admin.controller.php
+++ b/sources/admin/Admin.controller.php
@@ -770,7 +770,7 @@ class Admin_Controller extends Action_Controller
 		$context['page_title'] = $txt['admin_search_results'];
 
 		// You did remember to enter something to search for, otherwise its easy
-		if (trim($context['search_term']) == '')
+		if ($context['search_term'] === '')
 			$context['search_results'] = array();
 		else
 			$action->dispatch($subAction);

--- a/sources/admin/AdminDebug.controller.php
+++ b/sources/admin/AdminDebug.controller.php
@@ -32,7 +32,7 @@ class AdminDebug_Controller extends Action_Controller
 	private $_req;
 
 	/**
-	 * Pre Dispatch, called before other methods.  Loads integration hooks
+	 * Pre Dispatch, called before other methods.  Loads HttpReq instance.
 	 */
 	public function pre_dispatch()
 	{

--- a/sources/admin/AdminDebug.controller.php
+++ b/sources/admin/AdminDebug.controller.php
@@ -26,6 +26,20 @@ if (!defined('ELK'))
 class AdminDebug_Controller extends Action_Controller
 {
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	private $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads integration hooks
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Main dispatcher.
 	 *
 	 * @see Action_Controller::action_index()
@@ -50,25 +64,28 @@ class AdminDebug_Controller extends Action_Controller
 		global $context, $db_show_debug;
 
 		// We should have debug mode enabled, as well as something to display!
-		if ($db_show_debug !== true || !isset($_SESSION['debug']))
+		if ($db_show_debug !== true || !isset($this->_req->session->debug))
 			Errors::fatal_lang_error('no_access', false);
 
 		// Don't allow except for administrators.
 		isAllowedTo('admin_forum');
 
 		$debug = Debug::get();
+
 		// If we're just hiding/showing, do it now.
-		if (isset($_REQUEST['sa']) && $_REQUEST['sa'] == 'hide')
+		if (isset($this->_req->query->sa) && $this->_req->query->sa === 'hide')
 		{
 			$debug->toggleViewQueries();
 
-			if (strpos($_SESSION['old_url'], 'action=viewquery') !== false)
+			if (strpos($this->_req->session->old_url, 'action=viewquery') !== false)
 				redirectexit();
 			else
-				redirectexit($_SESSION['old_url']);
+				redirectexit($this->_req->session->old_url);
 		}
 
-		$query_id = isset($_REQUEST['qq']) ? (int) $_REQUEST['qq'] - 1 : -1;
+		// Looking at a specific query?
+		$query_id = $this->_req->getQuery('qq', 'intval');
+		$query_id = $query_id === null ? -1 : $query_id - 1;
 
 		// Just to stay on the safe side, better remove any layer and add back only html
 		$layers = Template_Layers::getInstance();

--- a/sources/admin/BadBehavior.controller.php
+++ b/sources/admin/BadBehavior.controller.php
@@ -127,7 +127,7 @@ class BadBehavior_Controller extends Action_Controller
 	 */
 	protected function _prepareMembers()
 	{
-		global $context, $txt;
+		global $context, $txt, $scripturl;
 
 		$members = array();
 		foreach ($context['bb_entries'] as $member)
@@ -232,7 +232,7 @@ class BadBehavior_Controller extends Action_Controller
 
 		if ($redirect === 'delete')
 		{
-			$start = $this->getQuery('start', 'intval', 0);
+			$start = $this->_req->getQuery('start', 'intval', 0);
 
 			// Go back to where we were.
 			redirectexit($redirect_path . ';start=' . $start . (!empty($filter) ? $filter['href'] : ''));

--- a/sources/admin/BadBehavior.controller.php
+++ b/sources/admin/BadBehavior.controller.php
@@ -23,6 +23,20 @@ if (!defined('ELK'))
 class BadBehavior_Controller extends Action_Controller
 {
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	private $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Call the appropriate action method.
 	 */
 	public function action_index()
@@ -57,18 +71,18 @@ class BadBehavior_Controller extends Action_Controller
 
 		// Set up the filtering...
 		$filter = array();
-		if (isset($_GET['value'], $_GET['filter']))
+		if (isset($this->_req->query->value, $this->_req->query->filter))
 			$filter = $this->_setFilter();
 
-		if (empty($filter))
+		if ($filter === false)
 		{
 			// Bad filter or something else going on, back to the start you go
 			unset($_GET['filter'], $_GET['value']);
-			redirectexit('action=admin;area=logs;sa=badbehaviorlog' . (isset($_REQUEST['desc']) ? ';desc' : ''));
+			redirectexit('action=admin;area=logs;sa=badbehaviorlog' . (isset($this->_req->query->desc) ? ';desc' : ''));
 		}
 
 		// Deleting or just doing a little weeding?
-		if (isset($_POST['delall']) || isset($_POST['delete']))
+		if (isset($this->_req->post->delall) || isset($this->_req->post->delete))
 			$this->_action_delete($filter);
 
 		// Just how many entries are there?
@@ -76,13 +90,14 @@ class BadBehavior_Controller extends Action_Controller
 
 		// If this filter turns up empty, just return
 		if (empty($num_errors) && !empty($filter))
-			redirectexit('action=admin;area=logs;sa=badbehaviorlog' . (isset($_REQUEST['desc']) ? ';desc' : ''));
+			redirectexit('action=admin;area=logs;sa=badbehaviorlog' . (isset($this->_req->query->desc) ? ';desc' : ''));
 
 		// Clean up start.
-		$start = (!isset($_GET['start']) || $_GET['start'] < 0) ? 0 : (int) $_GET['start'];
+		$start = $this->_req->getQuery('start', 'intval', 0);
+		$start = $start < 0 ? 0 : $start;
 
 		// Do we want to reverse the listing?
-		$sort = isset($_REQUEST['desc']) ? 'down' : 'up';
+		$sort = isset($this->_req->query->desc) ? 'down' : 'up';
 
 		// Set the page listing up.
 		$context['page_index'] = constructPageIndex($scripturl . '?action=admin;area=logs;sa=badbehaviorlog' . ($sort == 'down' ? ';desc' : '') . (!empty($filter) ? $filter['href'] : ''), $start, $num_errors, $modSettings['defaultMaxMessages']);
@@ -90,26 +105,8 @@ class BadBehavior_Controller extends Action_Controller
 		// Find and sort out the log entries.
 		$context['bb_entries'] = getBadBehaviorLogEntries($start, $modSettings['defaultMaxMessages'], $sort, $filter);
 
-		$members = array();
-		foreach ($context['bb_entries'] as $member)
-			$members[] = $member['member']['id'];
-
-		// Load the member data so we have more information available
-		if (!empty($members))
-		{
-			require_once(SUBSDIR . '/Members.subs.php');
-			$members = getBasicMemberData($members, array('add_guest' => true));
-
-			// Go through each entry and add the member data.
-			foreach ($context['bb_entries'] as $id => $dummy)
-			{
-				$memID = $context['bb_entries'][$id]['member']['id'];
-				$context['bb_entries'][$id]['member']['username'] = $members[$memID]['member_name'];
-				$context['bb_entries'][$id]['member']['name'] = $members[$memID]['real_name'];
-				$context['bb_entries'][$id]['member']['href'] = empty($memID) ? '' : $scripturl . '?action=profile;u=' . $memID;
-				$context['bb_entries'][$id]['member']['link'] = empty($memID) ? $txt['guest_title'] : '<a href="' . $scripturl . '?action=profile;u=' . $memID . '">' . $context['bb_entries'][$id]['member']['name'] . '</a>';
-			}
-		}
+		// Load member data if needed
+		$this->_prepareMembers();
 
 		// Filtering?
 		if (!empty($filter))
@@ -126,6 +123,35 @@ class BadBehavior_Controller extends Action_Controller
 	}
 
 	/**
+	 * Loads basic member data for any members that are in the log
+	 */
+	protected function _prepareMembers()
+	{
+		global $context, $txt;
+
+		$members = array();
+		foreach ($context['bb_entries'] as $member)
+			$members[] = $member['member']['id'];
+
+		// Load any member data so we have more information available
+		if (!empty($members))
+		{
+			require_once(SUBSDIR . '/Members.subs.php');
+			$members = getBasicMemberData($members, array('add_guest' => true));
+
+			// Go through each entry and add the member data.
+			foreach ($context['bb_entries'] as $id => $dummy)
+			{
+				$memID = $context['bb_entries'][$id]['member']['id'];
+				$context['bb_entries'][$id]['member']['username'] = $members[$memID]['member_name'];
+				$context['bb_entries'][$id]['member']['name'] = $members[$memID]['real_name'];
+				$context['bb_entries'][$id]['member']['href'] = empty($memID) ? '' : $scripturl . '?action=profile;u=' . $memID;
+				$context['bb_entries'][$id]['member']['link'] = empty($memID) ? $txt['guest_title'] : '<a href="' . $scripturl . '?action=profile;u=' . $memID . '">' . $context['bb_entries'][$id]['member']['name'] . '</a>';
+			}
+		}
+	}
+
+	/**
 	 * Prepares the filter index of the $context variable
 	 *
 	 * @param string[] $filter - an array describing the current filter
@@ -137,23 +163,23 @@ class BadBehavior_Controller extends Action_Controller
 		$context['filter'] = $filter;
 
 		// Set the filtering context.
-		if ($filter['variable'] === 'id_member')
+		switch ($filter['variable'])
 		{
-			$id = $filter['value']['sql'];
-			loadMemberData($id, false, 'minimal');
-			$context['filter']['value']['html'] = '<a href="' . $scripturl . '?action=profile;u=' . $id . '">' . $user_profile[$id]['real_name'] . '</a>';
+			case 'id_member':
+				$id = $filter['value']['sql'];
+				loadMemberData($id, false, 'minimal');
+				$context['filter']['value']['html'] = '<a href="' . $scripturl . '?action=profile;u=' . $id . '">' . $user_profile[$id]['real_name'] . '</a>';
+				break;
+			case 'url':
+				$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars((substr($filter['value']['sql'], 0, 1) === '?' ? $scripturl : '') . $filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array('\_' => '_')) . '\'';
+				break;
+			case 'headers':
+				$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars($filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array("\n" => '<br />', '&lt;br /&gt;' => '<br />', "\t" => '&nbsp;&nbsp;&nbsp;', '\_' => '_', '\\%' => '%', '\\\\' => '\\')) . '\'';
+				$context['filter']['value']['html'] = preg_replace('~&amp;lt;span class=&amp;quot;remove&amp;quot;&amp;gt;(.+?)&amp;lt;/span&amp;gt;~', '$1', $context['filter']['value']['html']);
+				break;
+			default:
+				$context['filter']['value']['html'] = $filter['value']['sql'];
 		}
-		elseif ($filter['variable'] === 'url')
-		{
-			$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars((substr($filter['value']['sql'], 0, 1) === '?' ? $scripturl : '') . $filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array('\_' => '_')) . '\'';
-		}
-		elseif ($filter['variable'] === 'headers')
-		{
-			$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars($filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array("\n" => '<br />', '&lt;br /&gt;' => '<br />', "\t" => '&nbsp;&nbsp;&nbsp;', '\_' => '_', '\\%' => '%', '\\\\' => '\\')) . '\'';
-			$context['filter']['value']['html'] = preg_replace('~&amp;lt;span class=&amp;quot;remove&amp;quot;&amp;gt;(.+?)&amp;lt;/span&amp;gt;~', '$1', $context['filter']['value']['html']);
-		}
-		else
-			$context['filter']['value']['html'] = $filter['value']['sql'];
 	}
 
 	/**
@@ -175,16 +201,16 @@ class BadBehavior_Controller extends Action_Controller
 			'user_agent' => $txt['badbehaviorlog_agent'],
 		);
 
-		if (!isset($filters[$_GET['filter']]))
-			return array();
+		if (!isset($filters[$this->_req->query->filter]))
+			return false;
 
 		return array(
-			'variable' => $_GET['filter'] == 'useragent' ? 'user_agent' : $_GET['filter'],
+			'variable' => $this->_req->query->filter == 'useragent' ? 'user_agent' : $this->_req->query->filter,
 			'value' => array(
-				'sql' => in_array($_GET['filter'], array('request_uri', 'user_agent')) ? base64_decode(strtr($_GET['value'], array(' ' => '+'))) : $db->escape_wildcard_string($_GET['value']),
+				'sql' => in_array($this->_req->query->filter, array('request_uri', 'user_agent')) ? base64_decode(strtr($this->_req->query->value, array(' ' => '+'))) : $db->escape_wildcard_string($this->_req->query->value),
 			),
-			'href' => ';filter=' . $_GET['filter'] . ';value=' . $_GET['value'],
-			'entity' => $filters[$_GET['filter']]
+			'href' => ';filter=' . $this->_req->query->filter . ';value=' . $this->_req->query->value,
+			'entity' => $filters[$this->_req->query->filter]
 		);
 	}
 
@@ -195,21 +221,22 @@ class BadBehavior_Controller extends Action_Controller
 	 */
 	protected function _action_delete($filter)
 	{
-		$type = isset($_POST['delall']) ? 'delall' : 'delete';
+		$type = isset($this->_req->post->delall) ? 'delall' : 'delete';
+
 		// Make sure the session exists and the token is correct
 		checkSession();
 		validateToken('admin-bbl');
 
 		$redirect = deleteBadBehavior($type, $filter);
-		$redirect_path = 'action=admin;area=logs;sa=badbehaviorlog' . (isset($_REQUEST['desc']) ? ';desc' : '');
+		$redirect_path = 'action=admin;area=logs;sa=badbehaviorlog' . (isset($this->_req->query->desc) ? ';desc' : '');
 
 		if ($redirect === 'delete')
 		{
-			$start = isset($_REQUEST['start']) ? (int) $_REQUEST['start'] : 0;
+			$start = $this->getQuery('start', 'intval', 0);
+
 			// Go back to where we were.
 			redirectexit($redirect_path . ';start=' . $start . (!empty($filter) ? $filter['href'] : ''));
 		}
 		redirectexit($redirect_path);
 	}
-
 }

--- a/sources/admin/CoreFeatures.controller.php
+++ b/sources/admin/CoreFeatures.controller.php
@@ -88,7 +88,7 @@ class CoreFeatures_Controller extends Action_Controller
 		{
 			checkSession();
 
-			if (isset($this->_req->get->xml))
+			if (isset($this->_req->query->xml))
 			{
 				$tokenValidation = validateToken('admin-core', 'post', false);
 

--- a/sources/admin/CoreFeatures.controller.php
+++ b/sources/admin/CoreFeatures.controller.php
@@ -33,6 +33,20 @@ if (!defined('ELK'))
 class CoreFeatures_Controller extends Action_Controller
 {
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	private $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Default handler.
 	 *
 	 * @see Action_Controller::action_index()
@@ -70,11 +84,11 @@ class CoreFeatures_Controller extends Action_Controller
 		$this->loadGeneralSettingParameters();
 
 		// Are we saving?
-		if (isset($_POST['save']))
+		if (isset($this->_req->post->save))
 		{
 			checkSession();
 
-			if (isset($_GET['xml']))
+			if (isset($this->_req->get->xml))
 			{
 				$tokenValidation = validateToken('admin-core', 'post', false);
 
@@ -86,7 +100,7 @@ class CoreFeatures_Controller extends Action_Controller
 
 			$this->_save_core_features($core_features);
 
-			if (!isset($_REQUEST['xml']))
+			if (!isset($this->_req->request->xml))
 				redirectexit('action=admin;area=corefeatures;' . $context['session_var'] . '=' . $context['session_id']);
 		}
 
@@ -102,7 +116,7 @@ class CoreFeatures_Controller extends Action_Controller
 			updateSettings(array('admin_features' => ''));
 
 		// sub_template is already generic_xml and the token is created somewhere else
-		if (isset($_REQUEST['xml']))
+		if (isset($this->_req->request->xml))
 			return;
 
 		$context['sub_template'] = 'core_features';
@@ -362,12 +376,15 @@ class CoreFeatures_Controller extends Action_Controller
 		$context['sub_template'] = 'show_settings';
 
 		// By default do the basic settings.
-		if (isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]))
-			$context['sub_action'] = $_REQUEST['sa'];
+		if (isset($this->_req->request->sa, $subActions[$this->_req->request->sa]))
+			$context['sub_action'] = $this->_req->request->sa;
 		elseif (!empty($defaultAction))
 			$context['sub_action'] = $defaultAction;
 		else
-			$context['sub_action'] = array_pop($temp = array_keys($subActions));
+		{
+			$temp = array_keys($subActions);
+			$context['sub_action'] = array_pop($temp);
+		}
 	}
 
 	/**
@@ -385,8 +402,10 @@ class CoreFeatures_Controller extends Action_Controller
 		// Cycle each feature and change things as required!
 		foreach ($core_features as $id => $feature)
 		{
+			$feature_id = $this->_req->getPost('feature_' . $id);
+
 			// Enabled?
-			if (!empty($_POST['feature_' . $id]))
+			if (!empty($feature_id))
 				$setting_changes['admin_features'][] = $id;
 
 			// Setting values to change?
@@ -394,15 +413,15 @@ class CoreFeatures_Controller extends Action_Controller
 			{
 				foreach ($feature['settings'] as $key => $value)
 				{
-					if (empty($_POST['feature_' . $id]) || (!empty($_POST['feature_' . $id]) && ($value < 2 || empty($modSettings[$key]))))
-						$setting_changes[$key] = !empty($_POST['feature_' . $id]) ? $value : !$value;
+					if (empty($feature_id) || (!empty($feature_id) && ($value < 2 || empty($modSettings[$key]))))
+						$setting_changes[$key] = !empty($feature_id) ? $value : !$value;
 				}
 			}
 
 			// Is there a call back for settings?
 			if (isset($feature['setting_callback']))
 			{
-				$returned_settings = $feature['setting_callback'](!empty($_POST['feature_' . $id]));
+				$returned_settings = $feature['setting_callback'](!empty($feature_id));
 				if (!empty($returned_settings))
 					$setting_changes = array_merge($setting_changes, $returned_settings);
 			}

--- a/sources/admin/CoreFeatures.controller.php
+++ b/sources/admin/CoreFeatures.controller.php
@@ -100,7 +100,7 @@ class CoreFeatures_Controller extends Action_Controller
 
 			$this->_save_core_features($core_features);
 
-			if (!isset($this->_req->request->xml))
+			if (!isset($this->_req->query->xml))
 				redirectexit('action=admin;area=corefeatures;' . $context['session_var'] . '=' . $context['session_id']);
 		}
 
@@ -116,7 +116,7 @@ class CoreFeatures_Controller extends Action_Controller
 			updateSettings(array('admin_features' => ''));
 
 		// sub_template is already generic_xml and the token is created somewhere else
-		if (isset($this->_req->request->xml))
+		if (isset($this->_req->query->xml))
 			return;
 
 		$context['sub_template'] = 'core_features';
@@ -376,8 +376,8 @@ class CoreFeatures_Controller extends Action_Controller
 		$context['sub_template'] = 'show_settings';
 
 		// By default do the basic settings.
-		if (isset($this->_req->request->sa, $subActions[$this->_req->request->sa]))
-			$context['sub_action'] = $this->_req->request->sa;
+		if (isset($this->_req->query->sa, $subActions[$this->_req->query->sa]))
+			$context['sub_action'] = $this->_req->query->sa;
 		elseif (!empty($defaultAction))
 			$context['sub_action'] = $defaultAction;
 		else

--- a/sources/admin/Maintenance.controller.php
+++ b/sources/admin/Maintenance.controller.php
@@ -29,6 +29,20 @@ if (!defined('ELK'))
 class Maintenance_Controller extends Action_Controller
 {
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Main dispatcher, the maintenance access point.
 	 *
 	 * What it does:
@@ -120,8 +134,8 @@ class Maintenance_Controller extends Action_Controller
 		$subAction = $action->initialize($subActions, 'routine');
 
 		// Doing something special, does it exist?
-		if (isset($_REQUEST['activity']) && isset($subActions[$subAction]['activities'][$_REQUEST['activity']]))
-			$activity = $_REQUEST['activity'];
+		if (isset($this->_req->request->activity, $subActions[$subAction]['activities'][$this->_req->request->activity]))
+			$activity = $this->_req->request->activity;
 
 		// Set a few things.
 		$context[$context['admin_menu_name']]['current_subsection'] = $subAction;
@@ -243,7 +257,7 @@ class Maintenance_Controller extends Action_Controller
 	{
 		global $context, $txt, $scripturl;
 
-		if (isset($_GET['done']) && $_GET['done'] == 'recount')
+		if ($this->_req->getQuery('done', 'trim|strval') === 'recount')
 			$context['maintenance_finished'] = $txt['maintain_recount'];
 
 		// set up the sub-template
@@ -316,7 +330,7 @@ class Maintenance_Controller extends Action_Controller
 		$context['membergroups'] = getBasicMembergroupData(array('all'));
 
 		// Show that we completed this action
-		if (isset($_REQUEST['done']) && $_REQUEST['done'] == 'recountposts')
+		if ($this->_req->getQuery('done', 'strval') === 'recountposts')
 			$context['maintenance_finished'] = array(
 				'errors' => array(sprintf($txt['maintain_done'], $txt['maintain_recountposts'])),
 			);
@@ -376,11 +390,11 @@ class Maintenance_Controller extends Action_Controller
 
 		call_integration_hook('integrate_topics_maintenance', array(&$context['topics_actions']));
 
-		if (isset($_GET['done']) && $_GET['done'] == 'purgeold')
+		if ($this->_req->getQuery('done', 'strval') === 'purgeold')
 			$context['maintenance_finished'] = array(
 				'errors' => array(sprintf($txt['maintain_done'], $txt['maintain_old'])),
 			);
-		elseif (isset($_GET['done']) && $_GET['done'] == 'massmove')
+		elseif ($this->_req->getQuery('done', 'strval') === 'massmove')
 			$context['maintenance_finished'] = array(
 				'errors' => array(sprintf($txt['maintain_done'], $txt['move_topics_maintenance'])),
 			);
@@ -488,7 +502,7 @@ class Maintenance_Controller extends Action_Controller
 
 		$context['convert_to'] = $body_type == 'text' ? 'mediumtext' : 'text';
 
-		if ($body_type === 'text' || ($body_type !== 'text' && isset($_POST['do_conversion'])))
+		if ($body_type === 'text' || ($body_type !== 'text' && isset($this->_req->post->do_conversion)))
 		{
 			checkSession();
 			validateToken('admin-maint');
@@ -511,11 +525,11 @@ class Maintenance_Controller extends Action_Controller
 
 			return;
 		}
-		elseif ($body_type !== 'text' && (!isset($_POST['do_conversion']) || isset($_POST['cont'])))
+		elseif ($body_type !== 'text' && (!isset($this->_req->post->do_conversion) || isset($this->_req->post->cont)))
 		{
 			checkSession();
 
-			if (empty($_REQUEST['start']))
+			if (empty($this->_req->request->start))
 				validateToken('admin-maint');
 			else
 				validateToken('admin-convertMsg');
@@ -525,18 +539,19 @@ class Maintenance_Controller extends Action_Controller
 			$context['continue_countdown'] = 3;
 			$context['sub_template'] = 'not_done';
 			$increment = 500;
-			$id_msg_exceeding = isset($_POST['id_msg_exceeding']) ? explode(',', $_POST['id_msg_exceeding']) : array();
+			$id_msg_exceeding = isset($this->_req->post->id_msg_exceeding) ? explode(',', $this->_req->post->id_msg_exceeding) : array();
 
 			$max_msgs = countMessages();
+			$start = $this->_req->query->start;
 
 			// Try for as much time as possible.
 			setTimeLimit(600);
 
-			while ($_REQUEST['start'] < $max_msgs)
+			while ($start < $max_msgs)
 			{
-				$id_msg_exceeding = detectExceedingMessages($_REQUEST['start'], $increment);
+				$id_msg_exceeding = detectExceedingMessages($start, $increment);
 
-				$_REQUEST['start'] += $increment;
+				$start += $increment;
 
 				if (microtime(true) - $time_start > 3)
 				{
@@ -545,8 +560,8 @@ class Maintenance_Controller extends Action_Controller
 						<input type="hidden" name="' . $context['admin-convertMsg_token_var'] . '" value="' . $context['admin-convertMsg_token'] . '" />
 						<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />
 						<input type="hidden" name="id_msg_exceeding" value="' . implode(',', $id_msg_exceeding) . '" />';
-					$context['continue_get_data'] = '?action=admin;area=maintain;sa=database;activity=convertmsgbody;start=' . $_REQUEST['start'];
-					$context['continue_percent'] = round(100 * $_REQUEST['start'] / $max_msgs);
+					$context['continue_get_data'] = '?action=admin;area=maintain;sa=database;activity=convertmsgbody;start=' . $start;
+					$context['continue_percent'] = round(100 * $start / $max_msgs);
 					$context['not_done_title'] = $txt['not_done_title'] . ' (' . $context['continue_percent'] . '%)';
 
 					return;
@@ -656,7 +671,7 @@ class Maintenance_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Maintenance.subs.php');
 
 		// Validate the request or the loop
-		if (!isset($_REQUEST['step']))
+		if (!isset($this->_req->query->step))
 			validateToken('admin-maint');
 		else
 			validateToken('admin-boardrecount');
@@ -671,200 +686,165 @@ class Maintenance_Controller extends Action_Controller
 		setTimeLimit(600);
 
 		// Step the number of topics at a time so things don't time out...
-		$max_topics = getMaxTopicID();
+		$this->max_topics = getMaxTopicID();
+		$this->increment = min(max(50, ceil($this->max_topics / 4)), 2000);
 
-		$increment = min(max(50, ceil($max_topics / 4)), 2000);
-		if (empty($_REQUEST['start']))
-			$_REQUEST['start'] = 0;
+		// An 8 step process, should be 12 for the admin
+		$this->total_steps = 8;
+		$this->start = $this->_req->getQuery('start', 'inval', 0);
+		$this->step = $this->_req->getQuery('step', 'intval', 0);
 
-		$total_steps = 8;
-
-		// Get each topic with a wrong reply count and fix it - let's just do some at a time, though.
-		if (empty($_REQUEST['step']))
+		// Get each topic with a wrong reply count and fix it
+		if (empty($this->step))
 		{
-			$_REQUEST['step'] = 0;
-
-			while ($_REQUEST['start'] < $max_topics)
+			// let's just do some at a time, though.
+			while ($this->start < $this->max_topics)
 			{
-				recountApprovedMessages($_REQUEST['start'], $increment);
-				recountUnapprovedMessages($_REQUEST['start'], $increment);
-
-				$_REQUEST['start'] += $increment;
+				var_dump($this->start, $this->increment);
+				recountApprovedMessages($this->start, $this->increment);
+				recountUnapprovedMessages($this->start, $this->increment);
+				$this->start += $this->increment;
 
 				if (microtime(true) - $time_start > 3)
 				{
-					createToken('admin-boardrecount');
-					$context['continue_post_data'] = '
-						<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '" />
-						<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />';
-					$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=0;start=' . $_REQUEST['start'];
-					$context['continue_percent'] = round((100 * $_REQUEST['start'] / $max_topics) / $total_steps);
-					$context['not_done_title'] = $txt['not_done_title'] . ' (' . $context['continue_percent'] . '%)';
-
+					$percent = round((100 * $this->start / $this->max_topics) / $this->total_steps);
+					$this->_buildContinue($percent, 0);
 					return;
 				}
 			}
 
-			$_REQUEST['start'] = 0;
+			// Done with step 0, reset start for the next one
+			$this->start = 0;
 		}
 
 		// Update the post count of each board.
-		if ($_REQUEST['step'] <= 1)
+		if ($this->step <= 1)
 		{
-			if (empty($_REQUEST['start']))
+			if (empty($this->start))
 				resetBoardsCounter('num_posts');
 
-			while ($_REQUEST['start'] < $max_topics)
+			while ($this->start < $this->max_topics)
 			{
 				// Recount the posts
-				updateBoardsCounter('posts', $_REQUEST['start'], $increment);
-				$_REQUEST['start'] += $increment;
+				updateBoardsCounter('posts', $this->start, $this->increment);
+				$this->start += $this->increment;
 
 				if (microtime(true) - $time_start > 3)
 				{
-					createToken('admin-boardrecount');
-					$context['continue_post_data'] = '
-						<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '" />
-						<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />';
-					$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=1;start=' . $_REQUEST['start'];
-					$context['continue_percent'] = round((200 + 100 * $_REQUEST['start'] / $max_topics) / $total_steps);
-					$context['not_done_title'] = $txt['not_done_title'] . ' (' . $context['continue_percent'] . '%)';
-
+					$percent = round((200 + 100 * $this->start / $this->max_topics) / $this->total_steps);
+					$this->_buildContinue($percent, 1);
 					return;
 				}
 			}
 
-			$_REQUEST['start'] = 0;
+			// Done with step 1, reset start for the next one
+			$this->start = 0;
 		}
 
 		// Update the topic count of each board.
-		if ($_REQUEST['step'] <= 2)
+		if ($this->step <= 2)
 		{
-			if (empty($_REQUEST['start']))
+			if (empty($this->start))
 				resetBoardsCounter('num_topics');
 
-			while ($_REQUEST['start'] < $max_topics)
+			while ($this->start < $this->max_topics)
 			{
-				updateBoardsCounter('topics', $_REQUEST['start'], $increment);
-				$_REQUEST['start'] += $increment;
+				updateBoardsCounter('topics', $this->start, $this->increment);
+				$this->start += $this->increment;
 
 				if (microtime(true) - $time_start > 3)
 				{
-					createToken('admin-boardrecount');
-					$context['continue_post_data'] = '
-						<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '" />
-						<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />';
-					$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=2;start=' . $_REQUEST['start'];
-					$context['continue_percent'] = round((300 + 100 * $_REQUEST['start'] / $max_topics) / $total_steps);
-					$context['not_done_title'] = $txt['not_done_title'] . ' (' . $context['continue_percent'] . '%)';
-
+					$percent = round((300 + 100 * $this->start / $this->max_topics) / $this->total_steps);
+					$this->_buildContinue($percent, 2);
 					return;
 				}
 			}
 
-			$_REQUEST['start'] = 0;
+			// Done with step 2, reset start for the next one
+			$this->start = 0;
 		}
 
 		// Update the unapproved post count of each board.
-		if ($_REQUEST['step'] <= 3)
+		if ($this->step <= 3)
 		{
-			if (empty($_REQUEST['start']))
+			if (empty($this->start))
 				resetBoardsCounter('unapproved_posts');
 
-			while ($_REQUEST['start'] < $max_topics)
+			while ($this->start < $this->max_topics)
 			{
-				updateBoardsCounter('unapproved_posts', $_REQUEST['start'], $increment);
-
-				$_REQUEST['start'] += $increment;
+				updateBoardsCounter('unapproved_posts', $this->start, $this->increment);
+				$this->start += $this->increment;
 
 				if (microtime(true) - $time_start > 3)
 				{
-					createToken('admin-boardrecount');
-					$context['continue_post_data'] = '
-						<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '" />
-						<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />';
-					$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=3;start=' . $_REQUEST['start'];
-					$context['continue_percent'] = round((400 + 100 * $_REQUEST['start'] / $max_topics) / $total_steps);
-					$context['not_done_title'] = $txt['not_done_title'] . ' (' . $context['continue_percent'] . '%)';
-
+					$percent = round((400 + 100 * $this->start / $this->max_topics) / $this->total_steps);
+					$this->_buildContinue($percent, 3);
 					return;
 				}
 			}
 
-			$_REQUEST['start'] = 0;
+			// Done with step 3, reset start for the next one
+			$this->start = 0;
 		}
 
 		// Update the unapproved topic count of each board.
-		if ($_REQUEST['step'] <= 4)
+		if ($this->step <= 4)
 		{
-			if (empty($_REQUEST['start']))
+			if (empty($this->start))
 				resetBoardsCounter('unapproved_topics');
 
-			while ($_REQUEST['start'] < $max_topics)
+			while ($this->start < $this->max_topics)
 			{
-				updateBoardsCounter('unapproved_topics', $_REQUEST['start'], $increment);
-				$_REQUEST['start'] += $increment;
+				updateBoardsCounter('unapproved_topics', $this->start, $this->increment);
+				$this->start += $this->increment;
 
 				if (microtime(true) - $time_start > 3)
 				{
-					createToken('admin-boardrecount');
-					$context['continue_post_data'] = '
-						<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '" />
-						<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />';
-					$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=4;start=' . $_REQUEST['start'];
-					$context['continue_percent'] = round((500 + 100 * $_REQUEST['start'] / $max_topics) / $total_steps);
-					$context['not_done_title'] = $txt['not_done_title'] . ' (' . $context['continue_percent'] . '%)';
-
+					$percent = round((500 + 100 * $this->start / $this->max_topics) / $this->total_steps);
+					$this->_buildContinue($percent, 4);
 					return;
 				}
 			}
 
-			$_REQUEST['start'] = 0;
+			// Done with step 4, reset start for the next one
+			$this->start = 0;
 		}
 
 		// Get all members with wrong number of personal messages.
-		if ($_REQUEST['step'] <= 5)
+		if ($this->step <= 5)
 		{
 			updatePersonalMessagesCounter();
 
 			if (microtime(true) - $time_start > 3)
 			{
-				createToken('admin-boardrecount');
-				$context['continue_post_data'] = '
-					<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '" />
-					<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />';
-				$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=6;start=0';
-				$context['continue_percent'] = round(700 / $total_steps);
-				$context['not_done_title'] = $txt['not_done_title'] . ' (' . $context['continue_percent'] . '%)';
-
+				$this->start = 0;
+				$percent = round(700 / $total_steps);
+				$this->_buildContinue($percent, 6);
 				return;
 			}
+
+			// Done with step 5, reset start for the next one
+			$this->start = 0;
 		}
 
 		// Any messages pointing to the wrong board?
-		if ($_REQUEST['step'] <= 6)
+		if ($this->step <= 6)
 		{
-			while ($_REQUEST['start'] < $modSettings['maxMsgID'])
+			while ($this->start < $modSettings['maxMsgID'])
 			{
-				updateMessagesBoardID($_REQUEST['start'], $increment);
-
-				$_REQUEST['start'] += $increment;
+				updateMessagesBoardID($this->_req->request->start, $this->increment);
+				$this->start += $this->increment;
 
 				if (microtime(true) - $time_start > 3)
 				{
-					createToken('admin-boardrecount');
-					$context['continue_post_data'] = '
-						<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '" />
-						<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />';
-					$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=6;start=' . $_REQUEST['start'];
-					$context['continue_percent'] = round((700 + 100 * $_REQUEST['start'] / $modSettings['maxMsgID']) / $total_steps);
-					$context['not_done_title'] = $txt['not_done_title'] . ' (' . $context['continue_percent'] . '%)';
-
+					$percent = round((700 + 100 * $this->start / $modSettings['maxMsgID']) / $total_steps);
+					$this->_buildContinue($percent, 6);
 					return;
 				}
 			}
 
-			$_REQUEST['start'] = 0;
+			// Done with step 6, reset start for the next one
+			$this->start = 0;
 		}
 
 		updateBoardsLastMessage();
@@ -881,7 +861,29 @@ class Maintenance_Controller extends Action_Controller
 		require_once(SUBSDIR . '/ScheduledTasks.subs.php');
 		calculateNextTrigger();
 
+		// Ta-da
 		redirectexit('action=admin;area=maintain;sa=routine;done=recount');
+	}
+
+	/**
+	 * Helper function for teh recount process, build the continue values for
+	 * the template
+	 *
+	 * @param int $percent percent done
+	 * @param int $step step we are on
+	 */
+	private function _buildContinue($percent, $step)
+	{
+		global $context, $txt;
+
+		createToken('admin-boardrecount');
+
+		$context['continue_post_data'] = '
+			<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '" />
+			<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />';
+		$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=' . $step . ';start=' . $this->start;
+		$context['continue_percent'] = $percent;
+		$context['not_done_title'] = $txt['not_done_title'] . ' (' . $context['continue_percent'] . '%)';
 	}
 
 	/**
@@ -930,8 +932,6 @@ class Maintenance_Controller extends Action_Controller
 
 		$context['sub_template'] = 'view_versions';
 		$context['page_title'] = $txt['admin_version_check'];
-		// @deprecated since 1.0 - remember to remove from 1.1 this is here just to avoid errors from not using upgrade.php
-		$context['detailed_version_url'] = !empty($modSettings['detailed-version.js']) ? $modSettings['detailed-version.js'] : 'https://elkarte.github.io/Elkarte/site/detailed-version.js';
 	}
 
 	/**
@@ -946,14 +946,17 @@ class Maintenance_Controller extends Action_Controller
 		$validator = new Data_Validator();
 		$validator->sanitation_rules(array('posts' => 'empty', 'type' => 'trim', 'from_email' => 'trim', 'from_name' => 'trim', 'to' => 'trim'));
 		$validator->validation_rules(array('from_email' => 'valid_email', 'from_name' => 'required', 'to' => 'required', 'type' => 'contains[name,email]'));
-		$validator->validate($_POST);
+		$validator->validate($this->_req->post);
+
+		// Fetch the Mr. Clean values
+		$our_post = array_replace((array) $this->_req->post, $validator->validation_data());
 
 		// Do we have a valid set of options to continue?
-		if (($validator->type === 'name' && !empty($validator->from_name)) || ($validator->type === 'email' && !$validator->validation_errors('from_email')))
+		if (($our_post['type'] === 'name' && !empty($our_post['from_name'])) || ($our_post['type'] === 'email' && !$validator->validation_errors('from_email')))
 		{
 			// Find the member.
 			require_once(SUBSDIR . '/Auth.subs.php');
-			$members = findMembers($validator->to);
+			$members = findMembers($our_post['to']);
 
 			// No members, no further
 			if (empty($members))
@@ -962,12 +965,12 @@ class Maintenance_Controller extends Action_Controller
 			$memID = array_shift($members);
 			$memID = $memID['id'];
 
-			$email = $validator->type == 'email' ? $validator->from_email : '';
-			$membername = $validator->type == 'name' ? $validator->from_name : '';
+			$email = $our_post['type'] == 'email' ? $our_post['from_email'] : '';
+			$membername = $our_post['type'] == 'name' ? $our_post['from_name'] : '';
 
 			// Now call the reattribute function.
 			require_once(SUBSDIR . '/Members.subs.php');
-			reattributePosts($memID, $email, $membername, !$validator->posts);
+			reattributePosts($memID, $email, $membername, !$our_post['posts']);
 
 			$context['maintenance_finished'] = array(
 				'errors' => array(sprintf($txt['maintain_done'], $txt['maintain_reattribute_posts'])),
@@ -976,7 +979,7 @@ class Maintenance_Controller extends Action_Controller
 		else
 		{
 			// Show them the correct error
-			if ($validator->type === 'name' && empty($validator->from_name))
+			if ($our_post['type'] === 'name' && empty($our_post['from_name']))
 				$error = $validator->validation_errors(array('from_name', 'to'));
 			else
 				$error = $validator->validation_errors(array('from_email', 'to'));
@@ -1010,13 +1013,13 @@ class Maintenance_Controller extends Action_Controller
 		{
 			require_once(SUBSDIR . '/FtpConnection.class.php');
 
-			$ftp = new Ftp_Connection($_POST['ftp_server'], $_POST['ftp_port'],$_POST['ftp_username'], $_POST['ftp_password']);
+			$ftp = new Ftp_Connection($this->_req->post->ftp_server, $this->_req->post->ftp_port, $this->_req->post->ftp_username, $this->_req->post->ftp_password);
 
 			if ($ftp->error === false)
 			{
 				// I know, I know... but a lot of people want to type /home/xyz/... which is wrong, but logical.
-				if (!$ftp->chdir($_POST['ftp_path']))
-					$ftp->chdir(preg_replace('~^/home[2]?/[^/]+?~', '', $_POST['ftp_path']));
+				if (!$ftp->chdir($this->_req->post->ftp_path))
+					$ftp->chdir(preg_replace('~^/home[2]?/[^/]+?~', '', $this->_req->post->ftp_path));
 			}
 
 			// If we had an error...
@@ -1028,10 +1031,10 @@ class Maintenance_Controller extends Action_Controller
 				// Fill the boxes for a FTP connection with data from the previous attempt
 				$context['package_ftp'] = array(
 					'form_elements_only' => 1,
-					'server' => $_POST['ftp_server'],
-					'port' => $_POST['ftp_port'],
-					'username' => $_POST['ftp_username'],
-					'path' => $_POST['ftp_path'],
+					'server' => $this->_req->post->ftp_server,
+					'port' => $this->_req->post->ftp_port,
+					'username' => $this->_req->post->ftp_username,
+					'path' => $this->_req->post->ftp_path,
 					'error' => empty($ftp_error) ? null : $ftp_error,
 				);
 
@@ -1066,17 +1069,20 @@ class Maintenance_Controller extends Action_Controller
 		$validator->validation_rules(array('maxdays' => 'required', 'groups' => 'isarray', 'del_type' => 'required'));
 
 		// Validator says, you can pass or not
-		if ($validator->validate($_POST))
+		if ($validator->validate($this->_req->post))
 		{
+			// Get the clean data
+			$our_post = array_replace((array) $this->_req->post, $validator->validation_data());
+
 			require_once(SUBSDIR . '/Maintenance.subs.php');
 			require_once(SUBSDIR . '/Members.subs.php');
 
 			$groups = array();
-			foreach ($validator->groups as $id => $dummy)
+			foreach ($our_post['groups'] as $id => $dummy)
 				$groups[] = (int) $id;
 
-			$time_limit = (time() - ($validator->maxdays * 24 * 3600));
-			$members = purgeMembers($validator->type, $groups, $time_limit);
+			$time_limit = (time() - ($our_post['maxdays'] * 24 * 3600));
+			$members = purgeMembers($our_post['del_type'], $groups, $time_limit);
 			deleteMembers($members);
 
 			$context['maintenance_finished'] = array(
@@ -1104,30 +1110,26 @@ class Maintenance_Controller extends Action_Controller
 		checkSession('post', 'admin');
 
 		// No boards at all?  Forget it then :/.
-		if (empty($_POST['boards']))
+		if (empty($this->_req->post->boards))
 			redirectexit('action=admin;area=maintain;sa=topics');
 
-		$boards = array_keys($_POST['boards']);
+		$boards = array_keys($this->_req->post->boards);
 
-		if (!isset($_POST['delete_type']) || !in_array($_POST['delete_type'], array('moved', 'nothing', 'locked')))
-		{
+		if (!isset($this->_req->post->delete_type) || !in_array($this->_req->post->delete_type, array('moved', 'nothing', 'locked')))
 			$delete_type = 'nothing';
-		}
 		else
-		{
-			$delete_type = $_POST['delete_type'];
-		}
+			$delete_type = $this->_req->post->delete_type;
 
-		$exclude_stickies = isset($_POST['delete_old_not_sticky']);
+		$exclude_stickies = isset($this->_req->post->delete_old_not_sticky);
 
 		// @todo what is the minimum for maxdays? Maybe throw an error?
-		$older_than = time() - 3600 * 24 *  max((int) $_POST['maxdays'], 1);
+		$older_than = time() - 3600 * 24 *  max($this->_req->getPost('maxdays', 'intval', 0), 1);
 
 		require_once(SUBSDIR . '/Topic.subs.php');
 		removeOldTopics($boards, $delete_type, $exclude_stickies, $older_than);
 
 		// Log an action into the moderation log.
-		logAction('pruned', array('days' => (int) $_POST['maxdays']));
+		logAction('pruned', array('days' => max($this->_req->getPost('maxdays', 'intval', 0), 1)));
 
 		redirectexit('action=admin;area=maintain;sa=topics;done=purgeold');
 	}
@@ -1153,11 +1155,11 @@ class Maintenance_Controller extends Action_Controller
 		$context['continue_post_data'] = '';
 		$context['continue_get_data'] = '';
 		$context['sub_template'] = 'not_done';
-		$context['start'] = empty($_REQUEST['start']) ? 0 : (int) $_REQUEST['start'];
+		$context['start'] = $this->_reqQuery('start', 'intval', 0);
 
 		// First time we do this?
-		$id_board_from = isset($_POST['id_board_from']) ? (int) $_POST['id_board_from'] : (int) $_REQUEST['id_board_from'];
-		$id_board_to = isset($_POST['id_board_to']) ? (int) $_POST['id_board_to'] : (int) $_REQUEST['id_board_to'];
+		$id_board_from = $this->_req->getPost('id_board_from', 'intval', (int) $this->_req->query->id_board_from);
+		$id_board_to = $this->_req->getPost('id_board_to', 'intval', (int) $this->_req->query->id_board_to);
 
 		// No boards then this is your stop.
 		if (empty($id_board_from) || empty($id_board_to))
@@ -1168,11 +1170,11 @@ class Maintenance_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Topic.subs.php');
 
 		// How many topics are we moving?
-		if (!isset($_REQUEST['totaltopics']))
+		if (!isset($this->_req->request->totaltopics))
 			$total_topics = countTopicsFromBoard($id_board_from);
 		else
 		{
-			$total_topics = (int) $_REQUEST['totaltopics'];
+			$total_topics = (int) $this->_req->request->totaltopics;
 			validateToken('admin_movetopics');
 		}
 
@@ -1238,39 +1240,39 @@ class Maintenance_Controller extends Action_Controller
 
 		// Get the list of the current system hooks, filter them if needed
 		$currentHooks = get_integration_hooks();
-		if (isset($_GET['filter']) && in_array($_GET['filter'], array_keys($currentHooks)))
+		if (isset($this->_req->query->filter) && in_array($this->_req->query->filter, array_keys($currentHooks)))
 		{
-			$context['filter_url'] = ';filter=' . $_GET['filter'];
-			$context['current_filter'] = $_GET['filter'];
+			$context['filter_url'] = ';filter=' . $this->_req->query->filter;
+			$context['current_filter'] = $this->_req->query->filter;
 		}
 
 		if (!empty($modSettings['handlinghooks_enabled']))
 		{
-			if (!empty($_REQUEST['do']) && isset($_REQUEST['hook']) && isset($_REQUEST['function']))
+			if (!empty($this->_req->query->do) && isset($this->_req->query->hook) && isset($this->_req->query->function))
 			{
 				checkSession('request');
 				validateToken('admin-hook', 'request');
 
-				if ($_REQUEST['do'] == 'remove')
-					remove_integration_function($_REQUEST['hook'], urldecode($_REQUEST['function']));
+				if ($this->_req->query->do == 'remove')
+					remove_integration_function($this->_req->query->hook, urldecode($this->_req->query->function));
 				else
 				{
-					if ($_REQUEST['do'] == 'disable')
+					if ($this->_req->query->do == 'disable')
 					{
 						// It's a hack I know...but I'm way too lazy!!!
-						$function_remove = $_REQUEST['function'];
-						$function_add = $_REQUEST['function'] . ']';
+						$function_remove = $this->_req->query->function;
+						$function_add = $this->_req->query->function . ']';
 					}
 					else
 					{
-						$function_remove = $_REQUEST['function'] . ']';
-						$function_add = $_REQUEST['function'];
+						$function_remove = $this->_req->query->function . ']';
+						$function_add = $this->_req->query->function;
 					}
 
-					$file = !empty($_REQUEST['includedfile']) ? urldecode($_REQUEST['includedfile']) : '';
+					$file = !empty($this->_req->query->includedfile) ? urldecode($this->_req->query->includedfile) : '';
 
-					remove_integration_function($_REQUEST['hook'], $function_remove, $file);
-					add_integration_function($_REQUEST['hook'], $function_add, $file);
+					remove_integration_function($this->_req->query->hook, $function_remove, $file);
+					add_integration_function($this->_req->query->hook, $function_add, $file);
 
 					// Clean the cache.
 					Cache::instance()->clean();
@@ -1448,7 +1450,7 @@ class Maintenance_Controller extends Action_Controller
 
 		// Init, do 200 members in a bunch
 		$increment = 200;
-		$_REQUEST['start'] = !isset($_REQUEST['start']) ? 0 : (int) $_REQUEST['start'];
+		$start = $this->_req->getQuery('start', 'intval', 0);
 
 		// Ask for some extra time, on big boards this may take a bit
 		setTimeLimit(600);
@@ -1457,26 +1459,30 @@ class Maintenance_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Maintenance.subs.php');
 
 		// Only run this query if we don't have the total number of members that have posted
-		if (!isset($_SESSION['total_members']) || $_REQUEST['start'] == 0)
+		if (!isset($this->_req->session->total_members) || $start === 0)
 		{
 			validateToken('admin-maint');
-			$_SESSION['total_members'] = countContributors();
+			$total_members = countContributors();
+			$_SESSION['total_member'] = $total_members;
 		}
 		else
+		{
 			validateToken('admin-recountposts');
+			$total_members = $this->_req->session->total_members;
+		}
 
 		// Lets get the next group of members and determine their post count
 		// (from the boards that have post count enabled of course).
-		$total_rows = updateMembersPostCount($_REQUEST['start'], $increment);
+		$total_rows = updateMembersPostCount($start, $increment);
 
 		// Continue?
 		if ($total_rows == $increment)
 		{
 			createToken('admin-recountposts');
 
-			$_REQUEST['start'] += $increment;
-			$context['continue_get_data'] = '?action=admin;area=maintain;sa=members;activity=recountposts;start=' . $_REQUEST['start'];
-			$context['continue_percent'] = round(100 * $_REQUEST['start'] / $_SESSION['total_members']);
+			$start += $increment;
+			$context['continue_get_data'] = '?action=admin;area=maintain;sa=members;activity=recountposts;start=' . $start;
+			$context['continue_percent'] = round(100 * $start / $total_members);
 			$context['not_done_title'] = $txt['not_done_title'] . ' (' . $context['continue_percent'] . '%)';
 			$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-recountposts_token_var'] . '" value="' . $context['admin-recountposts_token'] . '" />
 					<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />';
@@ -1503,8 +1509,8 @@ class Maintenance_Controller extends Action_Controller
 		global $context;
 
 		$context['filter'] = false;
-		if (isset($_GET['filter']))
-			$context['filter'] = $_GET['filter'];
+		if (isset($this->_req->query->filter))
+			$context['filter'] = $this->_req->query->filter;
 
 		return integration_hooks_count($context['filter']);
 	}

--- a/sources/admin/Maintenance.controller.php
+++ b/sources/admin/Maintenance.controller.php
@@ -134,8 +134,8 @@ class Maintenance_Controller extends Action_Controller
 		$subAction = $action->initialize($subActions, 'routine');
 
 		// Doing something special, does it exist?
-		if (isset($this->_req->request->activity, $subActions[$subAction]['activities'][$this->_req->request->activity]))
-			$activity = $this->_req->request->activity;
+		if (isset($this->_req->query->activity, $subActions[$subAction]['activities'][$this->_req->query->activity]))
+			$activity = $this->_req->query->activity;
 
 		// Set a few things.
 		$context[$context['admin_menu_name']]['current_subsection'] = $subAction;
@@ -529,7 +529,7 @@ class Maintenance_Controller extends Action_Controller
 		{
 			checkSession();
 
-			if (empty($this->_req->request->start))
+			if (empty($this->_req->query->start))
 				validateToken('admin-maint');
 			else
 				validateToken('admin-convertMsg');
@@ -832,7 +832,7 @@ class Maintenance_Controller extends Action_Controller
 		{
 			while ($this->start < $modSettings['maxMsgID'])
 			{
-				updateMessagesBoardID($this->_req->request->start, $this->increment);
+				updateMessagesBoardID($this->_req->query->start, $this->increment);
 				$this->start += $this->increment;
 
 				if (microtime(true) - $time_start > 3)
@@ -1170,11 +1170,11 @@ class Maintenance_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Topic.subs.php');
 
 		// How many topics are we moving?
-		if (!isset($this->_req->request->totaltopics))
+		if (!isset($this->_req->query->totaltopics))
 			$total_topics = countTopicsFromBoard($id_board_from);
 		else
 		{
-			$total_topics = (int) $this->_req->request->totaltopics;
+			$total_topics = (int) $this->_req->query->totaltopics;
 			validateToken('admin_movetopics');
 		}
 

--- a/sources/admin/ManageAttachments.controller.php
+++ b/sources/admin/ManageAttachments.controller.php
@@ -29,6 +29,54 @@ if (!defined('ELK'))
 class ManageAttachments_Controller extends Action_Controller
 {
 	/**
+	 * Loop counter for paused attachment maintance actions
+	 * @var int
+	 */
+	public $step;
+
+	/**
+	 * substep counter for paused attachment maintance actions
+	 * @var int
+	 */
+	public $substep;
+
+	/**
+	 * Substep at the beginig of a maintance loop
+	 * @var int
+	 */
+	public $starting_substep;
+
+	/**
+	 * Current directory key being processed
+	 * @var int
+	 */
+	public $current_dir;
+
+	/**
+	 * Current base directory key being processed
+	 * @var int
+	 */
+	public $current_base_dir;
+
+	/**
+	 * Used during transfer of files
+	 * @var string
+	 */
+	public $from;
+
+	/**
+	 * Type of attachment management in use
+	 * @var string
+	 */
+	public $auto;
+
+	/**
+	 * Desitination when transfering attachments
+	 * @var string
+	 */
+	public $to;
+
+	/**
 	 * Attachments settings form
 	 * @var Settings_Form
 	 */
@@ -1345,7 +1393,7 @@ class ManageAttachments_Controller extends Action_Controller
 			}
 
 			if (!empty($errors))
-				$this->_req->SESSION->errors['base'] = $errors;
+				$_SESSION['errors']['base'] = $errors;
 
 			if (!empty($update))
 				updateSettings($update);
@@ -1353,20 +1401,20 @@ class ManageAttachments_Controller extends Action_Controller
 			redirectexit('action=admin;area=manageattachments;sa=attachpaths;' . $context['session_var'] . '=' . $context['session_id']);
 		}
 
-		if (isset($this->_req->SESSION->errors))
+		if (isset($this->_req->session->errors))
 		{
-			if (is_array($this->_req->SESSION->errors))
+			if (is_array($this->_req->session->errors))
 			{
 				$errors = array();
-				if (!empty($this->_req->SESSION->errors['dir']))
-					foreach ($this->_req->SESSION->errors['dir'] as $error)
+				if (!empty($this->_req->session->errors['dir']))
+					foreach ($this->_req->session->errors['dir'] as $error)
 						$errors['dir'][] = Util::htmlspecialchars($error, ENT_QUOTES);
 
-				if (!empty($this->_req->SESSION->errors['base']))
-					foreach ($this->_req->SESSION->errors['base'] as $error)
+				if (!empty($this->_req->session->errors['base']))
+					foreach ($this->_req->session->errors['base'] as $error)
 						$errors['base'][] = Util::htmlspecialchars($error, ENT_QUOTES);
 			}
-			unset($this->_req->SESSION->errors);
+			unset($_SESSION['errors'], $this->_req->session->errors);
 		}
 
 		$listOptions = array(

--- a/sources/admin/ManageAttachments.controller.php
+++ b/sources/admin/ManageAttachments.controller.php
@@ -35,6 +35,19 @@ class ManageAttachments_Controller extends Action_Controller
 	protected $_attachSettingsForm;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+	/**
 	 * The main 'Attachments and Avatars' admin.
 	 *
 	 * What it does:

--- a/sources/admin/ManageAttachments.controller.php
+++ b/sources/admin/ManageAttachments.controller.php
@@ -797,8 +797,8 @@ class ManageAttachments_Controller extends Action_Controller
 		// Try give us a while to sort this out...
 		setTimeLimit(600);
 
-		$this->step = $this->_reqQuery('step', 'intval', 0);
-		$this->substep = $this->_reqQuery('substep', 'intval', 0);
+		$this->step = $this->_req->getQuery('step', 'intval', 0);
+		$this->substep = $this->_req->getQuery('substep', 'intval', 0);
 		$this->starting_substep = $this->substep;
 
 		// Don't recall the session just in case.
@@ -836,7 +836,7 @@ class ManageAttachments_Controller extends Action_Controller
 		);
 
 		$to_fix = !empty($this->_req->session->attachments_to_fix) ? $this->_req->session->attachments_to_fix : array();
-		$context['repair_errors'] = $this->_req->getSsession('attachments_to_fix2', $context['repair_errors']);
+		$context['repair_errors'] = $this->_req->getSession('attachments_to_fix2', $context['repair_errors']);
 		$fix_errors = isset($this->_req->query->fixErrors) ? true : false;
 
 		// Get stranded thumbnails.
@@ -1272,7 +1272,7 @@ class ManageAttachments_Controller extends Action_Controller
 			checkSession();
 
 			// Changing the current base directory?
-			$this->current_base_dir = $this->getQuery('current_base_dir', 'intval');
+			$this->current_base_dir = $this->_req->getQuery('current_base_dir', 'intval');
 			if (empty($this->_req->post->new_base_dir) && !empty($this->current_base_dir))
 			{
 				if ($modSettings['basedirectory_for_attachments'] != $modSettings['attachmentUploadDir'][$this->current_base_dir])

--- a/sources/admin/ManageAvatars.controller.php
+++ b/sources/admin/ManageAvatars.controller.php
@@ -31,6 +31,20 @@ class ManageAvatars_Controller extends Action_Controller
 	protected $_avatarSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * The Avatars admin area
 	 *
 	 * What it does:
@@ -83,17 +97,17 @@ class ManageAvatars_Controller extends Action_Controller
 		$config_vars = $this->_avatarSettings->settings();
 
 		// Saving avatar settings?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			call_integration_hook('integrate_save_avatar_settings');
 
 			// Disable if invalid values would result
-			if (isset($_POST['custom_avatar_enabled']) && $_POST['custom_avatar_enabled'] == 1 && (empty($_POST['custom_avatar_dir']) || empty($_POST['custom_avatar_url'])))
-				$_POST['custom_avatar_enabled'] = 0;
+			if (isset($this->_req->post->custom_avatar_enabled) && $this->_req->post->custom_avatar_enabled == 1 && (empty($this->_req->post->custom_avatar_dir) || empty($this->_req->post->custom_avatar_url)))
+				$this->_req->post->custom_avatar_enabled = 0;
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			redirectexit('action=admin;area=manageattachments;sa=avatars');
 		}
 

--- a/sources/admin/ManageBBC.controller.php
+++ b/sources/admin/ManageBBC.controller.php
@@ -110,7 +110,7 @@ class ManageBBC_Controller extends Action_Controller
 
 			if (!isset($this->_req->post->disabledBBC_enabledTags))
 				$this->_req->post->disabledBBC_enabledTags = array();
-			elseif (!is_array($this->_req->POST->disabledBBC_enabledTags))
+			elseif (!is_array($this->_req->post->disabledBBC_enabledTags))
 				$this->_req->post->disabledBBC_enabledTags = array($this->_req->post->disabledBBC_enabledTags);
 
 			// Work out what is actually disabled!

--- a/sources/admin/ManageBBC.controller.php
+++ b/sources/admin/ManageBBC.controller.php
@@ -29,6 +29,20 @@ class ManageBBC_Controller extends Action_Controller
 	protected $_bbcSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * The BBC admin area
 	 *
 	 * What it does:
@@ -85,7 +99,7 @@ class ManageBBC_Controller extends Action_Controller
 		$modSettings['bbc_disabled_disabledBBC'] = empty($modSettings['disabledBBC']) ? array() : explode(',', $modSettings['disabledBBC']);
 
 		// Save page
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
@@ -94,19 +108,19 @@ class ManageBBC_Controller extends Action_Controller
 			foreach (parse_bbc(false) as $tag)
 				$bbcTags[] = $tag['tag'];
 
-			if (!isset($_POST['disabledBBC_enabledTags']))
-				$_POST['disabledBBC_enabledTags'] = array();
-			elseif (!is_array($_POST['disabledBBC_enabledTags']))
-				$_POST['disabledBBC_enabledTags'] = array($_POST['disabledBBC_enabledTags']);
+			if (!isset($this->_req->post->disabledBBC_enabledTags))
+				$this->_req->post->disabledBBC_enabledTags = array();
+			elseif (!is_array($this->_req->POST->disabledBBC_enabledTags))
+				$this->_req->post->disabledBBC_enabledTags = array($this->_req->post->disabledBBC_enabledTags);
 
 			// Work out what is actually disabled!
-			$_POST['disabledBBC'] = implode(',', array_diff($bbcTags, $_POST['disabledBBC_enabledTags']));
+			$this->_req->post->disabledBBC = implode(',', array_diff($bbcTags, $this->_req->post->disabledBBC_enabledTags));
 
 			// Notify addons and integrations
 			call_integration_hook('integrate_save_bbc_settings', array($bbcTags));
 
 			// Save the result
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 
 			// And we're out of here!
 			redirectexit('action=admin;area=postsettings;sa=bbc');

--- a/sources/admin/ManageBans.controller.php
+++ b/sources/admin/ManageBans.controller.php
@@ -724,7 +724,7 @@ class ManageBans_Controller extends Action_Controller
 		// Update the triggers associated with this ban
 		if (isset($this->_req->post->ban_suggestions, $ban_info['id']))
 		{
-			$saved_triggers = saveTriggers($_POST, $ban_info['id'], $this->_req->getQuery('u', 'intval', 0), $this->_req->getQuery('bi', 'intval', 0));
+			$saved_triggers = saveTriggers((array) $this->_req->post, $ban_info['id'], $this->_req->getQuery('u', 'intval', 0), $this->_req->getQuery('bi', 'intval', 0));
 			$context['ban_suggestions']['saved_triggers'] = $saved_triggers;
 		}
 
@@ -798,7 +798,7 @@ class ManageBans_Controller extends Action_Controller
 		// Adding a new trigger
 		if (isset($this->_req->post->add_new_trigger) && !empty($this->_req->post->ban_suggestions))
 		{
-			saveTriggers($this->_req->post, $ban_group, 0, $ban_id);
+			saveTriggers((array) $this->_req->post, $ban_group, 0, $ban_id);
 			redirectexit('action=admin;area=ban;sa=edit' . (!empty($ban_group) ? ';bg=' . $ban_group : ''));
 		}
 		// Edit an existing trigger with new / updated details
@@ -806,11 +806,11 @@ class ManageBans_Controller extends Action_Controller
 		{
 			// The first replaces the old one, the others are added new
 			// (simplification, otherwise it would require another query and some work...)
-			$dummy = $_POST;
+			$dummy = (array) $this->_req->post;
 			$dummy['ban_suggestions'] = array_shift($this->_req->post->ban_suggestions);
 			saveTriggers($dummy, $ban_group, 0, $ban_id);
 			if (!empty($this->_req->post->ban_suggestions))
-				saveTriggers($this->_req->post, $ban_group);
+				saveTriggers((array) $this->_req->post, $ban_group);
 
 			redirectexit('action=admin;area=ban;sa=edit' . (!empty($ban_group) ? ';bg=' . $ban_group : ''));
 		}

--- a/sources/admin/ManageBans.controller.php
+++ b/sources/admin/ManageBans.controller.php
@@ -23,6 +23,20 @@ if (!defined('ELK'))
 class ManageBans_Controller extends Action_Controller
 {
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Ban center. The main entrance point for all ban center functions.
 	 *
 	 * What it does:
@@ -54,7 +68,7 @@ class ManageBans_Controller extends Action_Controller
 		$action = new Action();
 
 		// Default the sub-action to 'view ban list'.
-		$subAction = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : 'list';
+		$subAction = $this->_req->getQuery('sa', 'strval', 'list');
 
 		// Tabs for browsing the different ban functions.
 		$context[$context['admin_menu_name']]['tab_data'] = array(
@@ -116,12 +130,12 @@ class ManageBans_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Bans.subs.php');
 
 		// User pressed the 'remove selection button'.
-		if (!empty($_POST['removeBans']) && !empty($_POST['remove']) && is_array($_POST['remove']))
+		if (!empty($this->_req->post->removeBans) && !empty($this->_req->post->remove) && is_array($this->_req->post->remove))
 		{
 			checkSession();
 
 			// Make sure every entry is a proper integer.
-			$to_remove = array_map('intval', $_POST['remove']);
+			$to_remove = array_map('intval', $this->_req->post->remove);
 
 			// Unban them all!
 			removeBanGroups($to_remove);
@@ -311,10 +325,10 @@ class ManageBans_Controller extends Action_Controller
 		$ban_errors = Error_Context::context('ban', 1);
 
 		// Saving a new or edited ban?
-		if ((isset($_POST['add_ban']) || isset($_POST['modify_ban']) || isset($_POST['remove_selection'])) && !$ban_errors->hasErrors())
+		if ((isset($this->_req->post->add_ban) || isset($this->_req->post->modify_ban) || isset($this->_req->post->remove_selection)) && !$ban_errors->hasErrors())
 			$this->action_edit2();
 
-		$ban_group_id = isset($context['ban']['id']) ? $context['ban']['id'] : (isset($_REQUEST['bg']) ? (int) $_REQUEST['bg'] : 0);
+		$ban_group_id = isset($context['ban']['id']) ? $context['ban']['id'] : $this->_req->getQuery('bg', 'intval', 0);
 
 		// Template needs this to show errors using javascript
 		loadLanguage('Errors');
@@ -459,9 +473,9 @@ class ManageBans_Controller extends Action_Controller
 				);
 
 				// Overwrite some of the default form values if a user ID was given.
-				if (!empty($_REQUEST['u']))
+				if (!empty($this->_req->query->u))
 				{
-					$context['ban_suggestions'] = array_merge($context['ban_suggestions'], getMemberData((int) $_REQUEST['u']));
+					$context['ban_suggestions'] = array_merge($context['ban_suggestions'], getMemberData((int) $this->_req->query->u));
 
 					if (!empty($context['ban_suggestions']['member']['id']))
 					{
@@ -519,18 +533,18 @@ class ManageBans_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Bans.subs.php');
 
 		// Delete one or more entries.
-		if (!empty($_POST['removeAll']) || (!empty($_POST['removeSelected']) && !empty($_POST['remove'])))
+		if (!empty($this->_req->post->removeAll) || (!empty($this->_req->post->removeSelected) && !empty($this->_req->post->remove)))
 		{
 			checkSession();
 			validateToken('admin-bl');
 
 			// 'Delete all entries' button was pressed.
-			if (!empty($_POST['removeAll']))
+			if (!empty($this->_req->post->removeAll))
 				removeBanLogs();
 			// 'Delete selection' button was pressed.
 			else
 			{
-				$to_remove = array_map('intval', $_POST['remove']);
+				$to_remove = array_map('intval', $this->_req->post->remove);
 				removeBanLogs($to_remove);
 			}
 		}
@@ -668,28 +682,28 @@ class ManageBans_Controller extends Action_Controller
 		$ban_errors = Error_Context::context('ban', 1);
 
 		// Adding or editing a ban group
-		if (isset($_POST['add_ban']) || isset($_POST['modify_ban']))
+		if (isset($this->_req->post->add_ban) || isset($this->_req->post->modify_ban))
 		{
 			$ban_info = array();
 
 			// Let's collect all the information we need
-			$ban_info['id'] = isset($_REQUEST['bg']) ? (int) $_REQUEST['bg'] : 0;
+			$ban_info['id'] = $this->_req->getQuery('bg', 'intval', 0);
 			$ban_info['is_new'] = empty($ban_info['id']);
-			$ban_info['expire_date'] = !empty($_POST['expire_date']) ? (int) $_POST['expire_date'] : 0;
+			$ban_info['expire_date'] = $this->_req->getPost('expire_date', 'intval', 0);
 			$ban_info['expiration'] = array(
-				'status' => isset($_POST['expiration']) && in_array($_POST['expiration'], array('never', 'one_day', 'expired')) ? $_POST['expiration'] : 'never',
+				'status' => isset($this->_req->post->expiration) && in_array($this->_req->post->expiration, array('never', 'one_day', 'expired')) ? $this->_req->post->expiration : 'never',
 				'days' => $ban_info['expire_date'],
 			);
 			$ban_info['db_expiration'] = $ban_info['expiration']['status'] == 'never' ? 'NULL' : ($ban_info['expiration']['status'] == 'one_day' ? time() + 24 * 60 * 60 * $ban_info['expire_date'] : 0);
-			$ban_info['full_ban'] = empty($_POST['full_ban']) ? 0 : 1;
-			$ban_info['reason'] = !empty($_POST['reason']) ? Util::htmlspecialchars($_POST['reason'], ENT_QUOTES) : '';
-			$ban_info['name'] = !empty($_POST['ban_name']) ? Util::htmlspecialchars($_POST['ban_name'], ENT_QUOTES) : '';
-			$ban_info['notes'] = isset($_POST['notes']) ? Util::htmlspecialchars($_POST['notes'], ENT_QUOTES) : '';
+			$ban_info['full_ban'] = empty($this->_req->post->full_ban) ? 0 : 1;
+			$ban_info['reason'] = $this->_req->getPost('reason', 'Util::htmlspecialchars[ENT_QUOTES]', '');
+			$ban_info['name'] = $this->_req->getPost('ban_name', 'Util::htmlspecialchars[ENT_QUOTES]', '');
+			$ban_info['notes'] = $this->_req->getPost('notes', 'Util::htmlspecialchars[ENT_QUOTES]', '');
 			$ban_info['notes'] = str_replace(array("\r", "\n", '  '), array('', '<br />', '&nbsp; '), $ban_info['notes']);
 			$ban_info['cannot']['access'] = empty($ban_info['full_ban']) ? 0 : 1;
-			$ban_info['cannot']['post'] = !empty($ban_info['full_ban']) || empty($_POST['cannot_post']) ? 0 : 1;
-			$ban_info['cannot']['register'] = !empty($ban_info['full_ban']) || empty($_POST['cannot_register']) ? 0 : 1;
-			$ban_info['cannot']['login'] = !empty($ban_info['full_ban']) || empty($_POST['cannot_login']) ? 0 : 1;
+			$ban_info['cannot']['post'] = !empty($ban_info['full_ban']) || empty($this->_req->post->cannot_post) ? 0 : 1;
+			$ban_info['cannot']['register'] = !empty($ban_info['full_ban']) || empty($this->_req->post->cannot_register) ? 0 : 1;
+			$ban_info['cannot']['login'] = !empty($ban_info['full_ban']) || empty($this->_req->post->cannot_login) ? 0 : 1;
 
 			// Adding a new ban group
 			if (empty($ban_info['id']))
@@ -708,9 +722,9 @@ class ManageBans_Controller extends Action_Controller
 		}
 
 		// Update the triggers associated with this ban
-		if (isset($_POST['ban_suggestions'], $ban_info['id']))
+		if (isset($this->_req->post->ban_suggestions, $ban_info['id']))
 		{
-			$saved_triggers = saveTriggers($_POST, $ban_info['id'], isset($_REQUEST['u']) ? (int) $_REQUEST['u'] : 0, isset($_REQUEST['bi']) ? (int) $_REQUEST['bi'] : 0);
+			$saved_triggers = saveTriggers($_POST, $ban_info['id'], $this->_req->getQuery('u', 'intval', 0), $this->_req->getQuery('bi', 'intval', 0));
 			$context['ban_suggestions']['saved_triggers'] = $saved_triggers;
 		}
 
@@ -721,13 +735,13 @@ class ManageBans_Controller extends Action_Controller
 			$context['ban']['from_user'] = true;
 
 			// They may have entered a name not using the member select box
-			if (isset($_REQUEST['u']))
-				$context['ban_suggestions'] = array_merge($context['ban_suggestions'], getMemberData((int) $_REQUEST['u']));
-			elseif (isset($_REQUEST['user']))
+			if (isset($this->_req->query->u))
+				$context['ban_suggestions'] = array_merge($context['ban_suggestions'], getMemberData((int) $this->_req->query->u));
+			elseif (isset($this->_req->query->user))
 			{
 				$context['ban']['from_user'] = false;
 				$context['use_autosuggest'] = true;
-				$context['ban_suggestions']['member']['name'] = $_REQUEST['user'];
+				$context['ban_suggestions']['member']['name'] = $this->_req->query->user;
 			}
 
 			// Not strictly necessary, but it's nice
@@ -737,10 +751,10 @@ class ManageBans_Controller extends Action_Controller
 			return $this->action_edit();
 		}
 
-		if (isset($_POST['ban_items']))
+		if (isset($this->_req->post->ban_items))
 		{
-			$ban_group_id = isset($_REQUEST['bg']) ? (int) $_REQUEST['bg'] : 0;
-			$ban_items = array_map('intval', $_POST['ban_items']);
+			$ban_group_id = $this->_req->getQuery('bg', 'intval', 0);
+			$ban_items = array_map('intval', $this->_req->post->ban_items);
 
 			removeBanTriggers($ban_items, $ban_group_id);
 		}
@@ -752,7 +766,7 @@ class ManageBans_Controller extends Action_Controller
 		updateBanMembers();
 
 		// Go back to an appropriate spot
-		redirectexit('action=admin;area=ban;sa=' . (isset($_POST['add_ban']) ? 'list' : 'edit;bg=' . isset($ban_group_id) ? $ban_group_id : 0));
+		redirectexit('action=admin;area=ban;sa=' . (isset($this->_req->post->add_ban) ? 'list' : 'edit;bg=' . isset($ban_group_id) ? $ban_group_id : 0));
 	}
 
 	/**
@@ -775,33 +789,33 @@ class ManageBans_Controller extends Action_Controller
 
 		require_once(SUBSDIR . '/Bans.subs.php');
 
-		$ban_group = isset($_REQUEST['bg']) ? (int) $_REQUEST['bg'] : 0;
-		$ban_id = isset($_REQUEST['bi']) ? (int) $_REQUEST['bi'] : 0;
+		$ban_group = $this->_req->getQuery('bg'. 'intval', 0);
+		$ban_id = $this->_req->getQuery('bi'. 'intval', 0);
 
 		if (empty($ban_group))
 			Errors::fatal_lang_error('ban_not_found', false);
 
 		// Adding a new trigger
-		if (isset($_POST['add_new_trigger']) && !empty($_POST['ban_suggestions']))
+		if (isset($this->_req->post->add_new_trigger) && !empty($this->_req->post->ban_suggestions))
 		{
-			saveTriggers($_POST, $ban_group, 0, $ban_id);
+			saveTriggers($this->_req->post, $ban_group, 0, $ban_id);
 			redirectexit('action=admin;area=ban;sa=edit' . (!empty($ban_group) ? ';bg=' . $ban_group : ''));
 		}
 		// Edit an existing trigger with new / updated details
-		elseif (isset($_POST['edit_trigger']) && !empty($_POST['ban_suggestions']))
+		elseif (isset($this->_req->post->edit_trigger) && !empty($this->_req->post->ban_suggestions))
 		{
 			// The first replaces the old one, the others are added new
 			// (simplification, otherwise it would require another query and some work...)
 			$dummy = $_POST;
-			$dummy['ban_suggestions'] = array_shift($_POST['ban_suggestions']);
+			$dummy['ban_suggestions'] = array_shift($this->_req->post->ban_suggestions);
 			saveTriggers($dummy, $ban_group, 0, $ban_id);
-			if (!empty($_POST['ban_suggestions']))
-				saveTriggers($_POST, $ban_group);
+			if (!empty($this->_req->post->ban_suggestions))
+				saveTriggers($this->_req->post, $ban_group);
 
 			redirectexit('action=admin;area=ban;sa=edit' . (!empty($ban_group) ? ';bg=' . $ban_group : ''));
 		}
 		// Removing a ban trigger by clearing the checkbox
-		elseif (isset($_POST['edit_trigger']))
+		elseif (isset($this->_req->post->edit_trigger))
 		{
 			removeBanTriggers($ban_id);
 			redirectexit('action=admin;area=ban;sa=edit' . (!empty($ban_group) ? ';bg=' . $ban_group : ''));
@@ -889,24 +903,24 @@ class ManageBans_Controller extends Action_Controller
 
 		require_once(SUBSDIR . '/Bans.subs.php');
 
-		if (!empty($_POST['remove_triggers']) && !empty($_POST['remove']) && is_array($_POST['remove']))
+		if (!empty($this->_req->post->remove_triggers) && !empty($this->_req->post->remove) && is_array($this->_req->post->remove))
 		{
 			checkSession();
 
 			// Make sure every entry is a proper integer.
-			$to_remove = array_map('intval', $_POST['remove']);
+			$to_remove = array_map('intval', $this->_req->post->remove);
 
 			removeBanTriggers($to_remove);
 
 			// Rehabilitate some members.
-			if ($_REQUEST['entity'] == 'member')
+			if ($this->_req->query->entity == 'member')
 				updateBanMembers();
 
 			// Make sure the ban cache is refreshed.
 			updateSettings(array('banLastUpdated' => time()));
 		}
 
-		$context['selected_entity'] = isset($_REQUEST['entity']) && in_array($_REQUEST['entity'], array('ip', 'hostname', 'email', 'member')) ? $_REQUEST['entity'] : 'ip';
+		$context['selected_entity'] = isset($this->_req->query->entity) && in_array($this->_req->query->entity, array('ip', 'hostname', 'email', 'member')) ? $this->_req->query->entity : 'ip';
 
 		$listOptions = array(
 			'id' => 'ban_trigger_list',

--- a/sources/admin/ManageBoards.controller.php
+++ b/sources/admin/ManageBoards.controller.php
@@ -29,6 +29,18 @@ if (!defined('ELK'))
 class ManageBoards_Controller extends Action_Controller
 {
 	/**
+	 * Category being worked on
+	 * @var int
+	 */
+	public $cat;
+
+	/**
+	 * Current board id being modified
+	 * @var int
+	 */
+	public $boardid;
+
+	/**
 	 * Boards settings form.
 	 * @var Settings_Form
 	 */

--- a/sources/admin/ManageCalendarModule.controller.php
+++ b/sources/admin/ManageCalendarModule.controller.php
@@ -35,6 +35,20 @@ class ManageCalendarModule_Controller extends Action_Controller
 	protected $_calendarSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Used to add the Calendar entry to the Core Features list.
 	 *
 	 * @param mixed[] $core_features The core features array
@@ -154,12 +168,12 @@ class ManageCalendarModule_Controller extends Action_Controller
 		global $scripturl, $txt, $context;
 
 		// Submitting something...
-		if (isset($_REQUEST['delete']) && !empty($_REQUEST['holiday']))
+		if (isset($this->_req->query->delete) && !empty($this->_req->query->holiday))
 		{
 			checkSession();
 			validateToken('admin-mc');
 
-			$to_remove = array_map('intval', array_keys($_REQUEST['holiday']));
+			$to_remove = array_map('intval', array_keys($this->_req->query->holiday));
 
 			// Now the IDs are "safe" do the delete...
 			require_once(SUBSDIR . '/Calendar.subs.php');
@@ -271,32 +285,31 @@ class ManageCalendarModule_Controller extends Action_Controller
 
 		loadTemplate('ManageCalendar');
 
-		$context['is_new'] = !isset($_REQUEST['holiday']);
+		$context['is_new'] = !isset($this->_req->query->holiday);
 		$context['page_title'] = $context['is_new'] ? $txt['holidays_add'] : $txt['holidays_edit'];
 		$context['sub_template'] = 'edit_holiday';
 
 		// Cast this for safety...
-		if (isset($_REQUEST['holiday']))
-			$_REQUEST['holiday'] = (int) $_REQUEST['holiday'];
+		$this->_req->query->holiday = $this->_req->getQuery('holiday', 'intval');
 
 		// Submitting?
-		if (isset($_POST[$context['session_var']]) && (isset($_REQUEST['delete']) || $_REQUEST['title'] != ''))
+		if (isset($_POST[$context['session_var']]) && (isset($this->_req->post->delete) || $this->_req->post->title != ''))
 		{
 			checkSession();
 
 			// Not too long good sir?
-			$_REQUEST['title'] = Util::substr($_REQUEST['title'], 0, 60);
-			$_REQUEST['holiday'] = isset($_REQUEST['holiday']) ? (int) $_REQUEST['holiday'] : 0;
+			$this->_req->post->title = Util::substr($this->_req->post->title, 0, 60);
+			$this->_req->post->holiday = $this->_req->getPost('holiday', 'intval', 0);
 
-			if (isset($_REQUEST['delete']))
-				removeHolidays($_REQUEST['holiday']);
+			if (isset($this->_req->post->delete))
+				removeHolidays($this->_req->post->holiday);
 			else
 			{
-				$date = strftime($_REQUEST['year'] <= 4 ? '0004-%m-%d' : '%Y-%m-%d', mktime(0, 0, 0, $_REQUEST['month'], $_REQUEST['day'], $_REQUEST['year']));
-				if (isset($_REQUEST['edit']))
-					editHoliday($_REQUEST['holiday'], $date, $_REQUEST['title']);
+				$date = strftime($this->_req->post->year <= 4 ? '0004-%m-%d' : '%Y-%m-%d', mktime(0, 0, 0, $this->_req->post->month, $this->_req->REQUEST->day, $this->_req->REQUEST->year));
+				if (isset($this->_req->post->edit))
+					editHoliday($this->_req->post->holiday, $date, $this->_req->post->title);
 				else
-					insertHoliday($date, $_REQUEST['title']);
+					insertHoliday($date, $this->_req->post->title);
 			}
 
 			redirectexit('action=admin;area=managecalendar;sa=holidays');
@@ -315,7 +328,7 @@ class ManageCalendarModule_Controller extends Action_Controller
 		}
 		// If it's not new load the data.
 		else
-			$context['holiday'] = getHoliday($_REQUEST['holiday']);
+			$context['holiday'] = getHoliday($this->_req->query->holiday);
 
 		// Last day for the drop down?
 		$context['holiday']['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $context['holiday']['month'] == 12 ? 1 : $context['holiday']['month'] + 1, 0, $context['holiday']['month'] == 12 ? $context['holiday']['year'] + 1 : $context['holiday']['year']));
@@ -340,11 +353,11 @@ class ManageCalendarModule_Controller extends Action_Controller
 		$context[$context['admin_menu_name']]['current_subsection'] = 'settings';
 
 		// Saving the settings?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 			call_integration_hook('integrate_save_calendar_settings');
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 
 			// Update the stats in case.
 			updateSettings(array(

--- a/sources/admin/ManageCalendarModule.controller.php
+++ b/sources/admin/ManageCalendarModule.controller.php
@@ -305,7 +305,7 @@ class ManageCalendarModule_Controller extends Action_Controller
 				removeHolidays($this->_req->post->holiday);
 			else
 			{
-				$date = strftime($this->_req->post->year <= 4 ? '0004-%m-%d' : '%Y-%m-%d', mktime(0, 0, 0, $this->_req->post->month, $this->_req->REQUEST->day, $this->_req->REQUEST->year));
+				$date = strftime($this->_req->post->year <= 4 ? '0004-%m-%d' : '%Y-%m-%d', mktime(0, 0, 0, $this->_req->post->month, $this->_req->post->day, $this->_req->post->year));
 				if (isset($this->_req->post->edit))
 					editHoliday($this->_req->post->holiday, $date, $this->_req->post->title);
 				else

--- a/sources/admin/ManageDraftsModule.controller.php
+++ b/sources/admin/ManageDraftsModule.controller.php
@@ -28,6 +28,20 @@ class ManageDraftsModule_Controller extends Action_Controller
 	protected $_draftSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Used to add the Drafts entry to the Core Features list.
 	 *
 	 * @param mixed[] $core_features The core features array
@@ -158,7 +172,7 @@ class ManageDraftsModule_Controller extends Action_Controller
 		validateToken('admin-maint');
 
 		require_once(SUBSDIR . '/Drafts.subs.php');
-		$drafts = getOldDrafts((int) $_POST['draftdays']);
+		$drafts = getOldDrafts((int) $this->_req->post->draftdays);
 
 		// If we have old drafts, remove them
 		if (count($drafts) > 0)
@@ -226,16 +240,16 @@ class ManageDraftsModule_Controller extends Action_Controller
 		);
 
 		// Saving them ?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			call_integration_hook('integrate_save_drafts_settings');
 
 			// Protect them from themselves.
-			$_POST['drafts_autosave_frequency'] = $_POST['drafts_autosave_frequency'] < 30 ? 30 : $_POST['drafts_autosave_frequency'];
+			$this->_req->post->drafts_autosave_frequency = $this->_req->post->drafts_autosave_frequency < 30 ? 30 : $this->_req->post->drafts_autosave_frequency;
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			redirectexit('action=admin;area=managedrafts');
 		}
 

--- a/sources/admin/ManageErrors.controller.php
+++ b/sources/admin/ManageErrors.controller.php
@@ -105,6 +105,7 @@ class ManageErrors_Controller extends Action_Controller
 		}
 
 		$num_errors = numErrors($filter);
+		$members = array();
 
 		// If this filter is empty...
 		if ($num_errors == 0 && isset($filter))

--- a/sources/admin/ManageErrors.controller.php
+++ b/sources/admin/ManageErrors.controller.php
@@ -27,6 +27,20 @@ if (!defined('ELK'))
 class ManageErrors_Controller extends Action_Controller
 {
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Calls the right handler.
 	 * Requires admin_forum permission.
 	 *
@@ -38,8 +52,7 @@ class ManageErrors_Controller extends Action_Controller
 		isAllowedTo('admin_forum');
 
 		// The error log. View the list or view a file?
-		if (isset($_REQUEST['activity']))
-			$activity = $_REQUEST['activity'];
+		$activity = $this->_req->getQuery('activity', 'strval');
 
 		// Some code redundancy... and we only take this!
 		if (isset($activity) && $activity == 'file')
@@ -62,10 +75,7 @@ class ManageErrors_Controller extends Action_Controller
 	 */
 	protected function action_log()
 	{
-		global $scripturl, $txt, $context, $modSettings, $user_profile, $filter;
-
-		// We'll escape some strings...
-		$db = database();
+		global $scripturl, $txt, $context, $modSettings, $filter;
 
 		require_once(SUBSDIR . '/Error.subs.php');
 
@@ -73,70 +83,46 @@ class ManageErrors_Controller extends Action_Controller
 		loadLanguage('Maintenance');
 		loadTemplate('Errors');
 
-		// You can filter by any of the following columns:
-		$filters = array(
-			'id_member' => $txt['username'],
-			'ip' => $txt['ip_address'],
-			'session' => $txt['session'],
-			'url' => $txt['error_url'],
-			'message' => $txt['error_message'],
-			'error_type' => $txt['error_type'],
-			'file' => $txt['file'],
-			'line' => $txt['line'],
-		);
-
-		// Set up the filtering...
-		if (isset($_GET['value'], $_GET['filter']) && isset($filters[$_GET['filter']]))
-			$filter = array(
-				'variable' => $_GET['filter'],
-				'value' => array(
-					'sql' => in_array($_GET['filter'], array('message', 'url', 'file')) ? base64_decode(strtr($_GET['value'], array(' ' => '+'))) : $db->escape_wildcard_string($_GET['value']),
-				),
-				'href' => ';filter=' . $_GET['filter'] . ';value=' . $_GET['value'],
-				'entity' => $filters[$_GET['filter']]
-			);
-		elseif (isset($_GET['filter']) || isset($_GET['value']))
-			unset($_GET['filter'], $_GET['value']);
+		// Set up any filters chosen
+		$filter = $this->_setupFiltering();
 
 		// Deleting, are we?
-		$type = isset($_POST['delall']) ? 'delall' : (isset($_POST['delete']) ? 'delete' : false);
-		$error_list = isset($_POST['delete']) ? $_POST['delete'] : null;
-
+		$type = isset($this->_req->post->delall) ? 'delall' : (isset($this->_req->post->delete) ? 'delete' : false);
 		if ($type !== false)
 		{
 			// Make sure the session exists and is correct; otherwise, might be a hacker.
 			checkSession();
 			validateToken('admin-el');
 
+			$error_list = $this->_req->getPost('delete');
 			deleteErrors($type, $filter, $error_list);
 
 			// Go back to where we were.
 			if ($type == 'delete')
-				redirectexit('action=admin;area=logs;sa=errorlog' . (isset($_REQUEST['desc']) ? ';desc' : '') . ';start=' . $_GET['start'] . (isset($filter) ? ';filter=' . $_GET['filter'] . ';value=' . $_GET['value'] : ''));// Go back to where we were.
+				redirectexit('action=admin;area=logs;sa=errorlog' . (isset($this->_req->query->desc) ? ';desc' : '') . ';start=' . $this->_req->query->start . (isset($filter) ? ';filter=' . $this->_req->query->filter . ';value=' . $this->_req->query->value : ''));
 
-			redirectexit('action=admin;area=logs;sa=errorlog' . (isset($_REQUEST['desc']) ? ';desc' : ''));
-
+			redirectexit('action=admin;area=logs;sa=errorlog' . (isset($this->_req->query->desc) ? ';desc' : ''));
 		}
 
 		$num_errors = numErrors($filter);
 
 		// If this filter is empty...
 		if ($num_errors == 0 && isset($filter))
-			redirectexit('action=admin;area=logs;sa=errorlog' . (isset($_REQUEST['desc']) ? ';desc' : ''));
+			redirectexit('action=admin;area=logs;sa=errorlog' . (isset($this->_req->query->desc) ? ';desc' : ''));
 
 		// Clean up start.
-		if (!isset($_GET['start']) || $_GET['start'] < 0)
-			$_GET['start'] = 0;
+		if (!isset($this->_req->query->start) || $this->_req->query->start < 0)
+			$this->_req->query->start = 0;
 
 		// Do we want to reverse error listing?
-		$context['sort_direction'] = isset($_REQUEST['desc']) ? 'down' : 'up';
+		$context['sort_direction'] = isset($this->_req->query->desc) ? 'down' : 'up';
 
 		// Set the page listing up.
-		$context['page_index'] = constructPageIndex($scripturl . '?action=admin;area=logs;sa=errorlog' . ($context['sort_direction'] == 'down' ? ';desc' : '') . (isset($filter) ? $filter['href'] : ''), $_GET['start'], $num_errors, $modSettings['defaultMaxMessages']);
-		$context['start'] = $_GET['start'];
+		$context['page_index'] = constructPageIndex($scripturl . '?action=admin;area=logs;sa=errorlog' . ($context['sort_direction'] == 'down' ? ';desc' : '') . (isset($filter) ? $filter['href'] : ''), $this->_req->query->start, $num_errors, $modSettings['defaultMaxMessages']);
+		$context['start'] = $this->_req->query->start;
 		$context['errors'] = array();
 
-		$logdata = getErrorLogData($_GET['start'], $context['sort_direction'], $filter);
+		$logdata = getErrorLogData($this->_req->query->start, $context['sort_direction'], $filter);
 		if (!empty($logdata))
 		{
 			$context['errors'] = $logdata['errors'];
@@ -144,48 +130,10 @@ class ManageErrors_Controller extends Action_Controller
 		}
 
 		// Load the member data.
-		if (!empty($members))
-		{
-			require_once(SUBSDIR . '/Members.subs.php');
-			$members = getBasicMemberData($members, array('add_guest' => true));
-
-			// Go through each error and tack the data on.
-			foreach ($context['errors'] as $id => $dummy)
-			{
-				$memID = $context['errors'][$id]['member']['id'];
-				$context['errors'][$id]['member']['username'] = $members[$memID]['member_name'];
-				$context['errors'][$id]['member']['name'] = $members[$memID]['real_name'];
-				$context['errors'][$id]['member']['href'] = empty($memID) ? '' : $scripturl . '?action=profile;u=' . $memID;
-				$context['errors'][$id]['member']['link'] = empty($memID) ? $txt['guest_title'] : '<a href="' . $scripturl . '?action=profile;u=' . $memID . '">' . $context['errors'][$id]['member']['name'] . '</a>';
-			}
-		}
+		$this->_loadMemData($members);
 
 		// Filtering anything?
-		if (isset($filter))
-		{
-			$context['filter'] = &$filter;
-
-			// Set the filtering context.
-			if ($filter['variable'] == 'id_member')
-			{
-				$id = $filter['value']['sql'];
-				loadMemberData($id, false, 'minimal');
-				$context['filter']['value']['html'] = '<a href="' . $scripturl . '?action=profile;u=' . $id . '">' . $user_profile[$id]['real_name'] . '</a>';
-			}
-			elseif ($filter['variable'] == 'url')
-				$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars((substr($filter['value']['sql'], 0, 1) == '?' ? $scripturl : '') . $filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array('\_' => '_')) . '\'';
-			elseif ($filter['variable'] == 'message')
-			{
-				$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars($filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array("\n" => '<br />', '&lt;br /&gt;' => '<br />', "\t" => '&nbsp;&nbsp;&nbsp;', '\_' => '_', '\\%' => '%', '\\\\' => '\\')) . '\'';
-				$context['filter']['value']['html'] = preg_replace('~&amp;lt;span class=&amp;quot;remove&amp;quot;&amp;gt;(.+?)&amp;lt;/span&amp;gt;~', '$1', $context['filter']['value']['html']);
-			}
-			elseif ($filter['variable'] == 'error_type')
-			{
-				$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars($filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array("\n" => '<br />', '&lt;br /&gt;' => '<br />', "\t" => '&nbsp;&nbsp;&nbsp;', '\_' => '_', '\\%' => '%', '\\\\' => '\\')) . '\'';
-			}
-			else
-				$context['filter']['value']['html'] = &$filter['value']['sql'];
-		}
+		$this->_applyFilter($filter);
 
 		$sort = ($context['sort_direction'] == 'down') ? ';desc' : '';
 
@@ -220,6 +168,114 @@ class ManageErrors_Controller extends Action_Controller
 	}
 
 	/**
+	 * Applys the filter to the template
+	 *
+	 * @param mixed[] $filter
+	 */
+	private function _applyFilter($filter)
+	{
+		global $context, $scripturl, $user_profile;
+
+		if (isset($filter))
+		{
+			$context['filter'] = &$filter;
+
+			// Set the filtering context.
+			switch ($filter['variable'])
+			{
+				case 'id_member':
+					$id = $filter['value']['sql'];
+					loadMemberData($id, false, 'minimal');
+					$context['filter']['value']['html'] = '<a href="' . $scripturl . '?action=profile;u=' . $id . '">' . $user_profile[$id]['real_name'] . '</a>';
+					break;
+				case 'url':
+					$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars((substr($filter['value']['sql'], 0, 1) == '?' ? $scripturl : '') . $filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array('\_' => '_')) . '\'';
+					break;
+				case 'message':
+					$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars($filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array("\n" => '<br />', '&lt;br /&gt;' => '<br />', "\t" => '&nbsp;&nbsp;&nbsp;', '\_' => '_', '\\%' => '%', '\\\\' => '\\')) . '\'';
+					$context['filter']['value']['html'] = preg_replace('~&amp;lt;span class=&amp;quot;remove&amp;quot;&amp;gt;(.+?)&amp;lt;/span&amp;gt;~', '$1', $context['filter']['value']['html']);
+					break;
+				case 'error_type':
+					$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars($filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array("\n" => '<br />', '&lt;br /&gt;' => '<br />', "\t" => '&nbsp;&nbsp;&nbsp;', '\_' => '_', '\\%' => '%', '\\\\' => '\\')) . '\'';
+					break;
+				default:
+					$context['filter']['value']['html'] = &$filter['value']['sql'];
+			}
+		}
+	}
+
+	/**
+	 * Load basic member information for log viewing
+	 *
+	 * @param int[] $members
+	 */
+	private function _loadMemData($members)
+	{
+		global $context, $txt, $scripturl;
+
+		// Load the member data.
+		if (!empty($members))
+		{
+			require_once(SUBSDIR . '/Members.subs.php');
+			$members = getBasicMemberData($members, array('add_guest' => true));
+
+			// Go through each error and tack the data on.
+			foreach ($context['errors'] as $id => $dummy)
+			{
+				$memID = $context['errors'][$id]['member']['id'];
+				$context['errors'][$id]['member']['username'] = $members[$memID]['member_name'];
+				$context['errors'][$id]['member']['name'] = $members[$memID]['real_name'];
+				$context['errors'][$id]['member']['href'] = empty($memID) ? '' : $scripturl . '?action=profile;u=' . $memID;
+				$context['errors'][$id]['member']['link'] = empty($memID) ? $txt['guest_title'] : '<a href="' . $scripturl . '?action=profile;u=' . $memID . '">' . $context['errors'][$id]['member']['name'] . '</a>';
+			}
+		}
+	}
+
+	/**
+	 * Setup any filtering the user may have selected
+	 */
+	private function _setupFiltering()
+	{
+		global $txt;
+
+		// We'll escape some strings...
+		$db = database();
+
+		// You can filter by any of the following columns:
+		$filters = array(
+			'id_member' => $txt['username'],
+			'ip' => $txt['ip_address'],
+			'session' => $txt['session'],
+			'url' => $txt['error_url'],
+			'message' => $txt['error_message'],
+			'error_type' => $txt['error_type'],
+			'file' => $txt['file'],
+			'line' => $txt['line'],
+		);
+
+		$filter = null;
+
+		// Set up the filtering...
+		if (isset($this->_req->query->value, $this->_req->query->filter) && isset($filters[$this->_req->query->filter]))
+		{
+			$filter = array(
+				'variable' => $this->_req->query->filter,
+				'value' => array(
+					'sql' => in_array($this->_req->query->filter, array('message', 'url', 'file'))
+						? base64_decode(strtr($this->_req->query->value, array(' ' => '+')))
+						: $db->escape_wildcard_string($this->_req->query->value),
+				),
+				'href' => ';filter=' . $this->_req->query->filter . ';value=' . $this->_req->query->value,
+				'entity' => $filters[$this->_req->query->filter]
+			);
+		}
+		elseif (isset($this->_req->query->filter) || isset($this->_req->query->value))
+			unset($this->_req->query->filter, $this->_req->query->value);
+
+		return $filter;
+	}
+
+	/**
 	 * View a file specified in $_REQUEST['file'], with php highlighting on it
 	 *
 	 * Preconditions:
@@ -234,13 +290,13 @@ class ManageErrors_Controller extends Action_Controller
 		global $context;
 
 		// We can't help you if you don't spell it out loud :P
-		if (!isset($_REQUEST['file']))
+		if (!isset($this->_req->query->file))
 			redirectexit();
 
 		// Decode the file and get the line
-		$filename = base64_decode($_REQUEST['file']);
+		$filename = base64_decode($this->_req->query->file);
 		$file = realpath($filename);
-		$line = isset($_REQUEST['line']) ? (int) $_REQUEST['line'] : 0;
+		$line = $this->_req->getQuery('line', 'intval', 0);
 
 		// Make sure things are normalized
 		$real_board = realpath(BOARDDIR);
@@ -251,6 +307,8 @@ class ManageErrors_Controller extends Action_Controller
 		$excluded = array('settings.php', 'settings_bak.php');
 		$basename = strtolower(basename($file));
 		$ext = strrchr($basename, '.');
+
+		// Not like we can look at just any old file
 		if ($ext !== '.php' || (strpos($file, $real_board) === false && strpos($file, $real_source) === false) || strpos($file, $real_cache) !== false || in_array($basename, $excluded) || !is_readable($file))
 			Errors::fatal_lang_error('error_bad_file', true, array(htmlspecialchars($filename, ENT_COMPAT, 'UTF-8')));
 

--- a/sources/admin/ManageErrors.controller.php
+++ b/sources/admin/ManageErrors.controller.php
@@ -171,7 +171,7 @@ class ManageErrors_Controller extends Action_Controller
 	/**
 	 * Applys the filter to the template
 	 *
-	 * @param mixed[] $filter
+	 * @param array $filter
 	 */
 	private function _applyFilter($filter)
 	{

--- a/sources/admin/ManageFeatures.controller.php
+++ b/sources/admin/ManageFeatures.controller.php
@@ -71,6 +71,20 @@ class ManageFeatures_Controller extends Action_Controller
 	protected $_PMSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * This function passes control through to the relevant tab.
 	 *
 	 * @see Action_Controller::action_index()
@@ -196,17 +210,17 @@ class ManageFeatures_Controller extends Action_Controller
 		$config_vars = $this->_basicSettings->settings();
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			// Prevent absurd boundaries here - make it a day tops.
-			if (isset($_POST['lastActive']))
-				$_POST['lastActive'] = min((int) $_POST['lastActive'], 1440);
+			if (isset($this->_req->post->lastActive))
+				$this->_req->post->lastActive = min((int) $this->_req->post->lastActive, 1440);
 
 			call_integration_hook('integrate_save_basic_settings');
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 
 			writeLog();
 			redirectexit('action=admin;area=featuresettings;sa=basic');
@@ -251,13 +265,13 @@ class ManageFeatures_Controller extends Action_Controller
 		$config_vars = $this->_layoutSettings->settings();
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			call_integration_hook('integrate_save_layout_settings');
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			writeLog();
 
 			redirectexit('action=admin;area=featuresettings;sa=layout');
@@ -299,13 +313,13 @@ class ManageFeatures_Controller extends Action_Controller
 		$config_vars = $this->_karmaSettings->settings();
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			call_integration_hook('integrate_save_karma_settings');
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			redirectexit('action=admin;area=featuresettings;sa=karma');
 		}
 
@@ -345,13 +359,13 @@ class ManageFeatures_Controller extends Action_Controller
 		$config_vars = $this->_likesSettings->settings();
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			call_integration_hook('integrate_save_likes_settings');
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			redirectexit('action=admin;area=featuresettings;sa=likes');
 		}
 
@@ -391,24 +405,24 @@ class ManageFeatures_Controller extends Action_Controller
 		$config_vars = $this->_mentionSettings->settings();
 
 		// Saving the settings?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			$enabled_mentions = !empty($modSettings['enabled_mentions']) ? explode(',', $modSettings['enabled_mentions']) : array();
 
-			if ((!isset($_POST['mentions_dont_notify_rlike']) && !empty($modSettings['mentions_dont_notify_rlike'])) || (isset($_POST['mentions_dont_notify_rlike']) && $_POST['mentions_dont_notify_rlike'] != $modSettings['mentions_dont_notify_rlike']))
+			if ((!isset($this->_req->post->mentions_dont_notify_rlike) && !empty($modSettings['mentions_dont_notify_rlike'])) || (isset($this->_req->post->mentions_dont_notify_rlike) && $this->_req->post->mentions_dont_notify_rlike != $modSettings['mentions_dont_notify_rlike']))
 			{
 				require_once(SUBSDIR . '/Mentions.subs.php');
-				toggleMentionsVisibility('rlike', empty($_POST['mentions_dont_notify_rlike']));
+				toggleMentionsVisibility('rlike', empty($this->_req->post->mentions_dont_notify_rlike));
 			}
 
-			if ((!isset($_POST['mentions_buddy']) && !empty($modSettings['mentions_buddy'])) || (isset($_POST['mentions_buddy']) && $_POST['mentions_buddy'] != $modSettings['mentions_buddy']))
+			if ((!isset($this->_req->post->mentions_buddy) && !empty($modSettings['mentions_buddy'])) || (isset($this->_req->post->mentions_buddy) && $this->_req->post->mentions_buddy != $modSettings['mentions_buddy']))
 			{
 				require_once(SUBSDIR . '/Mentions.subs.php');
-				toggleMentionsVisibility('buddy', !empty($_POST['mentions_buddy']));
+				toggleMentionsVisibility('buddy', !empty($this->_req->post->mentions_buddy));
 
-				if (!empty($_POST['mentions_buddy']))
+				if (!empty($this->_req->post->mentions_buddy))
 					$enabled_mentions[] = 'buddy';
 				else
 					$enabled_mentions = array_diff($enabled_mentions, array('buddy'));
@@ -416,15 +430,15 @@ class ManageFeatures_Controller extends Action_Controller
 
 			// If mentions are enabled, the related task should be enabled as well, otherwise should be disabled.
 			require_once(SUBSDIR . '/ScheduledTasks.subs.php');
-			toggleTaskStatusByName('user_access_mentions', !empty($_POST['mentions_enabled']));
+			toggleTaskStatusByName('user_access_mentions', !empty($this->_req->post->mentions_enabled));
 
-			if (!empty($_POST['mentions_dont_notify_rlike']))
+			if (!empty($this->_req->post->mentions_dont_notify_rlike))
 				$enabled_mentions = array_diff($enabled_mentions, array('rlikemsg'));
 			else
 				$enabled_mentions[] = 'rlikemsg';
 
 			$modules = array('post', 'display');
-			if (!empty($_POST['mentions_enabled']))
+			if (!empty($this->_req->post->mentions_enabled))
 			{
 				enableModules('mention', $modules);
 				$enabled_mentions[] = 'mentionmem';
@@ -436,7 +450,7 @@ class ManageFeatures_Controller extends Action_Controller
 			}
 
 			updateSettings(array('enabled_mentions' => implode(',', $enabled_mentions)));
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			redirectexit('action=admin;area=featuresettings;sa=mention');
 		}
 
@@ -496,227 +510,17 @@ class ManageFeatures_Controller extends Action_Controller
 		$disabledTags = !empty($sig_bbc) ? explode(',', $sig_bbc) : array();
 
 		// Applying to ALL signatures?!!
-		if (isset($_GET['apply']))
+		if (isset($this->_req->query->apply))
 		{
 			// Security!
 			checkSession('get');
 
 			require_once(SUBSDIR . '/ManageFeatures.subs.php');
-			require_once(SUBSDIR . '/Members.subs.php');
 			$sig_start = time();
 
 			// This is horrid - but I suppose some people will want the option to do it.
-			$applied_sigs = isset($_GET['step']) ? (int) $_GET['step'] : 0;
-			$done = false;
-			$context['max_member'] = maxMemberID();
-
-			while (!$done)
-			{
-				$changes = array();
-				$update_sigs = getSignatureFromMembers($applied_sigs);
-
-				if (empty($update_sigs))
-					$done = true;
-
-				foreach ($update_sigs as $row)
-				{
-					// Apply all the rules we can realistically do.
-					$sig = strtr($row['signature'], array('<br />' => "\n"));
-
-					// Max characters...
-					if (!empty($sig_limits[1]))
-						$sig = Util::substr($sig, 0, $sig_limits[1]);
-
-					// Max lines...
-					if (!empty($sig_limits[2]))
-					{
-						$count = 0;
-						$str_len = strlen($sig);
-						for ($i = 0; $i < $str_len; $i++)
-						{
-							if ($sig[$i] == "\n")
-							{
-								$count++;
-								if ($count >= $sig_limits[2])
-									$sig = substr($sig, 0, $i) . strtr(substr($sig, $i), array("\n" => ' '));
-							}
-						}
-					}
-
-					if (!empty($sig_limits[7]) && preg_match_all('~\[size=([\d\.]+)?(px|pt|em|x-large|larger)~i', $sig, $matches) !== false && isset($matches[2]))
-					{
-						foreach ($matches[1] as $ind => $size)
-						{
-							$limit_broke = 0;
-
-							// Attempt to allow all sizes of abuse, so to speak.
-							if ($matches[2][$ind] == 'px' && $size > $sig_limits[7])
-								$limit_broke = $sig_limits[7] . 'px';
-							elseif ($matches[2][$ind] == 'pt' && $size > ($sig_limits[7] * 0.75))
-								$limit_broke = ((int) $sig_limits[7] * 0.75) . 'pt';
-							elseif ($matches[2][$ind] == 'em' && $size > ((float) $sig_limits[7] / 16))
-								$limit_broke = ((float) $sig_limits[7] / 16) . 'em';
-							elseif ($matches[2][$ind] != 'px' && $matches[2][$ind] != 'pt' && $matches[2][$ind] != 'em' && $sig_limits[7] < 18)
-								$limit_broke = 'large';
-
-							if ($limit_broke)
-								$sig = str_replace($matches[0][$ind], '[size=' . $sig_limits[7] . 'px', $sig);
-						}
-					}
-
-					// Stupid images - this is stupidly, stupidly challenging.
-					if ((!empty($sig_limits[3]) || !empty($sig_limits[5]) || !empty($sig_limits[6])))
-					{
-						$replaces = array();
-						$img_count = 0;
-
-						// Get all BBC tags...
-						preg_match_all('~\[img(\s+width=([\d]+))?(\s+height=([\d]+))?(\s+width=([\d]+))?\s*\](?:<br />)*([^<">]+?)(?:<br />)*\[/img\]~i', $sig, $matches);
-
-						// ... and all HTML ones.
-						preg_match_all('~&lt;img\s+src=(?:&quot;)?((?:http://|ftp://|https://|ftps://).+?)(?:&quot;)?(?:\s+alt=(?:&quot;)?(.*?)(?:&quot;)?)?(?:\s?/)?&gt;~i', $sig, $matches2, PREG_PATTERN_ORDER);
-
-						// And stick the HTML in the BBC.
-						if (!empty($matches2))
-						{
-							foreach ($matches2[0] as $ind => $dummy)
-							{
-								$matches[0][] = $matches2[0][$ind];
-								$matches[1][] = '';
-								$matches[2][] = '';
-								$matches[3][] = '';
-								$matches[4][] = '';
-								$matches[5][] = '';
-								$matches[6][] = '';
-								$matches[7][] = $matches2[1][$ind];
-							}
-						}
-
-						// Try to find all the images!
-						if (!empty($matches))
-						{
-							$image_count_holder = array();
-							foreach ($matches[0] as $key => $image)
-							{
-								$width = -1; $height = -1;
-								$img_count++;
-
-								// Too many images?
-								if (!empty($sig_limits[3]) && $img_count > $sig_limits[3])
-								{
-									// If we've already had this before we only want to remove the excess.
-									if (isset($image_count_holder[$image]))
-									{
-										$img_offset = -1;
-										$rep_img_count = 0;
-										while ($img_offset !== false)
-										{
-											$img_offset = strpos($sig, $image, $img_offset + 1);
-											$rep_img_count++;
-											if ($rep_img_count > $image_count_holder[$image])
-											{
-												// Only replace the excess.
-												$sig = substr($sig, 0, $img_offset) . str_replace($image, '', substr($sig, $img_offset));
-
-												// Stop looping.
-												$img_offset = false;
-											}
-										}
-									}
-									else
-										$replaces[$image] = '';
-
-									continue;
-								}
-
-								// Does it have predefined restraints? Width first.
-								if ($matches[6][$key])
-									$matches[2][$key] = $matches[6][$key];
-
-								if ($matches[2][$key] && $sig_limits[5] && $matches[2][$key] > $sig_limits[5])
-								{
-									$width = $sig_limits[5];
-									$matches[4][$key] = $matches[4][$key] * ($width / $matches[2][$key]);
-								}
-								elseif ($matches[2][$key])
-									$width = $matches[2][$key];
-
-								// ... and height.
-								if ($matches[4][$key] && $sig_limits[6] && $matches[4][$key] > $sig_limits[6])
-								{
-									$height = $sig_limits[6];
-									if ($width != -1)
-										$width = $width * ($height / $matches[4][$key]);
-								}
-								elseif ($matches[4][$key])
-									$height = $matches[4][$key];
-
-								// If the dimensions are still not fixed - we need to check the actual image.
-								if (($width == -1 && $sig_limits[5]) || ($height == -1 && $sig_limits[6]))
-								{
-									// We'll mess up with images, who knows.
-									require_once(SUBSDIR . '/Attachments.subs.php');
-
-									$sizes = url_image_size($matches[7][$key]);
-									if (is_array($sizes))
-									{
-										// Too wide?
-										if ($sizes[0] > $sig_limits[5] && $sig_limits[5])
-										{
-											$width = $sig_limits[5];
-											$sizes[1] = $sizes[1] * ($width / $sizes[0]);
-										}
-
-										// Too high?
-										if ($sizes[1] > $sig_limits[6] && $sig_limits[6])
-										{
-											$height = $sig_limits[6];
-											if ($width == -1)
-												$width = $sizes[0];
-											$width = $width * ($height / $sizes[1]);
-										}
-										elseif ($width != -1)
-											$height = $sizes[1];
-									}
-								}
-
-								// Did we come up with some changes? If so remake the string.
-								if ($width != -1 || $height != -1)
-									$replaces[$image] = '[img' . ($width != -1 ? ' width=' . round($width) : '') . ($height != -1 ? ' height=' . round($height) : '') . ']' . $matches[7][$key] . '[/img]';
-
-								// Record that we got one.
-								$image_count_holder[$image] = isset($image_count_holder[$image]) ? $image_count_holder[$image] + 1 : 1;
-							}
-
-							if (!empty($replaces))
-								$sig = str_replace(array_keys($replaces), array_values($replaces), $sig);
-						}
-					}
-
-					// Try to fix disabled tags.
-					if (!empty($disabledTags))
-					{
-						$sig = preg_replace('~\[(?:' . implode('|', $disabledTags) . ').+?\]~i', '', $sig);
-						$sig = preg_replace('~\[/(?:' . implode('|', $disabledTags) . ')\]~i', '', $sig);
-					}
-
-					$sig = strtr($sig, array("\n" => '<br />'));
-					call_integration_hook('integrate_apply_signature_settings', array(&$sig, $sig_limits, $disabledTags));
-					if ($sig != $row['signature'])
-						$changes[$row['id_member']] = $sig;
-				}
-
-				// Do we need to delete what we have?
-				if (!empty($changes))
-				{
-					foreach ($changes as $id => $sig)
-						updateSignature($id, $sig);
-				}
-
-				$applied_sigs += 50;
-				if (!$done)
-					pauseSignatureApplySettings($applied_sigs);
-			}
+			$applied_sigs = $this->_req->getQuery('step', 'intval', 0);
+			updateAllSignatures($applied_sigs);
 
 			$settings_applied = true;
 		}
@@ -741,7 +545,7 @@ class ManageFeatures_Controller extends Action_Controller
 		$modSettings['bbc_disabled_signature_bbc'] = $disabledTags;
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
@@ -750,31 +554,31 @@ class ManageFeatures_Controller extends Action_Controller
 			foreach (parse_bbc(false) as $tag)
 				$bbcTags[] = $tag['tag'];
 
-			if (!isset($_POST['signature_bbc_enabledTags']))
-				$_POST['signature_bbc_enabledTags'] = array();
-			elseif (!is_array($_POST['signature_bbc_enabledTags']))
-				$_POST['signature_bbc_enabledTags'] = array($_POST['signature_bbc_enabledTags']);
+			if (!isset($this->_req->post->signature_bbc_enabledTags))
+				$this->_req->post->signature_bbc_enabledTags = array();
+			elseif (!is_array($this->_req->post->signature_bbc_enabledTags))
+				$this->_req->post->signature_bbc_enabledTags = array($this->_req->post->signature_bbc_enabledTags);
 
 			$sig_limits = array();
 			foreach ($context['signature_settings'] as $key => $value)
 			{
 				if ($key == 'allow_smileys')
 					continue;
-				elseif ($key == 'max_smileys' && empty($_POST['signature_allow_smileys']))
+				elseif ($key == 'max_smileys' && empty($this->_req->post->signature_allow_smileys))
 					$sig_limits[] = -1;
 				else
-					$sig_limits[] = !empty($_POST['signature_' . $key]) ? max(1, (int) $_POST['signature_' . $key]) : 0;
+					$sig_limits[] = !empty($this->_req->getPost('signature_' . $key)) ? max(1, $this->_req->getPost('signature_' . $key, 'intval')) : 0;
 			}
 
 			call_integration_hook('integrate_save_signature_settings', array(&$sig_limits, &$bbcTags));
 
-			$_POST['signature_settings'] = implode(',', $sig_limits) . ':' . implode(',', array_diff($bbcTags, $_POST['signature_bbc_enabledTags']));
+			$this->_req->post->signature_settings = implode(',', $sig_limits) . ':' . implode(',', array_diff($bbcTags, $this->_req->post->signature_bbc_enabledTags));
 
 			// Even though we have practically no settings let's keep the convention going!
 			$save_vars = array();
 			$save_vars[] = array('text', 'signature_settings');
 
-			Settings_Form::save_db($save_vars);
+			Settings_Form::save_db($save_vars, $this->_req->post);
 			redirectexit('action=admin;area=featuresettings;sa=sig');
 		}
 
@@ -822,7 +626,7 @@ class ManageFeatures_Controller extends Action_Controller
 		$context['fields_no_registration'] = array('posts', 'warning_status');
 
 		// Are we saving any standard field changes?
-		if (isset($_POST['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 			validateToken('admin-scp');
@@ -831,11 +635,13 @@ class ManageFeatures_Controller extends Action_Controller
 
 			// Do the active ones first.
 			$disable_fields = array_flip($standard_fields);
-			if (!empty($_POST['active']))
+			if (!empty($this->_req->post->active))
 			{
-				foreach ($_POST['active'] as $value)
+				foreach ($this->_req->post->active as $value)
+				{
 					if (isset($disable_fields[$value]))
 						unset($disable_fields[$value]);
+				}
 			}
 
 			// What we have left!
@@ -843,11 +649,13 @@ class ManageFeatures_Controller extends Action_Controller
 
 			// Things we want to show on registration?
 			$reg_fields = array();
-			if (!empty($_POST['reg']))
+			if (!empty($this->_req->post->reg))
 			{
-				foreach ($_POST['reg'] as $value)
+				foreach ($this->_req->post->reg as $value)
+				{
 					if (in_array($value, $standard_fields) && !isset($disable_fields[$value]))
 						$reg_fields[] = $value;
+				}
 			}
 
 			// What we have left!
@@ -1089,18 +897,18 @@ class ManageFeatures_Controller extends Action_Controller
 		loadTemplate('ManageFeatures');
 
 		// Sort out the context!
-		$context['fid'] = isset($_GET['fid']) ? (int) $_GET['fid'] : 0;
+		$context['fid'] = $this->_req->getQuery('fid', 'intval', 0);
 		$context[$context['admin_menu_name']]['current_subsection'] = 'profile';
 		$context['page_title'] = $context['fid'] ? $txt['custom_edit_title'] : $txt['custom_add_title'];
 		$context['sub_template'] = 'edit_profile_field';
 
-		// any errors messages to show?
-		if (isset($_GET['msg']))
+		// Any errors messages to show?
+		if (isset($this->_req->query->msg))
 		{
 			loadLanguage('Errors');
 
-			if (isset($txt['custom_option_' . $_GET['msg']]))
-				$context['custom_option__error'] = $txt['custom_option_' . $_GET['msg']];
+			if (isset($txt['custom_option_' . $this->_req->query->msg]))
+				$context['custom_option__error'] = $txt['custom_option_' . $this->_req->query->msg];
 		}
 
 		// Load the profile language for section names.
@@ -1142,61 +950,61 @@ class ManageFeatures_Controller extends Action_Controller
 		addInlineJavascript('updateInputBoxes();', true);
 
 		// Are we toggling which ones are active?
-		if (isset($_POST['onoff']))
+		if (isset($this->_req->post->onoff))
 		{
 			checkSession();
 			validateToken('admin-scp');
 
 			// Enable and disable custom fields as required.
 			$enabled = array(0);
-			foreach ($_POST['cust'] as $id)
+			foreach ($this->_req->post->cust as $id)
 				$enabled[] = (int) $id;
 
 			updateRenamedProfileStatus($enabled);
 		}
 		// Are we saving?
-		elseif (isset($_POST['save']))
+		elseif (isset($this->_req->post->save))
 		{
 			checkSession();
 			validateToken('admin-ecp');
 
 			// Everyone needs a name - even the (bracket) unknown...
-			if (trim($_POST['field_name']) == '')
-				redirectexit($scripturl . '?action=admin;area=featuresettings;sa=profileedit;fid=' . $_GET['fid'] . ';msg=need_name');
+			if (trim($this->_req->post->field_name) == '')
+				redirectexit($scripturl . '?action=admin;area=featuresettings;sa=profileedit;fid=' . $this->_req->query->fid . ';msg=need_name');
 
 			// Regex you say?  Do a very basic test to see if the pattern is valid
-			if (!empty($_POST['regex']) && @preg_match($_POST['regex'], 'dummy') === false)
-				redirectexit($scripturl . '?action=admin;area=featuresettings;sa=profileedit;fid=' . $_GET['fid'] . ';msg=regex_error');
+			if (!empty($this->_req->post->regex) && @preg_match($this->_req->post->regex, 'dummy') === false)
+				redirectexit($scripturl . '?action=admin;area=featuresettings;sa=profileedit;fid=' . $this->_req->query->fid . ';msg=regex_error');
 
-			$_POST['field_name'] = Util::htmlspecialchars($_POST['field_name']);
-			$_POST['field_desc'] = Util::htmlspecialchars($_POST['field_desc']);
+			$this->_req->post->field_name = $this->_req->getPost('field_name', 'Util::htmlspecialchars');
+			$this->_req->post->field_desc = $this->_req->getPost('field_desc', 'Util::htmlspecialchars');
 
 			// Checkboxes...
-			$show_reg = isset($_POST['reg']) ? (int) $_POST['reg'] : 0;
-			$show_display = isset($_POST['display']) ? 1 : 0;
-			$show_memberlist = isset($_POST['memberlist']) ? 1 : 0;
-			$bbc = isset($_POST['bbc']) ? 1 : 0;
-			$show_profile = $_POST['profile_area'];
-			$active = isset($_POST['active']) ? 1 : 0;
-			$private = isset($_POST['private']) ? (int) $_POST['private'] : 0;
-			$can_search = isset($_POST['can_search']) ? 1 : 0;
+			$show_reg = $this->_req->getPost('reg', 'intval', 0);
+			$show_display = isset($this->_req->post->display) ? 1 : 0;
+			$show_memberlist = isset($this->_req->post->memberlist) ? 1 : 0;
+			$bbc = isset($this->_req->post->bbc) ? 1 : 0;
+			$show_profile = $this->_req->post->profile_area;
+			$active = isset($this->_req->post->active) ? 1 : 0;
+			$private = $this->_req->getPost('private', 'intval', 0);
+			$can_search = isset($this->_req->post->can_search) ? 1 : 0;
 
 			// Some masking stuff...
-			$mask = isset($_POST['mask']) ? $_POST['mask'] : '';
-			if ($mask == 'regex' && isset($_POST['regex']))
-				$mask .= $_POST['regex'];
+			$mask = $this->_req->getPost('mask', 'strval', '');
+			if ($mask == 'regex' && isset($this->_req->post->regex))
+				$mask .= $this->_req->post->regex;
 
-			$field_length = isset($_POST['max_length']) ? (int) $_POST['max_length'] : 255;
-			$enclose = isset($_POST['enclose']) ? $_POST['enclose'] : '';
-			$placement = isset($_POST['placement']) ? (int) $_POST['placement'] : 0;
+			$field_length = $this->_req->getPost('max_length', 'intval', 255);
+			$enclose = $this->_req->getPost('enclose', 'strval', '');
+			$placement = $this->_req->getPost('placement', 'intval', 0);
 
 			// Select options?
 			$field_options = '';
 			$newOptions = array();
-			$default = isset($_POST['default_check']) && $_POST['field_type'] == 'check' ? 1 : '';
-			if (!empty($_POST['select_option']) && ($_POST['field_type'] == 'select' || $_POST['field_type'] == 'radio'))
+			$default = isset($this->_req->post->default_check) && $this->_req->post->field_type == 'check' ? 1 : '';
+			if (!empty($this->_req->post->select_option) && ($this->_req->post->field_type == 'select' || $this->_req->post->field_type == 'radio'))
 			{
-				foreach ($_POST['select_option'] as $k => $v)
+				foreach ($this->_req->post->select_option as $k => $v)
 				{
 					// Clean, clean, clean...
 					$v = Util::htmlspecialchars($v);
@@ -1213,7 +1021,7 @@ class ManageFeatures_Controller extends Action_Controller
 					$newOptions[$k] = $v;
 
 					// Is it default?
-					if (isset($_POST['default_select']) && $_POST['default_select'] == $k)
+					if (isset($this->_req->post->default_select) && $this->_req->post->default_select == $k)
 						$default = $v;
 				}
 
@@ -1221,13 +1029,13 @@ class ManageFeatures_Controller extends Action_Controller
 			}
 
 			// Text area by default has dimensions
-			if ($_POST['field_type'] == 'textarea')
-				$default = (int) $_POST['rows'] . ',' . (int) $_POST['cols'];
+			if ($this->_req->post->field_type == 'textarea')
+				$default = (int) $this->_req->post->rows . ',' . (int) $this->_req->post->cols;
 
 			// Come up with the unique name?
 			if (empty($context['fid']))
 			{
-				$colname = Util::substr(strtr($_POST['field_name'], array(' ' => '')), 0, 6);
+				$colname = Util::substr(strtr($this->_req->post->field_name, array(' ' => '')), 0, 6);
 				preg_match('~([\w\d_-]+)~', $colname, $matches);
 
 				// If there is nothing to the name, then let's start our own - for foreign languages etc.
@@ -1238,7 +1046,7 @@ class ManageFeatures_Controller extends Action_Controller
 
 				$unique = ensureUniqueProfileField($colname, $initial_colname);
 
-				// Still not a unique colum name? Leave it up to the user, then.
+				// Still not a unique column name? Leave it up to the user, then.
 				if (!$unique)
 					Errors::fatal_lang_error('custom_option_not_unique');
 			}
@@ -1246,14 +1054,14 @@ class ManageFeatures_Controller extends Action_Controller
 			else
 			{
 				// Anything going to check or select is pointless keeping - as is anything coming from check!
-				if (($_POST['field_type'] == 'check' && $context['field']['type'] != 'check')
-					|| (($_POST['field_type'] == 'select' || $_POST['field_type'] == 'radio') && $context['field']['type'] != 'select' && $context['field']['type'] != 'radio')
-					|| ($context['field']['type'] == 'check' && $_POST['field_type'] != 'check'))
+				if (($this->_req->post->field_type == 'check' && $context['field']['type'] != 'check')
+					|| (($this->_req->post->field_type == 'select' || $this->_req->post->field_type == 'radio') && $context['field']['type'] != 'select' && $context['field']['type'] != 'radio')
+					|| ($context['field']['type'] == 'check' && $this->_req->post->field_type != 'check'))
 				{
 					deleteProfileFieldUserData($context['field']['colname']);
 				}
 				// Otherwise - if the select is edited may need to adjust!
-				elseif ($_POST['field_type'] == 'select' || $_POST['field_type'] == 'radio')
+				elseif ($this->_req->post->field_type == 'select' || $this->_req->post->field_type == 'radio')
 				{
 					$optionChanges = array();
 					$takenKeys = array();
@@ -1296,9 +1104,9 @@ class ManageFeatures_Controller extends Action_Controller
 					'can_search' => $can_search,
 					'bbc' => $bbc,
 					'current_field' => $context['fid'],
-					'field_name' => $_POST['field_name'],
-					'field_desc' => $_POST['field_desc'],
-					'field_type' => $_POST['field_type'],
+					'field_name' => $this->_req->post->field_name,
+					'field_desc' => $this->_req->post->field_desc,
+					'field_type' => $this->_req->post->field_type,
 					'field_options' => $field_options,
 					'show_profile' => $show_profile,
 					'default_value' => $default,
@@ -1310,7 +1118,7 @@ class ManageFeatures_Controller extends Action_Controller
 				updateProfileField($field_data);
 
 				// Just clean up any old selects - these are a pain!
-				if (($_POST['field_type'] == 'select' || $_POST['field_type'] == 'radio') && !empty($newOptions))
+				if (($this->_req->post->field_type == 'select' || $this->_req->post->field_type == 'radio') && !empty($newOptions))
 					deleteOldProfileFieldSelects($newOptions, $context['field']['colname']);
 			}
 			// Otherwise creating a new one
@@ -1318,9 +1126,9 @@ class ManageFeatures_Controller extends Action_Controller
 			{
 				$new_field = array(
 					'col_name' => $colname,
-					'field_name' => $_POST['field_name'],
-					'field_desc' => $_POST['field_desc'],
-					'field_type' => $_POST['field_type'],
+					'field_name' => $this->_req->post->field_name,
+					'field_desc' => $this->_req->post->field_desc,
+					'field_type' => $this->_req->post->field_type,
 					'field_length' => $field_length,
 					'field_options' => $field_options,
 					'show_reg' => $show_reg,
@@ -1341,7 +1149,7 @@ class ManageFeatures_Controller extends Action_Controller
 			}
 		}
 		// Deleting?
-		elseif (isset($_POST['delete']) && $context['field']['colname'])
+		elseif (isset($this->_req->post->delete) && $context['field']['colname'])
 		{
 			checkSession();
 			validateToken('admin-ecp');
@@ -1352,7 +1160,7 @@ class ManageFeatures_Controller extends Action_Controller
 		}
 
 		// Rebuild display cache etc.
-		if (isset($_POST['delete']) || isset($_POST['save']) || isset($_POST['onoff']))
+		if (isset($this->_req->post->delete) || isset($this->_req->post->save) || isset($this->_req->post->onoff))
 		{
 			checkSession();
 
@@ -1385,20 +1193,20 @@ class ManageFeatures_Controller extends Action_Controller
 		$context['pm_limits'] = loadPMLimits();
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			require_once(SUBSDIR . '/Membergroups.subs.php');
 			foreach ($context['pm_limits'] as $group_id => $group)
 			{
-				if (isset($_POST['group'][$group_id]) && $_POST['group'][$group_id] != $group['max_messages'])
-					updateMembergroupProperties(array('current_group' => $group_id, 'max_messages' => $_POST['group'][$group_id]));
+				if (isset($this->_req->post->group[$group_id]) && $this->_req->post->group[$group_id] != $group['max_messages'])
+					updateMembergroupProperties(array('current_group' => $group_id, 'max_messages' => $this->_req->post->group[$group_id]));
 			}
 
 			call_integration_hook('integrate_save_pmsettings_settings');
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			redirectexit('action=admin;area=featuresettings;sa=pmsettings');
 		}
 

--- a/sources/admin/ManageFeatures.controller.php
+++ b/sources/admin/ManageFeatures.controller.php
@@ -567,7 +567,10 @@ class ManageFeatures_Controller extends Action_Controller
 				elseif ($key == 'max_smileys' && empty($this->_req->post->signature_allow_smileys))
 					$sig_limits[] = -1;
 				else
-					$sig_limits[] = !empty($this->_req->getPost('signature_' . $key)) ? max(1, $this->_req->getPost('signature_' . $key, 'intval')) : 0;
+				{
+					$current_key = $this->_req->getPost('signature_' . $key, 'intval');
+					$sig_limits[] = !empty($current_key) ? max(1, $current_key) : 0;
+				}
 			}
 
 			call_integration_hook('integrate_save_signature_settings', array(&$sig_limits, &$bbcTags));

--- a/sources/admin/ManageLanguages.controller.php
+++ b/sources/admin/ManageLanguages.controller.php
@@ -34,6 +34,20 @@ class ManageLanguages_Controller extends Action_Controller
 	protected $_languageSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * This is the main function for the languages area.
 	 *
 	 * What it does:
@@ -88,13 +102,13 @@ class ManageLanguages_Controller extends Action_Controller
 		global $context, $txt;
 
 		// Are we searching for new languages on the site?
-		if (!empty($_POST['lang_add_sub']))
+		if (!empty($this->_req->post->lang_add_sub))
 		{
 			// Need fetch_web_data.
 			require_once(SUBSDIR . '/Package.subs.php');
 			require_once(SUBSDIR . '/Language.subs.php');
 
-			$context['elk_search_term'] = htmlspecialchars(trim($_POST['lang_add']), ENT_COMPAT, 'UTF-8');
+			$context['elk_search_term'] = $this->_req->getPost('lang_add', 'trim|htmlspecialchars[ENT_COMPAT]');
 
 			$listOptions = array(
 				'id' => 'languages',
@@ -163,7 +177,7 @@ class ManageLanguages_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Language.subs.php');
 
 		// Setting a new default?
-		if (!empty($_POST['set_default']) && !empty($_POST['def_language']))
+		if (!empty($this->_req->post->set_default) && !empty($this->_req->post->def_language))
 		{
 			checkSession();
 			validateToken('admin-lang');
@@ -172,17 +186,17 @@ class ManageLanguages_Controller extends Action_Controller
 			$available_langs = getLanguages();
 			foreach ($available_langs as $lang)
 			{
-				if ($_POST['def_language'] == $lang['filename'])
+				if ($this->_req->post->def_language == $lang['filename'])
 				{
 					$lang_exists = true;
 					break;
 				}
 			}
 
-			if ($_POST['def_language'] != $language && $lang_exists)
+			if ($this->_req->post->def_language != $language && $lang_exists)
 			{
-				Settings_Form::save_file(array('language' => '\'' . $_POST['def_language'] . '\''));
-				$language = $_POST['def_language'];
+				Settings_Form::save_file(array('language' => '\'' . $this->_req->post->def_language . '\''));
+				$language = $this->_req->post->def_language;
 			}
 		}
 
@@ -306,16 +320,16 @@ class ManageLanguages_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Package.subs.php');
 
 		// Clearly we need to know what to request.
-		if (!isset($_GET['did']))
+		if (!isset($this->_req->query->did))
 			Errors::fatal_lang_error('no_access', false);
 
 		// Some lovely context.
-		$context['download_id'] = $_GET['did'];
+		$context['download_id'] = $this->_req->query->did;
 		$context['sub_template'] = 'download_language';
 		$context['menu_data_' . $context['admin_menu_id']]['current_subsection'] = 'add';
 
 		// Can we actually do the installation - and do they want to?
-		if (!empty($_POST['do_install']) && !empty($_POST['copy_file']))
+		if (!empty($this->_req->post->do_install) && !empty($this->_req->post->copy_file))
 		{
 			checkSession('get');
 			validateToken('admin-dlang');
@@ -324,7 +338,7 @@ class ManageLanguages_Controller extends Action_Controller
 			$install_files = array();
 
 			// Check writable status.
-			foreach ($_POST['copy_file'] as $file)
+			foreach ($this->_req->post->copy_file as $file)
 			{
 				// Check it's not very bad.
 				if (strpos($file, '..') !== false || (strpos($file, 'themes') !== 0 && !preg_match('~agreement\.[A-Za-z-_0-9]+\.txt$~', $file)))
@@ -346,6 +360,7 @@ class ManageLanguages_Controller extends Action_Controller
 			{
 				// @todo retrieve the language pack per naming pattern from our sites
 				read_tgz_file('http://download.elkarte.net/fetch_language.php?version=' . urlencode(strtr(FORUM_VERSION, array('ElkArte ' => ''))) . ';fetch=' . urlencode($_GET['did']), BOARDDIR, false, true, $install_files);
+				read_tgz_file('http://download.elkarte.net/fetch_language.php?version=' . urlencode(strtr($forum_version, array('ElkArte ' => ''))) . ';fetch=' . urlencode($this->_req->query->did), BOARDDIR, false, true, $install_files);
 
 				// Make sure the files aren't stuck in the cache.
 				package_flush_cache();
@@ -358,6 +373,7 @@ class ManageLanguages_Controller extends Action_Controller
 		// @todo Open up the old china.
 		if (!isset($archive_content))
 			$archive_content = read_tgz_file('http://download.elkarte.net/fetch_language.php?version=' . urlencode(strtr(FORUM_VERSION, array('ElkArte ' => ''))) . ';fetch=' . urlencode($_GET['did']), null);
+			$archive_content = read_tgz_file('http://download.elkarte.net/fetch_language.php?version=' . urlencode(strtr($forum_version, array('ElkArte ' => ''))) . ';fetch=' . urlencode($this->_req->query->did), null);
 
 		if (empty($archive_content))
 			Errors::fatal_error($txt['add_language_error_no_response']);
@@ -635,8 +651,8 @@ class ManageLanguages_Controller extends Action_Controller
 		$context['page_title'] = $txt['edit_languages'];
 		$context['sub_template'] = 'modify_language_entries';
 
-		$context['lang_id'] = $_GET['lid'];
-		list ($theme_id, $file_id) = empty($_REQUEST['tfid']) || strpos($_REQUEST['tfid'], '+') === false ? array(1, '') : explode('+', $_REQUEST['tfid']);
+		$context['lang_id'] = $this->_req->query->lid;
+		list ($theme_id, $file_id) = empty($this->_req->post->tfid) || strpos($this->_req->post->tfid, '+') === false ? array(1, '') : explode('+', $this->_req->post->tfid);
 
 		// Clean the ID - just in case.
 		preg_match('~([A-Za-z0-9_-]+)~', $context['lang_id'], $matches);
@@ -709,7 +725,7 @@ class ManageLanguages_Controller extends Action_Controller
 		// @todo - languages have been moved to packages
 		// this may or may not be used in the future, for now it's not used at all
 		// @deprecated since 1.0
-		if (!empty($_POST['delete_main']) && $context['lang_id'] != 'english')
+		if (!empty($this->_req->post->delete_main) && $context['lang_id'] != 'english')
 		{
 			checkSession();
 			validateToken('admin-mlang');
@@ -718,7 +734,7 @@ class ManageLanguages_Controller extends Action_Controller
 			require_once(SUBSDIR . '/Package.subs.php');
 
 			// First, Make a backup?
-			if (!empty($modSettings['package_make_backups']) && (!isset($_SESSION['last_backup_for']) || $_SESSION['last_backup_for'] != $context['lang_id'] . '$$$'))
+			if (!empty($modSettings['package_make_backups']) && (!isset($this->_req->session->last_backup_for) || $this->_req->session->last_backup_for != $context['lang_id'] . '$$$'))
 			{
 				$_SESSION['last_backup_for'] = $context['lang_id'] . '$$$';
 				package_create_backup('backup_lang_' . $context['lang_id']);
@@ -770,7 +786,7 @@ class ManageLanguages_Controller extends Action_Controller
 
 		// Saving primary settings?
 		$madeSave = false;
-		if (!empty($_POST['save_main']) && !$current_file)
+		if (!empty($this->_req->post->save_main) && !$current_file)
 		{
 			checkSession();
 			validateToken('admin-mlang');
@@ -780,10 +796,10 @@ class ManageLanguages_Controller extends Action_Controller
 
 			// These are the replacements. old => new
 			$replace_array = array(
-				'~\$txt\[\'lang_locale\'\]\s=\s(\'|")[^\r\n]+~' => '$txt[\'lang_locale\'] = \'' . addslashes($_POST['locale']) . '\';',
-				'~\$txt\[\'lang_dictionary\'\]\s=\s(\'|")[^\r\n]+~' => '$txt[\'lang_dictionary\'] = \'' . addslashes($_POST['dictionary']) . '\';',
-				'~\$txt\[\'lang_spelling\'\]\s=\s(\'|")[^\r\n]+~' => '$txt[\'lang_spelling\'] = \'' . addslashes($_POST['spelling']) . '\';',
-				'~\$txt\[\'lang_rtl\'\]\s=\s[A-Za-z0-9]+;~' => '$txt[\'lang_rtl\'] = ' . (!empty($_POST['rtl']) ? 'true' : 'false') . ';',
+				'~\$txt\[\'lang_locale\'\]\s=\s(\'|")[^\r\n]+~' => '$txt[\'lang_locale\'] = \'' . addslashes($this->_req->post->locale) . '\';',
+				'~\$txt\[\'lang_dictionary\'\]\s=\s(\'|")[^\r\n]+~' => '$txt[\'lang_dictionary\'] = \'' . addslashes($this->_req->post->dictionary) . '\';',
+				'~\$txt\[\'lang_spelling\'\]\s=\s(\'|")[^\r\n]+~' => '$txt[\'lang_spelling\'] = \'' . addslashes($this->_req->post->spelling) . '\';',
+				'~\$txt\[\'lang_rtl\'\]\s=\s[A-Za-z0-9]+;~' => '$txt[\'lang_rtl\'] = ' . (!empty($this->_req->post->rtl) ? 'true' : 'false') . ';',
 			);
 			$current_data = preg_replace(array_keys($replace_array), array_values($replace_array), $current_data);
 			$fp = fopen($settings['default_theme_dir'] . '/languages/' . $context['lang_id'] . '/index.' . $context['lang_id'] . '.php', 'w+');
@@ -812,16 +828,16 @@ class ManageLanguages_Controller extends Action_Controller
 
 		// Are we saving?
 		$save_strings = array();
-		if (isset($_POST['save_entries']) && !empty($_POST['entry']))
+		if (isset($this->_req->post->save_entries) && !empty($this->_req->post->entry))
 		{
 			checkSession();
 			validateToken('admin-mlang');
 
 			// Clean each entry!
-			foreach ($_POST['entry'] as $k => $v)
+			foreach ($this->_req->post->entry as $k => $v)
 			{
 				// Only try to save if it's changed!
-				if ($_POST['entry'][$k] != $_POST['comp'][$k])
+				if ($this->_req->post->entry[$k] != $this->_req->post->comp[$k])
 					$save_strings[$k] = cleanLangString($v, false);
 			}
 		}
@@ -1027,7 +1043,7 @@ class ManageLanguages_Controller extends Action_Controller
 		$settings_backup_fail = !@is_writable(BOARDDIR . '/Settings_bak.php') || !@copy(BOARDDIR . '/Settings.php', BOARDDIR . '/Settings_bak.php');
 
 		// Saving settings?
-		if (isset($_REQUEST['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 

--- a/sources/admin/ManageLanguages.controller.php
+++ b/sources/admin/ManageLanguages.controller.php
@@ -359,8 +359,7 @@ class ManageLanguages_Controller extends Action_Controller
 			elseif (!empty($install_files))
 			{
 				// @todo retrieve the language pack per naming pattern from our sites
-				read_tgz_file('http://download.elkarte.net/fetch_language.php?version=' . urlencode(strtr(FORUM_VERSION, array('ElkArte ' => ''))) . ';fetch=' . urlencode($_GET['did']), BOARDDIR, false, true, $install_files);
-				read_tgz_file('http://download.elkarte.net/fetch_language.php?version=' . urlencode(strtr($forum_version, array('ElkArte ' => ''))) . ';fetch=' . urlencode($this->_req->query->did), BOARDDIR, false, true, $install_files);
+				read_tgz_file('http://download.elkarte.net/fetch_language.php?version=' . urlencode(strtr(FORUM_VERSION, array('ElkArte ' => ''))) . ';fetch=' . urlencode($this->_req->query->did), BOARDDIR, false, true, $install_files);
 
 				// Make sure the files aren't stuck in the cache.
 				package_flush_cache();
@@ -372,8 +371,7 @@ class ManageLanguages_Controller extends Action_Controller
 
 		// @todo Open up the old china.
 		if (!isset($archive_content))
-			$archive_content = read_tgz_file('http://download.elkarte.net/fetch_language.php?version=' . urlencode(strtr(FORUM_VERSION, array('ElkArte ' => ''))) . ';fetch=' . urlencode($_GET['did']), null);
-			$archive_content = read_tgz_file('http://download.elkarte.net/fetch_language.php?version=' . urlencode(strtr($forum_version, array('ElkArte ' => ''))) . ';fetch=' . urlencode($this->_req->query->did), null);
+			$archive_content = read_tgz_file('http://download.elkarte.net/fetch_language.php?version=' . urlencode(strtr(FORUM_VERSION, array('ElkArte ' => ''))) . ';fetch=' . urlencode($this->_req->query->did), null);
 
 		if (empty($archive_content))
 			Errors::fatal_error($txt['add_language_error_no_response']);

--- a/sources/admin/ManageMaillist.controller.php
+++ b/sources/admin/ManageMaillist.controller.php
@@ -1527,7 +1527,7 @@ class ManageMaillist_Controller extends Action_Controller
 					updateSettings(array('disallow_sendBody' => ''));
 
 				updateSettings(array('maillist_receiving_address' => serialize($maillist_receiving_address)));
-				Settings_Form::save_db($config_vars, $this->req->post);
+				Settings_Form::save_db($config_vars, $this->_req->post);
 				writeLog();
 				redirectexit('action=admin;area=maillist;sa=emailsettings;saved');
 			}

--- a/sources/admin/ManageMaillist.controller.php
+++ b/sources/admin/ManageMaillist.controller.php
@@ -45,6 +45,20 @@ class ManageMaillist_Controller extends Action_Controller
 	protected $_parsersSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Main dispatcher.
 	 *
 	 * This function checks permissions and passes control to the sub action.
@@ -93,7 +107,7 @@ class ManageMaillist_Controller extends Action_Controller
 		);
 
 		// Default to sub action 'emaillist' if none was given, call integrate_sa_manage_maillist
-		$subAction = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) && (empty($subActions[$_REQUEST['sa']]['permission']) || allowedTo($subActions[$_REQUEST['sa']]['permission'])) ? $_REQUEST['sa'] : 'emaillist';
+		$subAction = isset($this->_req->query->sa) && isset($subActions[$this->_req->query->sa]) && (empty($subActions[$this->_req->query->sa]['permission']) || allowedTo($subActions[$this->_req->query->sa]['permission'])) ? $this->_req->query->sa : 'emaillist';
 		$subAction = $action->initialize($subActions, $subAction);
 
 		// Final bits
@@ -120,7 +134,7 @@ class ManageMaillist_Controller extends Action_Controller
 		global $context, $scripturl, $modSettings, $txt;
 
 		// Set an id if none was supplied
-		$id = (isset($_REQUEST['e_id']) ? (int) $_REQUEST['e_id'] : 0);
+		$id = $this->_req->getQuery('e_id', 'intval', 0);
 		if (empty($id) || $id <= 0)
 			$id = 0;
 
@@ -236,21 +250,21 @@ class ManageMaillist_Controller extends Action_Controller
 					),
 					'data' => array(
 						'function' => function ($rowData) {
-						global $txt;
+							global $txt;
 
-						// Do we have a type?
-						if (empty($rowData['type']))
-							return $txt['not_applicable'];
-						// Personal?
-						elseif ($rowData['type'] === 'p')
-							return $txt['personal_message'];
-						// New Topic?
-						elseif ($rowData['type'] === 'x')
-							return $txt['new_topic'];
-						// Ah a Reply then
-						else
-							return $txt['topic'] . ' ' . $txt['reply'];
-					},
+							// Do we have a type?
+							if (empty($rowData['type']))
+								return $txt['not_applicable'];
+							// Personal?
+							elseif ($rowData['type'] === 'p')
+								return $txt['personal_message'];
+							// New Topic?
+							elseif ($rowData['type'] === 'x')
+								return $txt['new_topic'];
+							// Ah a Reply then
+							else
+								return $txt['topic'] . ' ' . $txt['reply'];
+						},
 					),
 					'sort' => array(
 						'default' => 'message_type',
@@ -292,7 +306,7 @@ class ManageMaillist_Controller extends Action_Controller
 			'additional_rows' => array(
 				array(
 					'position' => 'top_of_list',
-					'value' => isset($_SESSION['email_error']) ? '<div class="' . (isset($_SESSION['email_error_type']) ? 'successbox' : 'errorbox') . '">' . $_SESSION['email_error'] . '</div>' : $txt['heading'],
+					'value' => isset($this->_req->session->email_error) ? '<div class="' . (isset($this->_req->session->email_error_type) ? 'successbox' : 'errorbox') . '">' . $this->_req->session->email_error . '</div>' : $txt['heading'],
 					'class' => 'windowbg2',
 				),
 			),
@@ -326,7 +340,7 @@ class ManageMaillist_Controller extends Action_Controller
 		checkSession('get');
 		validateToken('admin-ml', 'get');
 
-		$id = (int) $_GET['item'];
+		$id = (int) $this->_req->query->item;
 		if (!empty($id))
 		{
 			// Load up the email details, no funny biz ;)
@@ -381,7 +395,7 @@ class ManageMaillist_Controller extends Action_Controller
 		checkSession('get');
 		validateToken('admin-ml', 'get');
 
-		$id = (int) $_GET['item'];
+		$id = (int) $this->_req->query->item;
 
 		// Remove this entry
 		if (!empty($id))
@@ -412,7 +426,7 @@ class ManageMaillist_Controller extends Action_Controller
 		validateToken('admin-ml', 'get');
 
 		// Get the id to approve
-		$id = (int) $_GET['item'];
+		$id = (int) $this->_req->query->item;
 
 		if (!empty($id) && $id !== -1)
 		{
@@ -483,7 +497,7 @@ class ManageMaillist_Controller extends Action_Controller
 	{
 		global $context, $txt, $modSettings, $scripturl, $mbname;
 
-		if (!isset($_REQUEST['bounce']))
+		if (!isset($this->_req->query->bounce))
 		{
 			checkSession('get');
 			validateToken('admin-ml', 'get');
@@ -492,10 +506,10 @@ class ManageMaillist_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Mail.subs.php');
 
 		// We should have been sent an email ID
-		if (isset($_REQUEST['item']))
+		if (isset($this->_req->query->item))
 		{
 			// Needs to be an int!
-			$id = (int) $_REQUEST['item'];
+			$id = (int) $this->_req->query->item;
 
 			// Load up the email details, no funny biz yall ;)
 			$temp_email = list_maillist_unapproved($id);
@@ -503,7 +517,7 @@ class ManageMaillist_Controller extends Action_Controller
 			if (!empty($temp_email))
 			{
 				// Set the options
-				$_POST['item'] = (int) $temp_email[0]['id_email'];
+				$this->_req->post->item = (int) $temp_email[0]['id_email'];
 				$fullerrortext = $txt[$temp_email[0]['error_code']];
 
 				// Build the template selection area, first the standard ones
@@ -540,19 +554,19 @@ class ManageMaillist_Controller extends Action_Controller
 			$context['settings_message'] = $txt['badid'];
 
 		// Check if they are sending the notice
-		if (isset($_REQUEST['bounce']) && isset($temp_email))
+		if (isset($this->_req->query->bounce) && isset($temp_email))
 		{
 			checkSession('post');
 			validateToken('admin-ml');
 
 			// They did check the box, how else could they have posted
-			if (isset($_POST['warn_notify']))
+			if (isset($this->_req->post->warn_notify))
 			{
 				// lets make sure we have the items to send it
 				$check_emails = explode('=>', $temp_email[0]['from']);
 				$to = trim($check_emails[0]);
-				$subject = trim($_POST['warn_sub']);
-				$body = trim($_POST['warn_body']);
+				$subject = trim($this->_req->post->warn_sub);
+				$body = trim($this->_req->post->warn_body);
 
 				if (empty($body) || empty($subject))
 					$context['settings_message'] = $txt['bad_bounce'];
@@ -569,7 +583,7 @@ class ManageMaillist_Controller extends Action_Controller
 		createToken('admin-ml');
 		$context['warning_data'] = array('notify' => '', 'notify_subject' => '', 'notify_body' => '');
 		$context['body'] = isset($fullerrortext) ? parse_bbc($fullerrortext) : '';
-		$context['item'] = isset($_POST['item']) ? $_POST['item'] : '';
+		$context['item'] = isset($this->_req->post->item) ? $this->_req->post->item : '';
 		$context['notice_to'] = $txt['to'] . ' ' . isset($temp_email[0]['from']) ? $temp_email[0]['from'] : '';
 		$context['page_title'] = $txt['bounce_title'];
 		$context['sub_template'] = 'bounce_email';
@@ -694,8 +708,8 @@ class ManageMaillist_Controller extends Action_Controller
 			),
 			'additional_rows' => array(
 				array(
-					'position' => isset($_GET['saved']) ? 'top_of_list' : 'after_title',
-					'value' => isset($_GET['saved']) ? '<div class="successbox">' . $txt['saved'] . '</div>' : $txt['filters_title'],
+					'position' => isset($this->_req->query->saved) ? 'top_of_list' : 'after_title',
+					'value' => isset($this->_req->query->saved) ? '<div class="successbox">' . $txt['saved'] . '</div>' : $txt['filters_title'],
 					'class' => 'windowbg2',
 				),
 				array(
@@ -869,10 +883,10 @@ class ManageMaillist_Controller extends Action_Controller
 		global $context, $scripturl, $txt, $modSettings;
 
 		// Editing an existing filter?
-		if (isset($_REQUEST['f_id']))
+		if (isset($this->_req->query->f_id))
 		{
 			// Needs to be an int!
-			$id = (int) $_REQUEST['f_id'];
+			$id = (int) $this->_req->query->f_id;
 			if (empty($id) || $id <= 0)
 				Errors::fatal_lang_error('error_no_id_filter');
 
@@ -909,33 +923,33 @@ class ManageMaillist_Controller extends Action_Controller
 		$config_vars = $this->_filtersSettings->settings();
 
 		// Saving the new or edited entry?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			call_integration_hook('integrate_save_filter_settings');
 
 			// Editing an entry?
-			$editid = (isset($_GET['edit'])) ? (int) $_GET['edit'] : -1;
-			$editname = (isset($_GET['edit'])) ? 'id_filter' : '';
+			$editid = (isset($this->_req->query->edit)) ? (int) $this->_req->query->edit : -1;
+			$editname = (isset($this->_req->query->edit)) ? 'id_filter' : '';
 
 			// If its regex we do a quick check to see if its valid or not
-			if ($_POST['filter_type'] === 'regex')
+			if ($this->_req->post->filter_type === 'regex')
 			{
-				$valid = (@preg_replace($_POST['filter_from'], $_POST['filter_to'], 'ElkArte') === null) ? false : true;
+				$valid = (@preg_replace($this->_req->post->filter_from, $this->_req->post->filter_to, 'ElkArte') === null) ? false : true;
 				if (!$valid)
 				{
 					// Seems to be bad ... reload the form, set the message
 					$context['error_type'] = 'notice';
 					$context['settings_message'][] = $txt['regex_invalid'];
-					$modSettings['filter_type'] = $_POST['filter_type'];
-					$modSettings['filter_to'] = $_POST['filter_to'];
-					$modSettings['filter_from'] = $_POST['filter_from'];
-					$modSettings['filter_name'] = $_POST['filter_name'];
+					$modSettings['filter_type'] = $this->_req->post->filter_type;
+					$modSettings['filter_to'] = $this->_req->post->filter_to;
+					$modSettings['filter_from'] = $this->_req->post->filter_from;
+					$modSettings['filter_name'] = $this->_req->post->filter_name;
 				}
 			}
 
-			if (empty($_POST['filter_type']) || empty($_POST['filter_from']))
+			if (empty($this->_req->post->filter_type) || empty($this->_req->post->filter_from))
 			{
 				$context['error_type'] = 'notice';
 				$context['settings_message'][] = $txt['filter_invalid'];
@@ -946,16 +960,16 @@ class ManageMaillist_Controller extends Action_Controller
 			{
 				// And ... its a filter
 				$config_vars[] = array('text', 'filter_style');
-				$_POST['filter_style'] = 'filter';
+				$this->_req->post->filter_style = 'filter';
 
-				Email_Settings::saveTableSettings($config_vars, 'postby_emails_filters', array(), $editid, $editname);
+				Email_Settings::saveTableSettings($config_vars, 'postby_emails_filters', $this->_req->post, array(), $editid, $editname);
 				writeLog();
 				redirectexit('action=admin;area=maillist;sa=emailfilters;saved');
 			}
 		}
 
 		// Prepare some final context for the template
-		$title = !empty($_GET['saved']) ? 'saved_filter' : ($context['editing'] == true ? 'edit_filter' : 'add_filter');
+		$title = !empty($this->_req->query->saved) ? 'saved_filter' : ($context['editing'] == true ? 'edit_filter' : 'add_filter');
 		$context['post_url'] = $scripturl . '?action=admin;area=maillist;sa=editfilter' . ($context['editing'] ? ';edit=' . $modSettings['id_filter'] : ';new') . ';save';
 		$context['settings_title'] = $txt[$title];
 		$context['linktree'][] = array(
@@ -1008,10 +1022,10 @@ class ManageMaillist_Controller extends Action_Controller
 	public function action_delete_filters()
 	{
 		// Removing the filter?
-		if (isset($_GET['f_id']))
+		if (isset($this->_req->query->f_id))
 		{
 			checkSession('get');
-			$id = (int) $_GET['f_id'];
+			$id = (int) $this->_req->query->f_id;
 
 			maillist_delete_filter_parser($id);
 			redirectexit('action=admin;area=maillist;sa=emailfilters;deleted');
@@ -1123,8 +1137,8 @@ class ManageMaillist_Controller extends Action_Controller
 			),
 			'additional_rows' => array(
 				array(
-					'position' => isset($_GET['saved']) ? 'top_of_list' : 'after_title',
-					'value' => isset($_GET['saved']) ? '<div class="successbox">' . $txt['saved'] . '</div>' : $txt['parsers_title'],
+					'position' => isset($this->_req->query->saved) ? 'top_of_list' : 'after_title',
+					'value' => isset($this->_req->query->saved) ? '<div class="successbox">' . $txt['saved'] . '</div>' : $txt['parsers_title'],
 					'class' => 'windowbg2',
 				),
 				array(
@@ -1164,6 +1178,7 @@ class ManageMaillist_Controller extends Action_Controller
 			'items_per_page' => 0,
 			'no_items_label' => $txt['no_parsers'],
 			'base_href' => $scripturl . '?action=admin;area=maillist;sa=sortparsers',
+			'default_sort_col' => 'filterorder',
 			'get_items' => array(
 				'function' => array($this, 'load_filter_parser'),
 				'params' => array(
@@ -1261,10 +1276,10 @@ class ManageMaillist_Controller extends Action_Controller
 		global $context, $scripturl, $txt, $modSettings;
 
 		// Editing an existing filter?
-		if (isset($_REQUEST['f_id']))
+		if (isset($this->_req->query->f_id))
 		{
 			// Needs to be an int!
-			$id = (int) $_REQUEST['f_id'];
+			$id = (int) $this->_req->query->f_id;
 			if (empty($id) || $id < 0)
 				Errors::fatal_lang_error('error_no_id_filter');
 
@@ -1298,33 +1313,33 @@ class ManageMaillist_Controller extends Action_Controller
 		$config_vars = $this->_parsersSettings->settings();
 
 		// Check if they are saving the changes
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			call_integration_hook('integrate_save_parser_settings');
 
 			// Editing a parser?
-			$editid = isset($_GET['edit']) ? (int) $_GET['edit'] : -1;
-			$editname = isset($_GET['edit']) ? 'id_filter' : '';
+			$editid = isset($this->_req->query->edit) ? (int) $this->_req->query->edit : -1;
+			$editname = isset($this->_req->query->edit) ? 'id_filter' : '';
 
 			// Test the regex
-			if ($_POST['filter_type'] === 'regex' && !empty($_POST['filter_from']))
+			if ($this->_req->post->filter_type === 'regex' && !empty($this->_req->post->filter_from))
 			{
-				$valid = (preg_replace($_POST['filter_from'], '', 'ElkArte') === null) ? false : true;
+				$valid = (preg_replace($this->_req->post->filter_from, '', 'ElkArte') === null) ? false : true;
 				if (!$valid)
 				{
 					// Regex did not compute .. Danger, Will Robinson
 					$context['settings_message'] = $txt['regex_invalid'];
 					$context['error_type'] = 'notice';
 
-					$modSettings['filter_type'] = $_POST['filter_type'];
-					$modSettings['filter_from'] = $_POST['filter_from'];
-					$modSettings['filter_name'] = $_POST['filter_name'];
+					$modSettings['filter_type'] = $this->_req->post->filter_type;
+					$modSettings['filter_from'] = $this->_req->post->filter_from;
+					$modSettings['filter_name'] = $this->_req->post->filter_name;
 				}
 			}
 
-			if (empty($_POST['filter_type']) || empty($_POST['filter_from']))
+			if (empty($this->_req->post->filter_type) || empty($this->_req->post->filter_from))
 			{
 				$context['error_type'] = 'notice';
 				$context['settings_message'][] = $txt['filter_invalid'];
@@ -1335,17 +1350,17 @@ class ManageMaillist_Controller extends Action_Controller
 			{
 				// Shhh ... its really a parser
 				$config_vars[] = array('text', 'filter_style');
-				$_POST['filter_style'] = 'parser';
+				$this->_req->post->filter_style = 'parser';
 
 				// Save, log, show
-				Email_Settings::saveTableSettings($config_vars, 'postby_emails_filters', array(), $editid, $editname);
+				Email_Settings::saveTableSettings($config_vars, 'postby_emails_filters', $this->_req->post, array(), $editid, $editname);
 				writeLog();
 				redirectexit('action=admin;area=maillist;sa=emailparser;saved');
 			}
 		}
 
 		// Prepare the context for viewing
-		$title = ((isset($_GET['saved']) && $_GET['saved'] == '1') ? 'saved_parser' : ($context['editing'] == true ? 'edit_parser' : 'add_parser'));
+		$title = ((isset($this->_req->query->saved) && $this->_req->query->saved == '1') ? 'saved_parser' : ($context['editing'] == true ? 'edit_parser' : 'add_parser'));
 		$context['settings_title'] = $txt[$title];
 		$context['post_url'] = $scripturl . '?action=admin;area=maillist;sa=editparser' . ($context['editing'] ? ';edit=' . $modSettings['id_filter'] : ';new') . ';save';
 		$context['linktree'][] = array(
@@ -1397,10 +1412,10 @@ class ManageMaillist_Controller extends Action_Controller
 	public function action_delete_parsers()
 	{
 		// Removing the filter?
-		if (isset($_GET['f_id']))
+		if (isset($this->_req->query->f_id))
 		{
 			checkSession('get');
-			$id = (int) $_GET['f_id'];
+			$id = (int) $this->_req->query->f_id;
 
 			maillist_delete_filter_parser($id);
 			redirectexit('action=admin;area=maillist;sa=emailparser;deleted');
@@ -1417,7 +1432,7 @@ class ManageMaillist_Controller extends Action_Controller
 		global $scripturl, $context, $txt, $modSettings;
 
 		// Be nice, show them we did something
-		if (isset($_GET['saved']))
+		if (isset($this->_req->query->saved))
 			$context['settings_message'] = $txt['saved'];
 
 		// Templates and language
@@ -1443,7 +1458,7 @@ class ManageMaillist_Controller extends Action_Controller
 		$config_vars = $this->_maillistSettings->settings();
 
 		// Saving settings?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
@@ -1454,22 +1469,22 @@ class ManageMaillist_Controller extends Action_Controller
 			$maillist_receiving_address = array();
 
 			// Basic checking of the email addresses
-			if (!Data_Validator::is_valid($_POST, array('maillist_sitename_address' => 'valid_email'), array('maillist_sitename_address' => 'trim')))
-				$email_error = $_POST['maillist_sitename_address'];
-			if (!Data_Validator::is_valid($_POST, array('maillist_sitename_help' => 'valid_email'), array('maillist_sitename_help' => 'trim')))
-				$email_error = $_POST['maillist_sitename_help'];
-			if (!Data_Validator::is_valid($_POST, array('maillist_mail_from' => 'valid_email'), array('maillist_mail_from' => 'trim')))
-				$email_error = $_POST['maillist_mail_from'];
+			if (!Data_Validator::is_valid($this->_req->post, array('maillist_sitename_address' => 'valid_email'), array('maillist_sitename_address' => 'trim')))
+				$email_error = $this->_req->post->maillist_sitename_address;
+			if (!Data_Validator::is_valid($this->_req->post, array('maillist_sitename_help' => 'valid_email'), array('maillist_sitename_help' => 'trim')))
+				$email_error = $this->_req->post->maillist_sitename_help;
+			if (!Data_Validator::is_valid($this->_req->post, array('maillist_mail_from' => 'valid_email'), array('maillist_mail_from' => 'trim')))
+				$email_error = $this->_req->post->maillist_mail_from;
 
 			// Inbound email set up then we need to check for both valid email and valid board
-			if (!$email_error && !empty($_POST['emailfrom']))
+			if (!$email_error && !empty($this->_req->post->emailfrom))
 			{
 				// Get the board ids for a quick check
 				$boards = maillist_board_list();
 
 				// Check the receiving emails and the board id as well
-				$boardtocheck = !empty($_POST['boardto']) ? $_POST['boardto'] : array();
-				$addresstocheck = !empty($_POST['emailfrom']) ? $_POST['emailfrom'] : array();
+				$boardtocheck = !empty($this->_req->post->boardto) ? $this->_req->post->boardto : array();
+				$addresstocheck = !empty($this->_req->post->emailfrom) ? $this->_req->post->emailfrom : array();
 
 				foreach ($addresstocheck as $key => $checkme)
 				{
@@ -1495,7 +1510,7 @@ class ManageMaillist_Controller extends Action_Controller
 			}
 
 			// Enable or disable the fake cron
-			enable_maillist_imap_cron(!empty($_POST['maillist_imap_cron']));
+			enable_maillist_imap_cron(!empty($this->_req->post->maillist_imap_cron));
 
 			// Check and set any errors or give the go ahead to save
 			if ($email_error)
@@ -1508,11 +1523,11 @@ class ManageMaillist_Controller extends Action_Controller
 				cache_put_data('num_menu_errors', null, 900);
 
 				// Should be off if mail posting is on, we ignore it anyway but this at least updates the ACP
-				if (!empty($_POST['maillist_enabled']))
+				if (!empty($this->_req->post->maillist_enabled))
 					updateSettings(array('disallow_sendBody' => ''));
 
 				updateSettings(array('maillist_receiving_address' => serialize($maillist_receiving_address)));
-				Settings_Form::save_db($config_vars);
+				Settings_Form::save_db($config_vars, $this->req->post);
 				writeLog();
 				redirectexit('action=admin;area=maillist;sa=emailsettings;saved');
 			}
@@ -1656,14 +1671,14 @@ class ManageMaillist_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Moderation.subs.php');
 
 		// Submitting a new one or editing an existing one then pass this request off
-		if (isset($_POST['add']) || isset($_POST['save']) || isset($_REQUEST['tid']))
+		if (isset($this->_req->post->add) || isset($this->_req->post->save) || isset($this->_req->query->tid))
 			return $this->action_modify_bounce_templates();
 		// Deleting and existing one
-		elseif (isset($_POST['delete']) && !empty($_POST['deltpl']))
+		elseif (isset($this->_req->post->delete) && !empty($this->_req->post->deltpl))
 		{
 			checkSession('post');
 			validateToken('mod-mlt');
-			removeWarningTemplate($_POST['deltpl'], 'bnctpl');
+			removeWarningTemplate($this->_req->post->deltpl, 'bnctpl');
 		}
 
 		// This is all the information required for showing the email templates.
@@ -1776,7 +1791,7 @@ class ManageMaillist_Controller extends Action_Controller
 
 		require_once(SUBSDIR . '/Moderation.subs.php');
 
-		$context['id_template'] = isset($_REQUEST['tid']) ? (int) $_REQUEST['tid'] : 0;
+		$context['id_template'] = isset($this->_req->query->tid) ? (int) $this->_req->query->tid : 0;
 		$context['is_edit'] = (bool) $context['id_template'];
 
 		// Standard template things, you know the drill
@@ -1798,7 +1813,7 @@ class ManageMaillist_Controller extends Action_Controller
 			modLoadTemplate($context['id_template'], 'bnctpl');
 
 		// Wait, we are saving?
-		if (isset($_POST['save']))
+		if (isset($this->_req->post->save))
 		{
 			checkSession('post');
 			validateToken('mod-mlt');
@@ -1807,8 +1822,8 @@ class ManageMaillist_Controller extends Action_Controller
 			require_once(SUBSDIR . '/Post.subs.php');
 
 			// Bit of cleaning!
-			$template_body = trim($_POST['template_body']);
-			$template_title = trim($_POST['template_title']);
+			$template_body = trim($this->_req->post->template_body);
+			$template_title = trim($this->_req->post->template_title);
 
 			// Need something in both boxes.
 			if (!empty($template_body) && !empty($template_title))
@@ -1823,7 +1838,7 @@ class ManageMaillist_Controller extends Action_Controller
 				$template_body = strtr($template_body, array('<br />' => "\n"));
 
 				// Is this personal?
-				$recipient_id = !empty($_POST['make_personal']) ? $user_info['id'] : 0;
+				$recipient_id = !empty($this->_req->post->make_personal) ? $user_info['id'] : 0;
 
 				// Updating or adding ?
 				if ($context['is_edit'])

--- a/sources/admin/ManageMembergroups.controller.php
+++ b/sources/admin/ManageMembergroups.controller.php
@@ -34,7 +34,21 @@ class ManageMembergroups_Controller extends Action_Controller
 	protected $_groupSettings;
 
 	/**
-	 * Main dispatcher, the entrance point for all 'Manage Membergroup' actions.
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
+	 * Main dispatcher, the en\trance point for all 'Manage Membergroup' actions.
 	 *
 	 * What it does:
 	 * - It forwards to a function based on the given subaction, default being subaction 'index', or, without manage_membergroup
@@ -91,7 +105,7 @@ class ManageMembergroups_Controller extends Action_Controller
 		);
 
 		// Default to sub action 'index' or 'settings' depending on permissions.
-		$subAction = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : (allowedTo('manage_membergroups') ? 'index' : 'settings');
+		$subAction = isset($this->_req->query->sa) && isset($subActions[$this->_req->query->sa]) ? $this->_req->query->sa : (allowedTo('manage_membergroups') ? 'index' : 'settings');
 
 		// Set that subaction, call integrate_sa_manage_membergroups
 		$subAction = $action->initialize($subActions, $subAction);
@@ -125,7 +139,7 @@ class ManageMembergroups_Controller extends Action_Controller
 		$listOptions = array(
 			'id' => 'regular_membergroups_list',
 			'title' => $txt['membergroups_regular'],
-			'base_href' => $scripturl . '?action=admin;area=membergroups' . (isset($_REQUEST['sort2']) ? ';sort2=' . urlencode($_REQUEST['sort2']) : ''),
+			'base_href' => $scripturl . '?action=admin;area=membergroups' . (isset($this->_req->query->sort2) ? ';sort2=' . urlencode($this->_req->query->sort2) : ''),
 			'default_sort_col' => 'name',
 			'get_items' => array(
 				'file' => SUBSDIR . '/Membergroups.subs.php',
@@ -233,7 +247,7 @@ class ManageMembergroups_Controller extends Action_Controller
 		$listOptions = array(
 			'id' => 'post_count_membergroups_list',
 			'title' => $txt['membergroups_post'],
-			'base_href' => $scripturl . '?action=admin;area=membergroups' . (isset($_REQUEST['sort']) ? ';sort=' . urlencode($_REQUEST['sort']) : ''),
+			'base_href' => $scripturl . '?action=admin;area=membergroups' . (isset($this->_req->query->sort) ? ';sort=' . urlencode($this->_req->query->sort) : ''),
 			'default_sort_col' => 'required_posts',
 			'request_vars' => array(
 				'sort' => 'sort2',
@@ -353,13 +367,13 @@ class ManageMembergroups_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Membergroups.subs.php');
 
 		// A form was submitted, we can start adding.
-		if (isset($_POST['group_name']) && trim($_POST['group_name']) != '')
+		if (isset($this->_req->post->group_name) && trim($this->_req->post->group_name) != '')
 		{
 			checkSession();
 			validateToken('admin-mmg');
 
-			$postCountBasedGroup = isset($_POST['min_posts']) && (!isset($_POST['postgroup_based']) || !empty($_POST['postgroup_based']));
-			$_POST['group_type'] = !isset($_POST['group_type']) || $_POST['group_type'] < 0 || $_POST['group_type'] > 3 || ($_POST['group_type'] == 1 && !allowedTo('admin_forum')) ? 0 : (int) $_POST['group_type'];
+			$postCountBasedGroup = isset($this->_req->post->min_posts) && (!isset($this->_req->post->postgroup_based) || !empty($this->_req->post->postgroup_based));
+			$group_type = !isset($this->_req->post->group_type) || $this->_req->post->group_type < 0 || $this->_req->post->group_type > 3 || ($this->_req->post->group_type == 1 && !allowedTo('admin_forum')) ? 0 : (int) $this->_req->post->group_type;
 
 			// @todo Check for members with same name too?
 
@@ -368,14 +382,14 @@ class ManageMembergroups_Controller extends Action_Controller
 
 			loadIllegalPermissions();
 			$id_group = getMaxGroupID() + 1;
-			$minposts = !empty($_POST['min_posts']) ? (int) $_POST['min_posts'] : '-1';
+			$minposts = !empty($this->_req->post->min_posts) ? (int) $this->_req->post->min_posts : '-1';
 
-			addMembergroup($id_group, $_POST['group_name'], $minposts, $_POST['group_type']);
+			addMembergroup($id_group, $this->_req->post->group_name, $minposts, $group_type);
 
 			call_integration_hook('integrate_add_membergroup', array($id_group, $postCountBasedGroup));
 
 			// Update the post groups now, if this is a post group!
-			if (isset($_POST['min_posts']))
+			if (isset($this->_req->post->min_posts))
 			{
 				require_once(SUBSDIR . '/Membergroups.subs.php');
 				updatePostGroupStats();
@@ -383,18 +397,18 @@ class ManageMembergroups_Controller extends Action_Controller
 
 			// You cannot set permissions for post groups if they are disabled.
 			if ($postCountBasedGroup && empty($modSettings['permission_enable_postgroups']))
-				$_POST['perm_type'] = '';
+				$this->_req->post->perm_type = '';
 
-			if ($_POST['perm_type'] == 'predefined')
+			if ($this->_req->post->perm_type == 'predefined')
 			{
 				// Set default permission level.
 				require_once(SUBSDIR . '/ManagePermissions.subs.php');
-				setPermissionLevel($_POST['level'], $id_group, null);
+				setPermissionLevel($this->_req->post->level, $id_group, null);
 			}
 			// Copy or inherit the permissions!
-			elseif ($_POST['perm_type'] == 'copy' || $_POST['perm_type'] == 'inherit')
+			elseif ($this->_req->post->perm_type == 'copy' || $this->_req->post->perm_type == 'inherit')
 			{
-				$copy_id = $_POST['perm_type'] == 'copy' ? (int) $_POST['copyperm'] : (int) $_POST['inheritperm'];
+				$copy_id = $this->_req->post->perm_type == 'copy' ? (int) $this->_req->post->copyperm : (int) $this->_req->post->inheritperm;
 
 				// Are you a powerful admin?
 				if (!allowedTo('admin_forum'))
@@ -414,17 +428,17 @@ class ManageMembergroups_Controller extends Action_Controller
 				copyBoardPermissions($id_group, $copy_id);
 
 				// Also get some membergroup information if we're copying and not copying from guests...
-				if ($copy_id > 0 && $_POST['perm_type'] == 'copy')
+				if ($copy_id > 0 && $this->_req->post->perm_type == 'copy')
 					updateCopiedGroup($id_group, $copy_id);
 
 				// If inheriting say so...
-				elseif ($_POST['perm_type'] == 'inherit')
+				elseif ($this->_req->post->perm_type == 'inherit')
 					updateInheritedGroup($id_group, $copy_id);
 			}
 
 			// Make sure all boards selected are stored in a proper array.
 			$changed_boards = array();
-			$accesses = empty($_POST['boardaccess']) || !is_array($_POST['boardaccess']) ? array() : $_POST['boardaccess'];
+			$accesses = empty($this->_req->post->boardaccess) || !is_array($this->_req->post->boardaccess) ? array() : $this->_req->post->boardaccess;
 			$changed_boards['allow'] = array();
 			$changed_boards['deny'] = array();
 			$changed_boards['ignore'] = array();
@@ -439,7 +453,7 @@ class ManageMembergroups_Controller extends Action_Controller
 			}
 
 			// If this is joinable then set it to show group membership in people's profiles.
-			if (empty($modSettings['show_group_membership']) && $_POST['group_type'] > 1)
+			if (empty($modSettings['show_group_membership']) && $group_type > 1)
 				updateSettings(array('show_group_membership' => 1));
 
 			// Rebuild the group cache.
@@ -448,7 +462,7 @@ class ManageMembergroups_Controller extends Action_Controller
 			));
 
 			// We did it.
-			logAction('add_group', array('group' => $_POST['group_name']), 'admin');
+			logAction('add_group', array('group' => $this->_req->post->group_name), 'admin');
 
 			// Go change some more settings.
 			redirectexit('action=admin;area=membergroups;sa=edit;group=' . $id_group);
@@ -457,8 +471,8 @@ class ManageMembergroups_Controller extends Action_Controller
 		// Just show the 'add membergroup' screen.
 		$context['page_title'] = $txt['membergroups_new_group'];
 		$context['sub_template'] = 'new_group';
-		$context['post_group'] = isset($_REQUEST['postgroup']);
-		$context['undefined_group'] = !isset($_REQUEST['postgroup']) && !isset($_REQUEST['generalgroup']);
+		$context['post_group'] = isset($this->_req->query->postgroup);
+		$context['undefined_group'] = !isset($this->_req->query->postgroup) && !isset($this->_req->query->generalgroup);
 		$context['allow_protected'] = allowedTo('admin_forum');
 
 		if (!empty($modSettings['deny_boards_access']))
@@ -491,7 +505,7 @@ class ManageMembergroups_Controller extends Action_Controller
 		checkSession('get');
 
 		require_once(SUBSDIR . '/Membergroups.subs.php');
-		deleteMembergroups((int) $_REQUEST['group']);
+		deleteMembergroups((int) $this->_req->query->group);
 
 		// Go back to the membergroup index.
 		redirectexit('action=admin;area=membergroups;');
@@ -513,7 +527,7 @@ class ManageMembergroups_Controller extends Action_Controller
 	{
 		global $context, $txt, $modSettings;
 
-		$current_group_id = isset($_REQUEST['group']) ? (int) $_REQUEST['group'] : 0;
+		$current_group_id = isset($this->_req->query->group) ? (int) $this->_req->query->group : 0;
 
 		if (!empty($modSettings['deny_boards_access']))
 			loadLanguage('ManagePermissions');
@@ -529,7 +543,7 @@ class ManageMembergroups_Controller extends Action_Controller
 			Errors::fatal_lang_error('membergroup_does_not_exist', false);
 
 		// The delete this membergroup button was pressed.
-		if (isset($_POST['delete']))
+		if (isset($this->_req->post->delete))
 		{
 			checkSession();
 			validateToken('admin-mmg');
@@ -543,7 +557,7 @@ class ManageMembergroups_Controller extends Action_Controller
 			redirectexit('action=admin;area=membergroups;');
 		}
 		// A form was submitted with the new membergroup settings.
-		elseif (isset($_POST['save']))
+		elseif (isset($this->_req->post->save))
 		{
 			// Validate the session.
 			checkSession();
@@ -573,30 +587,33 @@ class ManageMembergroups_Controller extends Action_Controller
 			$validator->validation_rules(array(
 				'boardaccess' => 'contains[allow,ignore,deny]',
 			));
-			$validator->validate($_POST);
+			$validator->validate($this->_req->post);
+
+			// Insert the clean data
+			$our_post = array_replace((array) $this->_req->post, $validator->validation_data());
 
 			// Can they really inherit from this group?
-			if ($validator->group_inherit != -2 && !allowedTo('admin_forum'))
-				$inherit_type = membergroupById($validator->group_inherit);
+			if ($our_post['group_inherit'] != -2 && !allowedTo('admin_forum'))
+				$inherit_type = membergroupById($our_post['group_inherit']);
 
-			$min_posts = $validator->group_type == -1 && $validator->min_posts >= 0 && $current_group['id_group'] > 3 ? $validator->min_posts : ($current_group['id_group'] == 4 ? 0 : -1);
-			$group_inherit = $current_group['id_group'] > 1 && $current_group['id_group'] != 3 && (empty($inherit_type['group_type']) || $inherit_type['group_type'] != 1) ? $validator->group_inherit : -2;
+			$min_posts = $our_post['group_type'] == -1 && $our_post['min_posts'] >= 0 && $current_group['id_group'] > 3 ? $our_post['min_posts'] : ($current_group['id_group'] == 4 ? 0 : -1);
+			$group_inherit = $current_group['id_group'] > 1 && $current_group['id_group'] != 3 && (empty($inherit_type['group_type']) || $inherit_type['group_type'] != 1) ? $our_post['group_inherit'] : -2;
 
 			//@todo Don't set online_color for the Moderators group?
 
 			// Do the update of the membergroup settings.
 			$properties = array(
-				'max_messages' => $validator->max_messages,
+				'max_messages' => $our_post['max_messages'],
 				'min_posts' => $min_posts,
-				'group_type' => $validator->group_type < 0 || $validator->group_type > 3 || ($validator->group_type == 1 && !allowedTo('admin_forum')) ? 0 : $validator->group_type,
-				'hidden' => !$validator->group_hidden || $min_posts != -1 || $current_group['id_group'] == 3 ? 0 : $validator->group_hidden,
+				'group_type' => $our_post['group_type'] < 0 || $our_post['group_type'] > 3 || ($our_post['group_type'] == 1 && !allowedTo('admin_forum')) ? 0 : $our_post['group_type'],
+				'hidden' => !$our_post['group_hidden'] || $min_posts != -1 || $current_group['id_group'] == 3 ? 0 : $our_post['group_hidden'],
 				'id_parent' => $group_inherit,
 				'current_group' => $current_group['id_group'],
-				'group_name' => $validator->group_name,
-				'online_color' => $validator->online_color,
-				'icons' => $validator->icon_count <= 0 ? '' : min($validator->icon_count, 10) . '#' . $validator->icon_image,
+				'group_name' => $our_post['group_name'],
+				'online_color' => $our_post['online_color'],
+				'icons' => $our_post['icon_count'] <= 0 ? '' : min($our_post['icon_count'], 10) . '#' . $our_post['icon_image'],
 				// /me wonders why admin is *so* special
-				'description' => $current_group['id_group'] == 1 || $validator->group_type != -1 ? $validator->group_desc : '',
+				'description' => $current_group['id_group'] == 1 || $our_post['group_type'] != -1 ? $our_post['group_desc'] : '',
 			);
 			updateMembergroupProperties($properties);
 
@@ -610,8 +627,8 @@ class ManageMembergroups_Controller extends Action_Controller
 				$changed_boards['deny'] = array();
 				$changed_boards['ignore'] = array();
 
-				if ($validator->boardaccess)
-					foreach ($validator->boardaccess as $group_id => $action)
+				if ($our_post['boardaccess'])
+					foreach ($our_post['boardaccess'] as $group_id => $action)
 						$changed_boards[$action][] = (int) $group_id;
 
 				foreach (array('allow', 'deny') as $board_action)
@@ -631,7 +648,7 @@ class ManageMembergroups_Controller extends Action_Controller
 			elseif ($current_group['id_group'] != 3)
 			{
 				// Making it a hidden group? If so remove everyone with it as primary group (Actually, just make them additional).
-				if ($validator->group_hidden == 2)
+				if ($our_post['group_hidden'] == 2)
 					setGroupToHidden($current_group['id_group']);
 
 				// Either way, let's check our "show group membership" setting is correct.
@@ -639,17 +656,17 @@ class ManageMembergroups_Controller extends Action_Controller
 			}
 
 			// Do we need to set inherited permissions?
-			if ($group_inherit != -2 && $group_inherit != $_POST['old_inherit'])
+			if ($group_inherit != -2 && $group_inherit != $this->_req->post->old_inherit)
 			{
 				require_once(SUBSDIR . '/Permission.subs.php');
 				updateChildPermissions($group_inherit);
 			}
 
 			// Finally, moderators!
-			$moderator_string = isset($_POST['group_moderators']) ? trim($_POST['group_moderators']) : '';
+			$moderator_string = isset($this->_req->post->group_moderators) ? trim($this->_req->post->group_moderators) : '';
 			detachGroupModerators($current_group['id_group']);
 
-			if ((!empty($moderator_string) || !empty($_POST['moderator_list'])) && $min_posts == -1 && $current_group['id_group'] != 3)
+			if ((!empty($moderator_string) || !empty($this->_req->post->moderator_list)) && $min_posts == -1 && $current_group['id_group'] != 3)
 			{
 				// Get all the usernames from the string
 				if (!empty($moderator_string))
@@ -672,7 +689,7 @@ class ManageMembergroups_Controller extends Action_Controller
 				else
 				{
 					$moderators = array();
-					foreach ($_POST['moderator_list'] as $moderator)
+					foreach ($this->_req->post->moderator_list as $moderator)
 						$moderators[] = (int) $moderator;
 
 					$group_moderators = array();
@@ -700,7 +717,7 @@ class ManageMembergroups_Controller extends Action_Controller
 			));
 
 			// Log the edit.
-			logAction('edited_group', array('group' => $validator->group_name), 'admin');
+			logAction('edited_group', array('group' => $our_post['group_name']), 'admin');
 
 			redirectexit('action=admin;area=membergroups');
 		}
@@ -791,7 +808,7 @@ class ManageMembergroups_Controller extends Action_Controller
 
 		$config_vars = $this->_groupSettings->settings();
 
-		if (isset($_REQUEST['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 			call_integration_hook('integrate_save_membergroup_settings');

--- a/sources/admin/ManageMembers.controller.php
+++ b/sources/admin/ManageMembers.controller.php
@@ -29,6 +29,18 @@ if (!defined('ELK'))
 class ManageMembers_Controller extends Action_Controller
 {
 	/**
+	 * Holds varous setting conditions for the current action
+	 * @var array
+	 */
+	protected $conditions;
+
+	/**
+	 * Holds the members that the action is being applied to
+	 * @var int[]
+	 */
+	protected $member_info;
+
+	/**
 	 * Holds instance of HttpReq object
 	 * @var HttpReq
 	 */

--- a/sources/admin/ManageNews.controller.php
+++ b/sources/admin/ManageNews.controller.php
@@ -41,7 +41,7 @@ class ManageNews_Controller extends Action_Controller
 
 	/**
 	 * Members specifically being excluded from a newsletter
-	 * @var int[]
+	 * @var array
 	 */
 	protected $_exclude_members = array();
 

--- a/sources/admin/ManageNews.controller.php
+++ b/sources/admin/ManageNews.controller.php
@@ -34,6 +34,32 @@ class ManageNews_Controller extends Action_Controller
 	protected $_newsSettings;
 
 	/**
+	 * Members specifically being included in a newsletter
+	 * @var int[]
+	 */
+	protected $_members = array();
+
+	/**
+	 * Members specifically being excluded from a newsletter
+	 * @var int[]
+	 */
+	protected $_exclude_members = array();
+
+	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * The news dispatcher / delegator
 	 *
 	 * What it does:
@@ -95,7 +121,7 @@ class ManageNews_Controller extends Action_Controller
 		);
 
 		// Default to sub action 'editnews' or 'mailingmembers' or 'settings' depending on permissions.
-		$subAction = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : (allowedTo('edit_news') ? 'editnews' : (allowedTo('send_mail') ? 'mailingmembers' : 'settings'));
+		$subAction = isset($this->_req->query->sa) && isset($subActions[$this->_req->query->sa]) ? $this->_req->query->sa : (allowedTo('edit_news') ? 'editnews' : (allowedTo('send_mail') ? 'mailingmembers' : 'settings'));
 
 		// Give integration its shot via integrate_sa_manage_news
 		$action->initialize($subActions, 'settings');
@@ -129,7 +155,7 @@ class ManageNews_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Post.subs.php');
 
 		// The 'remove selected' button was pressed.
-		if (!empty($_POST['delete_selection']) && !empty($_POST['remove']))
+		if (!empty($this->_req->post->delete_selection) && !empty($this->_req->post->remove))
 		{
 			checkSession();
 
@@ -138,7 +164,7 @@ class ManageNews_Controller extends Action_Controller
 
 			// Remove the items that were selected.
 			foreach ($temp_news as $i => $news)
-				if (in_array($i, $_POST['remove']))
+				if (in_array($i, $this->_req->post->remove))
 					unset($temp_news[$i]);
 
 			// Update the database.
@@ -147,23 +173,23 @@ class ManageNews_Controller extends Action_Controller
 			logAction('news');
 		}
 		// The 'Save' button was pressed.
-		elseif (!empty($_POST['save_items']))
+		elseif (!empty($this->_req->post->save_items))
 		{
 			checkSession();
 
-			foreach ($_POST['news'] as $i => $news)
+			foreach ($this->_req->post->news as $i => $news)
 			{
 				if (trim($news) == '')
-					unset($_POST['news'][$i]);
+					unset($this->_req->post->news[$i]);
 				else
 				{
-					$_POST['news'][$i] = Util::htmlspecialchars($_POST['news'][$i], ENT_QUOTES);
-					preparsecode($_POST['news'][$i]);
+					$this->_req->post->news[$i] = Util::htmlspecialchars($this->_req->post->news[$i], ENT_QUOTES);
+					preparsecode($this->_req->post->news[$i]);
 				}
 			}
 
 			// Send the new news to the database.
-			updateSettings(array('news' => implode("\n", $_POST['news'])));
+			updateSettings(array('news' => implode("\n", $this->_req->post->news)));
 
 			// Log this into the moderation log.
 			logAction('news');
@@ -350,8 +376,8 @@ class ManageNews_Controller extends Action_Controller
 		// Setup the template!
 		$context['page_title'] = $txt['admin_newsletters'];
 		$context['sub_template'] = 'email_members_compose';
-		$context['subject'] = !empty($_POST['subject']) ? $_POST['subject'] : $context['forum_name'] . ': ' . htmlspecialchars($txt['subject'], ENT_COMPAT, 'UTF-8');
-		$context['message'] = !empty($_POST['message']) ? $_POST['message'] : htmlspecialchars($txt['message'] . "\n\n" . replaceBasicActionUrl($txt['regards_team']) . "\n\n" . '{$board_url}', ENT_COMPAT, 'UTF-8');
+		$context['subject'] = !empty($this->_req->post->subject) ? $this->_req->post->subject : $context['forum_name'] . ': ' . htmlspecialchars($txt['subject'], ENT_COMPAT, 'UTF-8');
+		$context['message'] = !empty($this->_req->post->message) ? $this->_req->post->message : htmlspecialchars($txt['message'] . "\n\n" . replaceBasicActionUrl($txt['regards_team']) . "\n\n" . '{$board_url}', ENT_COMPAT, 'UTF-8');
 
 		// Needed for the WYSIWYG editor.
 		require_once(SUBSDIR . '/Editor.subs.php');
@@ -372,69 +398,25 @@ class ManageNews_Controller extends Action_Controller
 		if (isset($context['preview']))
 		{
 			require_once(SUBSDIR . '/Mail.subs.php');
-			$context['recipients']['members'] = !empty($_POST['members']) ? explode(',', $_POST['members']) : array();
-			$context['recipients']['exclude_members'] = !empty($_POST['exclude_members']) ? explode(',', $_POST['exclude_members']) : array();
-			$context['recipients']['groups'] = !empty($_POST['groups']) ? explode(',', $_POST['groups']) : array();
-			$context['recipients']['exclude_groups'] = !empty($_POST['exclude_groups']) ? explode(',', $_POST['exclude_groups']) : array();
-			$context['recipients']['emails'] = !empty($_POST['emails']) ? explode(';', $_POST['emails']) : array();
-			$context['email_force'] = !empty($_POST['email_force']) ? 1 : 0;
-			$context['total_emails'] = !empty($_POST['total_emails']) ? (int) $_POST['total_emails'] : 0;
-			$context['max_id_member'] = !empty($_POST['max_id_member']) ? (int) $_POST['max_id_member'] : 0;
-			$context['send_pm'] = !empty($_POST['send_pm']) ? 1 : 0;
-			$context['send_html'] = !empty($_POST['send_html']) ? '1' : '0';
+			$context['recipients']['members'] = !empty($this->_req->post->members) ? explode(',', $this->_req->post->members) : array();
+			$context['recipients']['exclude_members'] = !empty($this->_req->post->exclude_members) ? explode(',', $this->_req->post->exclude_members) : array();
+			$context['recipients']['groups'] = !empty($this->_req->post->groups) ? explode(',', $this->_req->post->groups) : array();
+			$context['recipients']['exclude_groups'] = !empty($this->_req->post->exclude_groups) ? explode(',', $this->_req->post->exclude_groups) : array();
+			$context['recipients']['emails'] = !empty($this->_req->post->emails) ? explode(';', $this->_req->post->emails) : array();
+			$context['email_force'] = $this->_req->getPost('email_force', 'intval', 0);
+			$context['total_emails'] = $this->_req->getPost('total_emails', 'intval', 0);
+			$context['max_id_member'] = $this->_req->getPost('max_id_member', 'intval', 0);
+			$context['send_pm'] = $this->_req->getPost('send_pm', 'intval', 0);
+			$context['send_html'] = $this->_req->getPost('send_html', 'intval', 0);
 
 			return prepareMailingForPreview();
 		}
 
-		// Start by finding any members!
-		$toClean = array();
-		if (!empty($_POST['members']))
-			$toClean[] = 'members';
+		// Start by finding any manually entered members!
+		$this->_toClean();
 
-		if (!empty($_POST['exclude_members']))
-			$toClean[] = 'exclude_members';
-
-		if (!empty($toClean))
-		{
-			require_once(SUBSDIR . '/Auth.subs.php');
-			foreach ($toClean as $type)
-			{
-				// Remove the quotes.
-				$_POST[$type] = strtr((string) $_POST[$type], array('\\"' => '"'));
-
-				preg_match_all('~"([^"]+)"~', $_POST[$type], $matches);
-				$_POST[$type] = array_unique(array_merge($matches[1], explode(',', preg_replace('~"[^"]+"~', '', $_POST[$type]))));
-
-				foreach ($_POST[$type] as $index => $member)
-				{
-					if (strlen(trim($member)) > 0)
-						$_POST[$type][$index] = Util::htmlspecialchars(Util::strtolower(trim($member)));
-					else
-						unset($_POST[$type][$index]);
-				}
-
-				// Find the members
-				$_POST[$type] = implode(',', array_keys(findMembers($_POST[$type])));
-			}
-		}
-
-		if (isset($_POST['member_list']) && is_array($_POST['member_list']))
-		{
-			$members = array();
-			foreach ($_POST['member_list'] as $member_id)
-				$members[] = (int) $member_id;
-
-			$_POST['members'] = implode(',', $members);
-		}
-
-		if (isset($_POST['exclude_member_list']) && is_array($_POST['exclude_member_list']))
-		{
-			$members = array();
-			foreach ($_POST['exclude_member_list'] as $member_id)
-				$members[] = (int) $member_id;
-
-			$_POST['exclude_members'] = implode(',', $members);
-		}
+		// Add in any members chosen from the autoselct dropdown.
+		$this->_toAddOrExclude();
 
 		// Clean the other vars.
 		$this->action_mailingsend(true);
@@ -467,9 +449,81 @@ class ManageNews_Controller extends Action_Controller
 		$context['total_emails'] = count($context['recipients']['emails']);
 		$context['max_id_member'] = maxMemberID();
 
+		// Make sure to fully load the array with the form choices
+		$context['recipients']['members'] = array_merge($this->_members, $context['recipients']['members']);
+		$context['recipients']['exclude_members'] = array_merge($this->_exclude_members, $context['recipients']['exclude_members']);
+
 		// Clean up the arrays.
 		$context['recipients']['members'] = array_unique($context['recipients']['members']);
 		$context['recipients']['exclude_members'] = array_unique($context['recipients']['exclude_members']);
+	}
+
+	/**
+	 * Members may have been chosen via autoselection pulldown for both Add or Exclude
+	 * this will process them and combine them to any manually added ones.
+	 */
+	private function _toAddOrExclude()
+	{
+		// Members selected (via autoselect) to specifically get the newsletter
+		if (isset($this->_req->post->member_list) && is_array($this->_req->post->member_list))
+		{
+			$members = array();
+			foreach ($this->_req->post->member_list as $member_id)
+				$members[] = (int) $member_id;
+
+			$this->_members = array_unique(array_merge($this->_members, $members));
+		}
+
+		// Members selected (via autoselect) to specifically not get the newsletter
+		if (isset($this->_req->post->exclude_member_list) && is_array($this->_req->post->exclude_member_list))
+		{
+			$members = array();
+			foreach ($this->_req->post->exclude_member_list as $member_id)
+				$members[] = (int) $member_id;
+
+			$this->_exclude_members = array_unique(array_merge($this->_exclude_members, $members));
+		}
+	}
+
+	/**
+	 * If they did not use autoselect function on the include/exclude members then
+	 * we need to look them up from the supplied "one","two" string
+	 */
+	private function _toClean()
+	{
+		$toClean = array();
+		if (!empty($this->_req->post->members))
+			$toClean['_members'] = 'members';
+
+		if (!empty($this->_req->post->exclude_members))
+			$toClean['_exclude_members'] = 'exclude_members';
+
+		// Manual entries found?
+		if (!empty($toClean))
+		{
+			require_once(SUBSDIR . '/Auth.subs.php');
+			foreach ($toClean as $key => $type)
+			{
+				// Remove the quotes.
+				$temp = strtr((string) $this->_req->post->$type, array('\\"' => '"'));
+
+				// Break it up in to an array for processing
+				preg_match_all('~"([^"]+)"~', $this->_req->post->$type, $matches);
+				$temp = array_unique(array_merge($matches[1], explode(',', preg_replace('~"[^"]+"~', '', $temp))));
+
+				// Clean the valid ones, drop the mangled ones
+				foreach ($temp as $index => $member)
+				{
+					if (strlen(trim($member)) > 0)
+						$temp[$index] = Util::htmlspecialchars(Util::strtolower(trim($member)));
+					else
+						unset($temp[$index]);
+				}
+
+				// Find the members
+				$this->$key = array_keys(findMembers($temp));
+			}
+		}
 	}
 
 	/**
@@ -489,7 +543,7 @@ class ManageNews_Controller extends Action_Controller
 		global $txt, $context, $scripturl, $modSettings, $user_info;
 
 		// A nice successful screen if you did it
-		if (isset($_REQUEST['success']))
+		if (isset($this->_req->query->success))
 		{
 			$context['sub_template'] = 'email_members_succeeded';
 			loadTemplate('ManageNews');
@@ -497,7 +551,7 @@ class ManageNews_Controller extends Action_Controller
 		}
 
 		// If just previewing we prepare a message and return it for viewing
-		if (isset($_POST['preview']))
+		if (isset($this->_req->post->preview))
 		{
 			$context['preview'] = true;
 			return $this->action_mailingcompose();
@@ -508,19 +562,19 @@ class ManageNews_Controller extends Action_Controller
 		$num_at_once = empty($modSettings['mail_queue']) ? 60 : 1000;
 
 		// If by PM's I suggest we half the above number.
-		if (!empty($_POST['send_pm']))
+		if (!empty($this->_req->post->send_pm))
 			$num_at_once /= 2;
 
 		checkSession();
 
 		// Where are we actually to?
-		$context['start'] = isset($_REQUEST['start']) ? (int) $_REQUEST['start'] : 0;
-		$context['email_force'] = !empty($_POST['email_force']) ? 1 : 0;
-		$context['send_pm'] = !empty($_POST['send_pm']) ? 1 : 0;
-		$context['total_emails'] = !empty($_POST['total_emails']) ? (int) $_POST['total_emails'] : 0;
-		$context['max_id_member'] = !empty($_POST['max_id_member']) ? (int) $_POST['max_id_member'] : 0;
-		$context['send_html'] = !empty($_POST['send_html']) ? 1 : 0;
-		$context['parse_html'] = !empty($_POST['parse_html']) ? 1 : 0;
+		$context['start'] = $this->_req->getPost('start', 'intval', 0);
+		$context['email_force'] = $this->_req->getPost('email_force', 'intval', 0);
+		$context['total_emails'] = $this->_req->getPost('total_emails', 'intval', 0);
+		$context['max_id_member'] = $this->_req->getPost('max_id_member', 'intval', 0);
+		$context['send_pm'] = $this->_req->getPost('send_pm', 'intval', 0);
+		$context['send_html'] = $this->_req->getPost('send_html', 'intval', 0);
+		$context['parse_html'] = $this->_req->getPost('parse_html', 'intval', 0);
 
 		// Create our main context.
 		$context['recipients'] = array(
@@ -532,9 +586,9 @@ class ManageNews_Controller extends Action_Controller
 		);
 
 		// Have we any excluded members?
-		if (!empty($_POST['exclude_members']))
+		if (!empty($this->_req->post->exclude_members))
 		{
-			$members = explode(',', $_POST['exclude_members']);
+			$members = explode(',', $this->_req->post->exclude_members);
 			foreach ($members as $member)
 			{
 				if ($member >= $context['start'])
@@ -543,9 +597,9 @@ class ManageNews_Controller extends Action_Controller
 		}
 
 		// What about members we *must* do?
-		if (!empty($_POST['members']))
+		if (!empty($this->_req->post->members))
 		{
-			$members = explode(',', $_POST['members']);
+			$members = explode(',', $this->_req->post->members);
 			foreach ($members as $member)
 			{
 				if ($member >= $context['start'])
@@ -554,41 +608,41 @@ class ManageNews_Controller extends Action_Controller
 		}
 
 		// Cleaning groups is simple - although deal with both checkbox and commas.
-		if (isset($_POST['groups']))
+		if (isset($this->_req->post->groups))
 		{
-			if (is_array($_POST['groups']))
+			if (is_array($this->_req->post->groups))
 			{
-				foreach ($_POST['groups'] as $group => $dummy)
+				foreach ($this->_req->post->groups as $group => $dummy)
 					$context['recipients']['groups'][] = (int) $group;
 			}
-			elseif (trim($_POST['groups']) != '')
+			elseif (trim($this->_req->post->groups) != '')
 			{
-				$groups = explode(',', $_POST['groups']);
+				$groups = explode(',', $this->_req->post->groups);
 				foreach ($groups as $group)
 					$context['recipients']['groups'][] = (int) $group;
 			}
 		}
 
 		// Same for excluded groups
-		if (isset($_POST['exclude_groups']))
+		if (isset($this->_req->post->exclude_groups))
 		{
-			if (is_array($_POST['exclude_groups']))
+			if (is_array($this->_req->post->exclude_groups))
 			{
-				foreach ($_POST['exclude_groups'] as $group => $dummy)
+				foreach ($this->_req->post->exclude_groups as $group => $dummy)
 					$context['recipients']['exclude_groups'][] = (int) $group;
 			}
-			elseif (trim($_POST['exclude_groups']) != '')
+			elseif (trim($this->_req->post->exclude_groups) != '')
 			{
-				$groups = explode(',', $_POST['exclude_groups']);
+				$groups = explode(',', $this->_req->post->exclude_groups);
 				foreach ($groups as $group)
 					$context['recipients']['exclude_groups'][] = (int) $group;
 			}
 		}
 
 		// Finally - emails!
-		if (!empty($_POST['emails']))
+		if (!empty($this->_req->post->emails))
 		{
-			$addressed = array_unique(explode(';', strtr($_POST['emails'], array("\n" => ';', "\r" => ';', ',' => ';'))));
+			$addressed = array_unique(explode(';', strtr($this->_req->post->emails, array("\n" => ';', "\r" => ';', ',' => ';'))));
 			foreach ($addressed as $curmem)
 			{
 				$curmem = trim($curmem);
@@ -607,18 +661,18 @@ class ManageNews_Controller extends Action_Controller
 			require_once(SUBSDIR . '/PersonalMessage.subs.php');
 
 		// We are relying too much on writing to superglobals...
-		$base_subject = !empty($_POST['subject']) ? $_POST['subject'] : '';
-		$base_message = !empty($_POST['message']) ? $_POST['message'] : '';
+		$base_subject = $this->_req->getPost('subject', 'strval', '');
+		$base_message = $this->_req->getPost('message', 'strval', '');
 
 		// Save the message and its subject in $context
 		$context['subject'] = htmlspecialchars($base_subject, ENT_COMPAT, 'UTF-8');
 		$context['message'] = htmlspecialchars($base_message, ENT_COMPAT, 'UTF-8');
 
 		// Prepare the message for sending it as HTML
-		if (!$context['send_pm'] && !empty($_POST['send_html']))
+		if (!$context['send_pm'] && !empty($this->_req->post->send_html))
 		{
 			// Prepare the message for HTML.
-			if (!empty($_POST['parse_html']))
+			if (!empty($this->_req->post->parse_html))
 				$base_message = str_replace(array("\n", '  '), array('<br />' . "\n", '&nbsp; '), $base_message);
 
 			// This is here to prevent spam filters from tagging this as spam.
@@ -649,14 +703,14 @@ class ManageNews_Controller extends Action_Controller
 		);
 
 		// We might need this in a bit
-		$cleanLatestMember = empty($_POST['send_html']) || $context['send_pm'] ? un_htmlspecialchars($modSettings['latestRealName']) : $modSettings['latestRealName'];
+		$cleanLatestMember = empty($this->_req->post->send_html) || $context['send_pm'] ? un_htmlspecialchars($modSettings['latestRealName']) : $modSettings['latestRealName'];
 
 		// Replace in all the standard things.
 		$base_message = str_replace($variables,
 			array(
-				!empty($_POST['send_html']) ? '<a href="' . $scripturl . '">' . $scripturl . '</a>' : $scripturl,
+				!empty($this->_req->post->send_html) ? '<a href="' . $scripturl . '">' . $scripturl . '</a>' : $scripturl,
 				standardTime(forum_time(), false),
-				!empty($_POST['send_html']) ? '<a href="' . $scripturl . '?action=profile;u=' . $modSettings['latestMember'] . '">' . $cleanLatestMember . '</a>' : ($context['send_pm'] ? '[url=' . $scripturl . '?action=profile;u=' . $modSettings['latestMember'] . ']' . $cleanLatestMember . '[/url]' : $cleanLatestMember),
+				!empty($this->_req->post->send_html) ? '<a href="' . $scripturl . '?action=profile;u=' . $modSettings['latestMember'] . '">' . $cleanLatestMember . '</a>' : ($context['send_pm'] ? '[url=' . $scripturl . '?action=profile;u=' . $modSettings['latestMember'] . ']' . $cleanLatestMember . '[/url]' : $cleanLatestMember),
 				$modSettings['latestMember'],
 				$cleanLatestMember
 			), $base_message);
@@ -694,12 +748,12 @@ class ManageNews_Controller extends Action_Controller
 
 			$to_member = array(
 				$email,
-				!empty($_POST['send_html']) ? '<a href="mailto:' . $email . '">' . $email . '</a>' : $email,
+				!empty($this->_req->post->send_html) ? '<a href="mailto:' . $email . '">' . $email . '</a>' : $email,
 				'??',
 				$email
 			);
 
-			sendmail($email, str_replace($from_member, $to_member, $base_subject), str_replace($from_member, $to_member, $base_message), null, null, !empty($_POST['send_html']), 5);
+			sendmail($email, str_replace($from_member, $to_member, $base_subject), str_replace($from_member, $to_member, $base_message), null, null, !empty($this->_req->post->send_html), 5);
 
 			// Done another...
 			$i++;
@@ -780,13 +834,13 @@ class ManageNews_Controller extends Action_Controller
 					continue;
 
 				// We might need this
-				$cleanMemberName = empty($_POST['send_html']) || $context['send_pm'] ? un_htmlspecialchars($row['real_name']) : $row['real_name'];
+				$cleanMemberName = empty($this->_req->post->send_html) || $context['send_pm'] ? un_htmlspecialchars($row['real_name']) : $row['real_name'];
 
 				// Replace the member-dependant variables
 				$message = str_replace($from_member,
 					array(
 						$row['email_address'],
-						!empty($_POST['send_html']) ? '<a href="' . $scripturl . '?action=profile;u=' . $row['id_member'] . '">' . $cleanMemberName . '</a>' : ($context['send_pm'] ? '[url=' . $scripturl . '?action=profile;u=' . $row['id_member'] . ']' . $cleanMemberName . '[/url]' : $cleanMemberName),
+						!empty($this->_req->post->send_html) ? '<a href="' . $scripturl . '?action=profile;u=' . $row['id_member'] . '">' . $cleanMemberName . '</a>' : ($context['send_pm'] ? '[url=' . $scripturl . '?action=profile;u=' . $row['id_member'] . ']' . $cleanMemberName . '[/url]' : $cleanMemberName),
 						$row['id_member'],
 						$cleanMemberName,
 					), $base_message);
@@ -801,7 +855,7 @@ class ManageNews_Controller extends Action_Controller
 
 				// Send the actual email - or a PM!
 				if (!$context['send_pm'])
-					sendmail($row['email_address'], $subject, $message, null, null, !empty($_POST['send_html']), 5);
+					sendmail($row['email_address'], $subject, $message, null, null, !empty($this->_req->post->send_html), 5);
 				else
 					sendpm(array('to' => array($row['id_member']), 'bcc' => array()), $subject, $message);
 			}
@@ -863,13 +917,13 @@ class ManageNews_Controller extends Action_Controller
 		$context['permissions_excluded'] = array(-1);
 
 		// Saving the settings?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			call_integration_hook('integrate_save_news_settings');
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			redirectexit('action=admin;area=news;sa=settings');
 		}
 

--- a/sources/admin/ManageNews.controller.php
+++ b/sources/admin/ManageNews.controller.php
@@ -35,7 +35,7 @@ class ManageNews_Controller extends Action_Controller
 
 	/**
 	 * Members specifically being included in a newsletter
-	 * @var int[]
+	 * @var array
 	 */
 	protected $_members = array();
 

--- a/sources/admin/ManagePaid.controller.php
+++ b/sources/admin/ManagePaid.controller.php
@@ -35,6 +35,20 @@ class ManagePaid_Controller extends Action_Controller
 	protected $_paidSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * The main entrance point for the 'Paid Subscription' screen,
 	 *
 	 * What it does:
@@ -95,7 +109,7 @@ class ManagePaid_Controller extends Action_Controller
 		);
 
 		// Default the sub-action to 'view subscriptions', but only if they have already set things up..
-		$subAction = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : (!empty($modSettings['paid_currency_symbol']) ? 'view' : 'settings');
+		$subAction = isset($this->_req->query->sa) && isset($subActions[$this->_req->query->sa]) ? $this->_req->query->sa : (!empty($modSettings['paid_currency_symbol']) ? 'view' : 'settings');
 
 		// Load in the subActions, call integrate_sa_manage_subscriptions
 		$action->initialize($subActions, 'settings');
@@ -154,14 +168,14 @@ class ManagePaid_Controller extends Action_Controller
 		toggleCurrencyOther();', true);
 
 		// Saving the settings?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			call_integration_hook('integrate_save_subscription_settings');
 
 			// Check that the entered email addresses are valid
-			if (!empty($_POST['paid_email_to']))
+			if (!empty($this->_req->post->paid_email_to))
 			{
 				$validator = new Data_Validator();
 
@@ -171,12 +185,12 @@ class ManagePaid_Controller extends Action_Controller
 				$validator->input_processing(array('paid_email_to' => 'csv'));
 				$validator->text_replacements(array('paid_email_to' => $txt['paid_email_to']));
 
-				if ($validator->validate($_POST))
-					$_POST['paid_email_to'] = $validator->paid_email_to;
+				if ($validator->validate($this->_req->post))
+					$this->_req->post->paid_email_to = $validator->validation_data('paid_email_to');
 				else
 				{
 					// Thats not an email, lets set it back in the form to be fixed and let them know its wrong
-					$config_vars[1]['value'] = $_POST['paid_email_to'];
+					$config_vars[1]['value'] = $this->_req->post->paid_email_to;
 					$context['error_type'] = 'minor';
 					$context['settings_message'] = array();
 					foreach ($validator->validation_errors() as $id => $error)
@@ -188,15 +202,15 @@ class ManagePaid_Controller extends Action_Controller
 			if (empty($context['error_type']))
 			{
 				// Sort out the currency stuff.
-				if ($_POST['paid_currency'] != 'other')
+				if ($this->_req->post->paid_currency != 'other')
 				{
-					$_POST['paid_currency_code'] = $_POST['paid_currency'];
-					$_POST['paid_currency_symbol'] = $txt[$_POST['paid_currency'] . '_symbol'];
+					$this->_req->post->paid_currency_code = $this->_req->post->paid_currency;
+					$this->_req->post->paid_currency_symbol = $txt[$this->_req->post->paid_currency . '_symbol'];
 				}
-				$_POST['paid_currency_code'] = trim($_POST['paid_currency_code']);
+				$this->_req->post->paid_currency_code = trim($this->_req->post->paid_currency_code);
 
 				unset($config_vars['dummy_currency']);
-				Settings_Form::save_db($config_vars);
+				Settings_Form::save_db($config_vars, $this->_req->post);
 				redirectexit('action=admin;area=paidsubscribe;sa=settings');
 			}
 		}
@@ -423,15 +437,15 @@ class ManagePaid_Controller extends Action_Controller
 
 		require_once(SUBSDIR . '/PaidSubscriptions.subs.php');
 
-		$context['sub_id'] = isset($_REQUEST['sid']) ? (int) $_REQUEST['sid'] : 0;
-		$context['action_type'] = $context['sub_id'] ? (isset($_REQUEST['delete']) ? 'delete' : 'edit') : 'add';
+		$context['sub_id'] = isset($this->_req->query->sid) ? (int) $this->_req->query->sid : 0;
+		$context['action_type'] = $context['sub_id'] ? (isset($this->_req->query->delete) ? 'delete' : 'edit') : 'add';
 
 		// Setup the template.
 		$context['sub_template'] = $context['action_type'] == 'delete' ? 'delete_subscription' : 'modify_subscription';
 		$context['page_title'] = $txt['paid_' . $context['action_type'] . '_subscription'];
 
 		// Delete it?
-		if (isset($_POST['delete_confirm']) && isset($_REQUEST['delete']))
+		if (isset($this->_req->post->delete_confirm) && isset($this->_req->query->delete))
 		{
 			checkSession();
 			validateToken('admin-pmsd');
@@ -444,29 +458,29 @@ class ManagePaid_Controller extends Action_Controller
 		}
 
 		// Saving?
-		if (isset($_POST['save']))
+		if (isset($this->_req->post->save))
 		{
 			checkSession();
 			validateToken('admin-pms');
 
 			// Some cleaning...
-			$isActive = isset($_POST['active']) ? 1 : 0;
-			$isRepeatable = isset($_POST['repeatable']) ? 1 : 0;
-			$allowpartial = isset($_POST['allow_partial']) ? 1 : 0;
-			$reminder = isset($_POST['reminder']) ? (int) $_POST['reminder'] : 0;
-			$emailComplete = strlen($_POST['emailcomplete']) > 10 ? trim($_POST['emailcomplete']) : '';
+			$isActive = max($this->_req->getPost('active', 'intval', 0), 1);
+			$isRepeatable = max($this->_req->getPost('repeatable', 'intval', 0), 1);
+			$allowPartial = max($this->_req->getPost('allow_partial', 'intval', 0), 1);
+			$reminder = max($this->_req->getPost('reminder', 'intval', 0), 1);
+			$emailComplete = strlen($this->_req->post->emailcomplete) > 10 ? trim($this->_req->post->emailcomplete) : '';
 
 			// Is this a fixed one?
-			if ($_POST['duration_type'] == 'fixed')
+			if ($this->_req->post->duration_type == 'fixed')
 			{
 				// Clean the span.
-				$span = $_POST['span_value'] . $_POST['span_unit'];
+				$span = $this->_req->post->span_value . $this->_req->post->span_unit;
 
 				// Sort out the cost.
-				$cost = array('fixed' => sprintf('%01.2f', strtr($_POST['cost'], ',', '.')));
+				$cost = array('fixed' => sprintf('%01.2f', strtr($this->_req->post->cost, ',', '.')));
 
 				// There needs to be something.
-				if (empty($_POST['span_value']) || empty($_POST['cost']))
+				if (empty($this->_req->post->span_value) || empty($this->_req->post->cost))
 					Errors::fatal_lang_error('paid_no_cost_value');
 			}
 			// Flexible is harder but more fun ;)
@@ -475,37 +489,40 @@ class ManagePaid_Controller extends Action_Controller
 				$span = 'F';
 
 				$cost = array(
-					'day' => sprintf('%01.2f', strtr($_POST['cost_day'], ',', '.')),
-					'week' => sprintf('%01.2f', strtr($_POST['cost_week'], ',', '.')),
-					'month' => sprintf('%01.2f', strtr($_POST['cost_month'], ',', '.')),
-					'year' => sprintf('%01.2f', strtr($_POST['cost_year'], ',', '.')),
+					'day' => sprintf('%01.2f', strtr($this->_req->post->cost_day, ',', '.')),
+					'week' => sprintf('%01.2f', strtr($this->_req->post->cost_week, ',', '.')),
+					'month' => sprintf('%01.2f', strtr($this->_req->post->cost_month, ',', '.')),
+					'year' => sprintf('%01.2f', strtr($this->_req->post->cost_year, ',', '.')),
 				);
 
-				if (empty($_POST['cost_day']) && empty($_POST['cost_week']) && empty($_POST['cost_month']) && empty($_POST['cost_year']))
+				if (empty($this->_req->post->cost_day) && empty($this->_req->post->cost_week) && empty($this->_req->post->cost_month) && empty($this->_req->post->cost_year))
 					Errors::fatal_lang_error('paid_all_freq_blank');
 			}
+
 			$cost = serialize($cost);
 
 			// Yep, time to do additional groups.
-			$addgroups = array();
-			if (!empty($_POST['addgroup']))
-				foreach ($_POST['addgroup'] as $id => $dummy)
-					$addgroups[] = (int) $id;
-			$addgroups = implode(',', $addgroups);
+			$addGroups = array();
+			if (!empty($this->_req->post->addgroup))
+			{
+				foreach ($this->_req->post->addgroup as $id => $dummy)
+					$addGroups[] = (int) $id;
+			}
+			$addGroups = implode(',', $addGroups);
 
 			// Is it new?!
 			if ($context['action_type'] == 'add')
 			{
 				$insert = array(
-					'name' => $_POST['name'],
-					'desc' => $_POST['desc'],
+					'name' => $this->_req->post->name,
+					'desc' => $this->_req->post->desc,
 					'isActive' => $isActive,
 					'span' => $span,
 					'cost' => $cost,
-					'prim_group' => $_POST['prim_group'],
-					'addgroups' => $addgroups,
+					'prim_group' => $this->_req->post->prim_group,
+					'addgroups' => $addGroups,
 					'isRepeatable' => $isRepeatable,
-					'allowpartial' => $allowpartial,
+					'allowpartial' => $allowPartial,
 					'emailComplete' => $emailComplete,
 					'reminder' => $reminder,
 				);
@@ -519,23 +536,23 @@ class ManagePaid_Controller extends Action_Controller
 
 				$update = array(
 					'is_active' => $isActive,
-					'id_group' => !empty($_POST['prim_group']) ? $_POST['prim_group'] : 0,
+					'id_group' => !empty($this->_req->post->prim_group) ? $this->_req->post->prim_group : 0,
 					'repeatable' => $isRepeatable,
-					'allow_partial' => $allowpartial,
+					'allow_partial' => $allowPartial,
 					'reminder' => $reminder,
 					'current_subscription' => $context['sub_id'],
-					'name' => $_POST['name'],
-					'desc' => $_POST['desc'],
+					'name' => $this->_req->post->name,
+					'desc' => $this->_req->post->desc,
 					'length' => $span,
 					'cost' => $cost,
-					'additional_groups' => !empty($addgroups) ? $addgroups : '',
+					'additional_groups' => !empty($addGroups) ? $addGroups : '',
 					'email_complete' => $emailComplete,
 				);
 
 				updateSubscription($update, $ignore_active);
 			}
 
-			call_integration_hook('integrate_save_subscription', array(($context['action_type'] == 'add' ? $sub_id : $context['sub_id']), $_POST['name'], $_POST['desc'], $isActive, $span, $cost, $_POST['prim_group'], $addgroups, $isRepeatable, $allowpartial, $emailComplete, $reminder));
+			call_integration_hook('integrate_save_subscription', array(($context['action_type'] == 'add' ? $sub_id : $context['sub_id']), $this->_req->post->name, $this->_req->post->desc, $isActive, $span, $cost, $this->_req->post->prim_group, $addGroups, $isRepeatable, $allowPartial, $emailComplete, $reminder));
 
 			redirectexit('action=admin;area=paidsubscribe;view');
 		}
@@ -597,14 +614,14 @@ class ManagePaid_Controller extends Action_Controller
 		$context['page_title'] = $txt['viewing_users_subscribed'];
 
 		// ID of the subscription.
-		$context['sub_id'] = (int) $_REQUEST['sid'];
+		$context['sub_id'] = (int) $this->_req->query->sid;
 
 		// Load the subscription information.
 		$context['subscription'] = getSubscriptionDetails($context['sub_id']);
 
 		// Are we searching for people?
-		$search_string = isset($_POST['ssearch']) && !empty($_POST['sub_search']) ? ' AND IFNULL(mem.real_name, {string:guest}) LIKE {string:search}' : '';
-		$search_vars = empty($_POST['sub_search']) ? array() : array('search' => '%' . $_POST['sub_search'] . '%', 'guest' => $txt['guest']);
+		$search_string = isset($this->_req->post->ssearch) && !empty($this->_req->post->sub_search) ? ' AND IFNULL(mem.real_name, {string:guest}) LIKE {string:search}' : '';
+		$search_vars = empty($this->_req->post->sub_search) ? array() : array('search' => '%' . $this->_req->post->sub_search . '%', 'guest' => $txt['guest']);
 
 		$listOptions = array(
 			'id' => 'subscribed_users_list',
@@ -770,7 +787,7 @@ class ManagePaid_Controller extends Action_Controller
 	 */
 	public function getSubscribedUserCount($id_sub, $search_string, $search_vars)
 	{
-	   return list_getSubscribedUserCount($id_sub, $search_string, $search_vars);
+		return list_getSubscribedUserCount($id_sub, $search_string, $search_vars);
 	}
 
 	/**
@@ -802,8 +819,8 @@ class ManagePaid_Controller extends Action_Controller
 		require_once(SUBSDIR . '/PaidSubscriptions.subs.php');
 		loadSubscriptions();
 
-		$context['log_id'] = isset($_REQUEST['lid']) ? (int) $_REQUEST['lid'] : 0;
-		$context['sub_id'] = isset($_REQUEST['sid']) ? (int) $_REQUEST['sid'] : 0;
+		$context['log_id'] = $this->_req->getQuery('lid', 'intval', 0);
+		$context['sub_id'] = $this->_req->getQuery('sid', 'intval', 0);
 		$context['action_type'] = $context['log_id'] ? 'edit' : 'add';
 
 		// Setup the template.
@@ -821,26 +838,26 @@ class ManagePaid_Controller extends Action_Controller
 		$context['current_subscription'] = $context['subscriptions'][$context['sub_id']];
 
 		// Searching?
-		if (isset($_POST['ssearch']))
+		if (isset($this->_req->post->ssearch))
 			return $this->action_viewsub();
 		// Saving?
-		elseif (isset($_REQUEST['save_sub']))
+		elseif (isset($this->_req->post->save_sub))
 		{
 			checkSession();
 
 			// Work out the dates...
-			$starttime = mktime($_POST['hour'], $_POST['minute'], 0, $_POST['month'], $_POST['day'], $_POST['year']);
-			$endtime = mktime($_POST['hourend'], $_POST['minuteend'], 0, $_POST['monthend'], $_POST['dayend'], $_POST['yearend']);
+			$starttime = mktime($this->_req->post->hour, $this->_req->post->minute, 0, $this->_req->post->month, $this->_req->post->day, $this->_req->post->year);
+			$endtime = mktime($this->_req->post->hourend, $this->_req->post->minuteend, 0, $this->_req->post->monthend, $this->_req->post->dayend, $this->_req->post->yearend);
 
 			// Status.
-			$status = $_POST['status'];
+			$status = $this->_req->post->status;
 
 			// New one?
 			if (empty($context['log_id']))
 			{
 				// Find the user...
 				require_once(SUBSDIR . '/Members.subs.php');
-				$member = getMemberByName($_POST['name']);
+				$member = getMemberByName($this->_req->post->name);
 
 				if (empty($member))
 					Errors::fatal_lang_error('error_member_not_found');
@@ -893,21 +910,21 @@ class ManagePaid_Controller extends Action_Controller
 			redirectexit('action=admin;area=paidsubscribe;sa=viewsub;sid=' . $context['sub_id']);
 		}
 		// Deleting?
-		elseif (isset($_REQUEST['delete']) || isset($_REQUEST['finished']))
+		elseif (isset($this->_req->post->delete) || isset($this->_req->post->finished))
 		{
 			checkSession();
 
 			// Do the actual deletes!
-			if (!empty($_REQUEST['delsub']))
+			if (!empty($this->_req->post->delsub))
 			{
 				$toDelete = array();
-				foreach ($_REQUEST['delsub'] as $id => $dummy)
+				foreach ($this->_req->post->delsub as $id => $dummy)
 					$toDelete[] = (int) $id;
 
 				$deletes = prepareDeleteSubscriptions($toDelete);
 
 				foreach ($deletes as $id_subscribe => $id_member)
-					removeSubscription($id_subscribe, $id_member, isset($_REQUEST['delete']));
+					removeSubscription($id_subscribe, $id_member, isset($this->_req->post->delete));
 			}
 			redirectexit('action=admin;area=paidsubscribe;sa=viewsub;sid=' . $context['sub_id']);
 		}
@@ -938,12 +955,12 @@ class ManagePaid_Controller extends Action_Controller
 			$context['sub']['start']['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $context['sub']['start']['month'] == 12 ? 1 : $context['sub']['start']['month'] + 1, 0, $context['sub']['start']['month'] == 12 ? $context['sub']['start']['year'] + 1 : $context['sub']['start']['year']));
 			$context['sub']['end']['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $context['sub']['end']['month'] == 12 ? 1 : $context['sub']['end']['month'] + 1, 0, $context['sub']['end']['month'] == 12 ? $context['sub']['end']['year'] + 1 : $context['sub']['end']['year']));
 
-			if (isset($_GET['uid']))
+			if (isset($this->_req->query->uid))
 			{
 				require_once(SUBSDIR . '/Members.subs.php');
 
 				// Get the latest activated member's display name.
-				$result = getBasicMemberData((int) $_GET['uid']);
+				$result = getBasicMemberData((int) $this->_req->query->uid);
 				$context['sub']['username'] = $result['real_name'];
 			}
 			else
@@ -989,15 +1006,15 @@ class ManagePaid_Controller extends Action_Controller
 				}
 
 				// Check if we are adding/removing any.
-				if (isset($_GET['pending']))
+				if (isset($this->_req->query->pending))
 				{
 					foreach ($pending_details as $id => $pending)
 					{
 						// Found the one to action?
-						if ($_GET['pending'] == $id && $pending[3] == 'payback' && isset($context['pending_payments'][$id]))
+						if ($this->_req->query->pending == $id && $pending[3] == 'payback' && isset($context['pending_payments'][$id]))
 						{
 							// Flexible?
-							if (isset($_GET['accept']))
+							if (isset($this->_req->query->accept))
 								addSubscription($context['current_subscription']['id'], $row['id_member'], $context['current_subscription']['real_length'] == 'F' ? strtoupper(substr($pending[2], 0, 1)) : 0);
 							unset($pending_details[$id]);
 

--- a/sources/admin/ManagePosts.controller.php
+++ b/sources/admin/ManagePosts.controller.php
@@ -34,6 +34,20 @@ class ManagePosts_Controller extends Action_Controller
 	protected $_postSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * The main entrance point for the 'Posts and topics' screen.
 	 *
 	 * What it does:
@@ -113,7 +127,7 @@ class ManagePosts_Controller extends Action_Controller
 	{
 		global $txt, $modSettings, $context;
 
-		if (!empty($_POST['save_censor']))
+		if (!empty($this->_req->post->save_censor))
 		{
 			// Make sure censoring is something they can do.
 			checkSession();
@@ -123,30 +137,30 @@ class ManagePosts_Controller extends Action_Controller
 			$censored_proper = array();
 
 			// Rip it apart, then split it into two arrays.
-			if (isset($_POST['censortext']))
+			if (isset($this->_req->post->censortext))
 			{
-				$_POST['censortext'] = explode("\n", strtr($_POST['censortext'], array("\r" => '')));
+				$this->_req->post->censortext = explode("\n", strtr($this->_req->post->censortext, array("\r" => '')));
 
-				foreach ($_POST['censortext'] as $c)
+				foreach ($this->_req->post->censortext as $c)
 					list ($censored_vulgar[], $censored_proper[]) = array_pad(explode('=', trim($c)), 2, '');
 			}
-			elseif (isset($_POST['censor_vulgar'], $_POST['censor_proper']))
+			elseif (isset($this->_req->post->censor_vulgar, $this->_req->post->censor_proper))
 			{
-				if (is_array($_POST['censor_vulgar']))
+				if (is_array($this->_req->post->censor_vulgar))
 				{
-					foreach ($_POST['censor_vulgar'] as $i => $value)
+					foreach ($this->_req->post->censor_vulgar as $i => $value)
 					{
 						if (trim(strtr($value, '*', ' ')) == '')
-							unset($_POST['censor_vulgar'][$i], $_POST['censor_proper'][$i]);
+							unset($this->_req->post->censor_vulgar[$i], $this->_req->POST->censor_proper[$i]);
 					}
 
-					$censored_vulgar = $_POST['censor_vulgar'];
-					$censored_proper = $_POST['censor_proper'];
+					$censored_vulgar = $this->_req->post->censor_vulgar;
+					$censored_proper = $this->_req->post->censor_proper;
 				}
 				else
 				{
-					$censored_vulgar = explode("\n", strtr($_POST['censor_vulgar'], array("\r" => '')));
-					$censored_proper = explode("\n", strtr($_POST['censor_proper'], array("\r" => '')));
+					$censored_vulgar = explode("\n", strtr($this->_req->post->censor_vulgar, array("\r" => '')));
+					$censored_proper = explode("\n", strtr($this->_req->post->censor_proper, array("\r" => '')));
 				}
 			}
 
@@ -154,8 +168,8 @@ class ManagePosts_Controller extends Action_Controller
 			$updates = array(
 				'censor_vulgar' => implode("\n", $censored_vulgar),
 				'censor_proper' => implode("\n", $censored_proper),
-				'censorWholeWord' => empty($_POST['censorWholeWord']) ? '0' : '1',
-				'censorIgnoreCase' => empty($_POST['censorIgnoreCase']) ? '0' : '1',
+				'censorWholeWord' => empty($this->_req->post->censorWholeWord) ? '0' : '1',
+				'censorIgnoreCase' => empty($this->_req->post->censorIgnoreCase) ? '0' : '1',
 			);
 
 			call_integration_hook('integrate_save_censors', array(&$updates));
@@ -164,10 +178,10 @@ class ManagePosts_Controller extends Action_Controller
 		}
 
 		// Testing a word to see how it will be censored?
-		if (isset($_POST['censortest']))
+		if (isset($this->_req->post->censortest))
 		{
 			require_once(SUBSDIR . '/Post.subs.php');
-			$censorText = htmlspecialchars($_POST['censortest'], ENT_QUOTES, 'UTF-8');
+			$censorText = htmlspecialchars($this->_req->post->censortest, ENT_QUOTES, 'UTF-8');
 			preparsecode($censorText);
 			$pre_censor = $censorText;
 			$context['censor_test'] = strtr(censorText($censorText), array('"' => '&quot;'));
@@ -194,7 +208,7 @@ class ManagePosts_Controller extends Action_Controller
 		createToken('admin-censor');
 
 		// Using ajax?
-		if (isset($_REQUEST['xml'], $_POST['censortest']))
+		if (isset($this->_req->query->xml, $this->_req->post->censortest))
 		{
 			// Clear the templates
 			$template_layers = Template_Layers::getInstance();
@@ -239,12 +253,13 @@ class ManagePosts_Controller extends Action_Controller
 		$context['sub_template'] = 'show_settings';
 
 		// Are we saving them - are we??
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			// If we're changing the message length (and we are using MySQL) let's check the column is big enough.
 			if (isset($_POST['max_messageLength']) && $_POST['max_messageLength'] != $modSettings['max_messageLength'] && DB_TYPE === 'MySQL')
+			if (isset($this->_req->post->max_messageLength) && $this->_req->post->max_messageLength != $modSettings['max_messageLength'] && $db_type == 'mysql')
 			{
 				require_once(SUBSDIR . '/Maintenance.subs.php');
 				$colData = getMessageTableColumns();
@@ -252,18 +267,18 @@ class ManagePosts_Controller extends Action_Controller
 					if ($column['name'] == 'body')
 						$body_type = $column['type'];
 
-				if (isset($body_type) && ($_POST['max_messageLength'] > 65535 || $_POST['max_messageLength'] == 0) && $body_type == 'text')
+				if (isset($body_type) && ($this->_req->post->max_messageLength > 65535 || $this->_req->post->max_messageLength == 0) && $body_type == 'text')
 					Errors::fatal_lang_error('convert_to_mediumtext', false, array($scripturl . '?action=admin;area=maintain;sa=database'));
 
 			}
 
 			// If we're changing the post preview length let's check its valid
-			if (!empty($_POST['preview_characters']))
-				$_POST['preview_characters'] = (int) min(max(0, $_POST['preview_characters']), 512);
+			if (!empty($this->_req->post->preview_characters))
+				$this->_req->post->preview_characters = (int) min(max(0, $this->_req->post->preview_characters), 512);
 
 			call_integration_hook('integrate_save_post_settings');
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			redirectexit('action=admin;area=postsettings;sa=posts');
 		}
 

--- a/sources/admin/ManagePosts.controller.php
+++ b/sources/admin/ManagePosts.controller.php
@@ -258,14 +258,15 @@ class ManagePosts_Controller extends Action_Controller
 			checkSession();
 
 			// If we're changing the message length (and we are using MySQL) let's check the column is big enough.
-			if (isset($_POST['max_messageLength']) && $_POST['max_messageLength'] != $modSettings['max_messageLength'] && DB_TYPE === 'MySQL')
-			if (isset($this->_req->post->max_messageLength) && $this->_req->post->max_messageLength != $modSettings['max_messageLength'] && $db_type == 'mysql')
+			if (isset($this->_req->post->max_messageLength) && $this->_req->post->max_messageLength != $modSettings['max_messageLength'] && DB_TYPE === 'MySQL')
 			{
 				require_once(SUBSDIR . '/Maintenance.subs.php');
 				$colData = getMessageTableColumns();
 				foreach ($colData as $column)
+				{
 					if ($column['name'] == 'body')
 						$body_type = $column['type'];
+				}
 
 				if (isset($body_type) && ($this->_req->post->max_messageLength > 65535 || $this->_req->post->max_messageLength == 0) && $body_type == 'text')
 					Errors::fatal_lang_error('convert_to_mediumtext', false, array($scripturl . '?action=admin;area=maintain;sa=database'));

--- a/sources/admin/ManageRegistration.controller.php
+++ b/sources/admin/ManageRegistration.controller.php
@@ -40,6 +40,20 @@ class ManageRegistration_Controller extends Action_Controller
 	protected $_registerSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Entrance point for the registration center, it checks permisions and forwards
 	 * to the right method based on the subaction.
 	 *
@@ -130,39 +144,39 @@ class ManageRegistration_Controller extends Action_Controller
 	{
 		global $txt, $context, $scripturl, $user_info;
 
-		if (!empty($_POST['regSubmit']))
+		if (!empty($this->_req->post->regSubmit))
 		{
 			checkSession();
 			validateToken('admin-regc');
 
 			// @todo move this to a filter/sanitzation class
-			foreach ($_POST as $key => $value)
+			foreach ($this->_req->post as $key => $value)
 				if (!is_array($value))
-					$_POST[$key] = htmltrim__recursive(str_replace(array("\n", "\r"), '', $value));
+					$this->_req->post[$key] = htmltrim__recursive(str_replace(array("\n", "\r"), '', $value));
 
 			// Generate a password
-			if (empty($_POST['password']) || !is_string($_POST['password']) || trim($_POST['password']) === '')
+			if (empty($this->_req->post->password) || !is_string($this->_req->post->password) || trim($this->_req->post->password) === '')
 			{
 				mt_srand(time() + 1277);
 				$password = generateValidationCode();
 			}
 			else
 			{
-				$password = $_POST['password'];
+				$password = $this->_req->post->password;
 			}
 
 			$regOptions = array(
 				'interface' => 'admin',
-				'username' => $_POST['user'],
-				'email' => $_POST['email'],
+				'username' => $this->_req->post->user,
+				'email' => $this->_req->post->email,
 				'password' => $password,
 				'password_check' => $password,
 				'check_reserved_name' => true,
 				'check_password_strength' => true,
 				'check_email_ban' => false,
-				'send_welcome_email' => isset($_POST['emailPassword']),
-				'require' => isset($_POST['emailActivate']) ? 'activation' : 'nothing',
-				'memberGroup' => empty($_POST['group']) || !allowedTo('manage_membergroups') ? 0 : (int) $_POST['group'],
+				'send_welcome_email' => isset($this->_req->post->emailPassword),
+				'require' => isset($this->_req->post->emailActivate) ? 'activation' : 'nothing',
+				'memberGroup' => empty($this->_req->post->group) || !allowedTo('manage_membergroups') ? 0 : (int) $this->_req->post->group,
 				'ip' => '127.0.0.1',
 				'ip2' => '127.0.0.1',
 				'auth_method' => 'password',
@@ -182,9 +196,9 @@ class ManageRegistration_Controller extends Action_Controller
 			{
 				$context['new_member'] = array(
 					'id' => $memberID,
-					'name' => $_POST['user'],
+					'name' => $this->_req->post->user,
 					'href' => $scripturl . '?action=profile;u=' . $memberID,
-					'link' => '<a href="' . $scripturl . '?action=profile;u=' . $memberID . '">' . $_POST['user'] . '</a>',
+					'link' => '<a href="' . $scripturl . '?action=profile;u=' . $memberID . '">' . $this->_req->post->user . '</a>',
 				);
 				$context['registration_done'] = sprintf($txt['admin_register_done'], $context['new_member']['link']);
 			}
@@ -248,23 +262,24 @@ class ManageRegistration_Controller extends Action_Controller
 			if (file_exists(BOARDDIR . '/agreement.' . $lang['filename'] . '.txt'))
 			{
 				$context['editable_agreements']['.' . $lang['filename']] = $lang['name'];
+
 				// Are we editing this?
-				if (isset($_POST['agree_lang']) && $_POST['agree_lang'] == '.' . $lang['filename'])
+				if (isset($this->_req->post->agree_lang) && $this->_req->post->agree_lang == '.' . $lang['filename'])
 					$context['current_agreement'] = '.' . $lang['filename'];
 			}
 		}
 
-		if (isset($_POST['agreement']))
+		if (isset($this->_req->post->agreement))
 		{
 			checkSession();
 			validateToken('admin-rega');
 
 			// Off it goes to the agreement file.
 			$fp = fopen(BOARDDIR . '/agreement' . $context['current_agreement'] . '.txt', 'w');
-			fwrite($fp, str_replace("\r", '', $_POST['agreement']));
+			fwrite($fp, str_replace("\r", '', $this->_req->post->agreement));
 			fclose($fp);
 
-			updateSettings(array('requireAgreement' => !empty($_POST['requireAgreement']), 'checkboxAgreement' => !empty($_POST['checkboxAgreement'])));
+			updateSettings(array('requireAgreement' => !empty($this->_req->post->requireAgreement), 'checkboxAgreement' => !empty($this->_req->post->checkboxAgreement)));
 		}
 
 		$context['agreement'] = file_exists(BOARDDIR . '/agreement' . $context['current_agreement'] . '.txt') ? htmlspecialchars(file_get_contents(BOARDDIR . '/agreement' . $context['current_agreement'] . '.txt'), ENT_COMPAT, 'UTF-8') : '';
@@ -290,18 +305,18 @@ class ManageRegistration_Controller extends Action_Controller
 		global $txt, $context, $modSettings;
 
 		// Submitting new reserved words.
-		if (!empty($_POST['save_reserved_names']))
+		if (!empty($this->_req->post->save_reserved_names))
 		{
 			checkSession();
 			validateToken('admin-regr');
 
 			// Set all the options....
 			updateSettings(array(
-				'reserveWord' => (isset($_POST['matchword']) ? '1' : '0'),
-				'reserveCase' => (isset($_POST['matchcase']) ? '1' : '0'),
-				'reserveUser' => (isset($_POST['matchuser']) ? '1' : '0'),
-				'reserveName' => (isset($_POST['matchname']) ? '1' : '0'),
-				'reserveNames' => str_replace("\r", '', $_POST['reserved'])
+				'reserveWord' => (isset($this->_req->post->matchword) ? '1' : '0'),
+				'reserveCase' => (isset($this->_req->post->matchcase) ? '1' : '0'),
+				'reserveUser' => (isset($this->_req->post->matchuser) ? '1' : '0'),
+				'reserveName' => (isset($this->_req->post->matchname) ? '1' : '0'),
+				'reserveNames' => str_replace("\r", '', $this->_req->post->reserved)
 			));
 		}
 
@@ -340,20 +355,20 @@ class ManageRegistration_Controller extends Action_Controller
 		$context['sub_template'] = 'show_settings';
 		$context['page_title'] = $txt['registration_center'];
 
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			// Are there some contacts missing?
-			if (!empty($_POST['coppaAge']) && !empty($_POST['coppaType']) && empty($_POST['coppaPost']) && empty($_POST['coppaFax']))
+			if (!empty($this->_req->post->coppaAge) && !empty($this->_req->post->coppaType) && empty($this->_req->post->coppaPost) && empty($this->_req->post->coppaFax))
 				Errors::fatal_lang_error('admin_setting_coppa_require_contact');
 
 			// Post needs to take into account line breaks.
-			$_POST['coppaPost'] = str_replace("\n", '<br />', empty($_POST['coppaPost']) ? '' : $_POST['coppaPost']);
+			$this->_req->post->coppaPost = str_replace("\n", '<br />', empty($this->_req->post->coppaPost) ? '' : $this->_req->post->coppaPost);
 
 			call_integration_hook('integrate_save_registration_settings');
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 
 			redirectexit('action=admin;area=regcenter;sa=settings');
 		}

--- a/sources/admin/ManageSecurity.controller.php
+++ b/sources/admin/ManageSecurity.controller.php
@@ -376,7 +376,7 @@ class ManageSecurity_Controller extends Action_Controller
 					$this_list = array_map('trim', array_filter($this->_req->post->$list));
 					$this_desc = array_intersect_key($this->_req->post->{$list . '_desc'}, $this_list);
 				}
-				var_dump($this_desc);
+
 				updateSettings(array($list => serialize($this_list), $list . '_desc' => serialize($this_desc)));
 			}
 

--- a/sources/admin/ManageSecurity.controller.php
+++ b/sources/admin/ManageSecurity.controller.php
@@ -54,6 +54,20 @@ class ManageSecurity_Controller extends Action_Controller
 	protected $_spamSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * This function passes control through to the relevant security tab.
 	 *
 	 * @see Action_Controller::action_index()
@@ -122,11 +136,11 @@ class ManageSecurity_Controller extends Action_Controller
 		$config_vars = $this->_securitySettings->settings();
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 
 			call_integration_hook('integrate_save_general_security_settings');
 
@@ -174,7 +188,7 @@ class ManageSecurity_Controller extends Action_Controller
 			unset($config_vars['moderate']);
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
@@ -183,25 +197,25 @@ class ManageSecurity_Controller extends Action_Controller
 			// Make sure these don't have an effect.
 			if ($modSettings['warning_settings'][0] != 1)
 			{
-				$_POST['warning_watch'] = 0;
-				$_POST['warning_moderate'] = 0;
-				$_POST['warning_mute'] = 0;
+				$this->_req->post->warning_watch = 0;
+				$this->_req->post->warning_moderate = 0;
+				$this->_req->post->warning_mute = 0;
 			}
 			else
 			{
-				$_POST['warning_watch'] = min($_POST['warning_watch'], 100);
-				$_POST['warning_moderate'] = $modSettings['postmod_active'] ? min($_POST['warning_moderate'], 100) : 0;
-				$_POST['warning_mute'] = min($_POST['warning_mute'], 100);
+				$this->_req->post->warning_watch = min($this->_req->post->warning_watch, 100);
+				$this->_req->post->warning_moderate = $modSettings['postmod_active'] ? min($this->_req->post->warning_moderate, 100) : 0;
+				$this->_req->post->warning_mute = min($this->_req->post->warning_mute, 100);
 			}
 
 			// Fix the warning setting array!
-			$_POST['warning_settings'] = '1,' . min(100, (int) $_POST['user_limit']) . ',' . min(100, (int) $_POST['warning_decrement']);
+			$this->_req->post->warning_settings = '1,' . min(100, (int) $this->_req->post->user_limit) . ',' . min(100, (int) $this->_req->post->warning_decrement);
 			$config_vars[] = array('text', 'warning_settings');
 			unset($config_vars['rem1'], $config_vars['rem2']);
 
 			call_integration_hook('integrate_save_moderation_settings');
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			redirectexit('action=admin;area=securitysettings;sa=moderation');
 		}
 
@@ -247,16 +261,16 @@ class ManageSecurity_Controller extends Action_Controller
 		$config_vars = $this->_spamSettings->settings();
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			// Fix PM settings.
-			$_POST['pm_spam_settings'] = (int) $_POST['max_pm_recipients'] . ',' . (int) $_POST['pm_posts_verification'] . ',' . (int) $_POST['pm_posts_per_hour'];
+			$this->_req->post->pm_spam_settings = (int) $this->_req->post->max_pm_recipients . ',' . (int) $this->_req->post->pm_posts_verification . ',' . (int) $this->_req->post->pm_posts_per_hour;
 
 			// Guest requiring verification!
-			if (empty($_POST['posts_require_captcha']) && !empty($_POST['guests_require_captcha']))
-				$_POST['posts_require_captcha'] = -1;
+			if (empty($this->_req->post->posts_require_captcha) && !empty($this->_req->post->guests_require_captcha))
+				$this->_req->post->posts_require_captcha = -1;
 
 			unset($config_vars['pm1'], $config_vars['pm2'], $config_vars['pm3'], $config_vars['guest_verify']);
 
@@ -265,7 +279,7 @@ class ManageSecurity_Controller extends Action_Controller
 			call_integration_hook('integrate_save_spam_settings');
 
 			// Now save.
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			cache_put_data('verificationQuestionIds', null, 300);
 			redirectexit('action=admin;area=securitysettings;sa=spam');
 		}
@@ -341,14 +355,14 @@ class ManageSecurity_Controller extends Action_Controller
 		$config_vars = $this->_bbSettings->settings();
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
 			// Make sure Bad Behavior defaults are set if nothing was specified
-			$_POST['badbehavior_httpbl_threat'] = empty($_POST['badbehavior_httpbl_threat']) ? 25 : $_POST['badbehavior_httpbl_threat'];
-			$_POST['badbehavior_httpbl_maxage'] = empty($_POST['badbehavior_httpbl_maxage']) ? 30 : $_POST['badbehavior_httpbl_maxage'];
-			$_POST['badbehavior_reverse_proxy_header'] = empty($_POST['badbehavior_reverse_proxy_header']) ? 'X-Forwarded-For' : $_POST['badbehavior_reverse_proxy_header'];
+			$this->_req->post->badbehavior_httpbl_threat = empty($this->_req->post->badbehavior_httpbl_threat) ? 25 : $this->_req->post->badbehavior_httpbl_threat;
+			$this->_req->post->badbehavior_httpbl_maxage = empty($this->_req->post->badbehavior_httpbl_maxage) ? 30 : $this->_req->post->badbehavior_httpbl_maxage;
+			$this->_req->post->badbehavior_reverse_proxy_header = empty($this->_req->post->badbehavior_reverse_proxy_header) ? 'X-Forwarded-For' : $this->_req->post->badbehavior_reverse_proxy_header;
 
 			// Build up the whitelist options
 			foreach ($whitelist as $list)
@@ -356,16 +370,17 @@ class ManageSecurity_Controller extends Action_Controller
 				$this_list = array();
 				$this_desc = array();
 
-				if (isset($_POST[$list]))
+				if (isset($this->_req->post->$list))
 				{
 					// Clear blanks from the data field, only grab the comments that don't have blank data value
-					$this_list = array_map('trim', array_filter($_POST[$list]));
-					$this_desc = array_intersect_key($_POST[$list . '_desc'], $this_list);
+					$this_list = array_map('trim', array_filter($this->_req->post->$list));
+					$this_desc = array_intersect_key($this->_req->post->{$list . '_desc'}, $this_list);
 				}
+				var_dump($this_desc);
 				updateSettings(array($list => serialize($this_list), $list . '_desc' => serialize($this_desc)));
 			}
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			redirectexit('action=admin;area=securitysettings;sa=badbehavior');
 		}
 

--- a/sources/admin/ManageServer.controller.php
+++ b/sources/admin/ManageServer.controller.php
@@ -62,6 +62,20 @@ class ManageServer_Controller extends Action_Controller
 	protected $_balancingSettingsForm;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * This is the main dispatcher. Sets up all the available sub-actions, all the tabs and selects
 	 * the appropriate one based on the sub-action.
 	 *
@@ -110,7 +124,7 @@ class ManageServer_Controller extends Action_Controller
 		$context['sub_template'] = 'show_settings';
 
 		// Any messages to speak of?
-		$context['settings_message'] = (isset($_REQUEST['msg']) && isset($txt[$_REQUEST['msg']])) ? $txt[$_REQUEST['msg']] : '';
+		$context['settings_message'] = (isset($this->_req->query->msg) && isset($txt[$this->_req->query->msg])) ? $txt[$this->_req->query->msg] : '';
 
 		// Warn the user if there's any relevant information regarding Settings.php.
 		if ($subAction != 'cache')
@@ -162,7 +176,7 @@ class ManageServer_Controller extends Action_Controller
 		$context['settings_title'] = $txt['general_settings'];
 
 		// Saving settings?
-		if (isset($_REQUEST['save']))
+		if (isset($this->_req->query->save))
 		{
 			call_integration_hook('integrate_save_general_settings');
 
@@ -215,7 +229,7 @@ class ManageServer_Controller extends Action_Controller
 		$context['save_disabled'] = $context['settings_not_writable'];
 
 		// Saving settings?
-		if (isset($_REQUEST['save']))
+		if (isset($this->_req->query->save))
 		{
 			call_integration_hook('integrate_save_database_settings');
 
@@ -257,22 +271,22 @@ class ManageServer_Controller extends Action_Controller
 		$context['settings_title'] = $txt['cookies_sessions_settings'];
 
 		// Saving settings?
-		if (isset($_REQUEST['save']))
+		if (isset($this->_req->query->save))
 		{
 			call_integration_hook('integrate_save_cookie_settings');
 
 			// Its either local or global cookies
-			if (!empty($_POST['localCookies']) && empty($_POST['globalCookies']))
-				unset($_POST['globalCookies']);
+			if (!empty($this->_req->post->localCookies) && empty($this->_req->post->globalCookies))
+				unset($this->_req->post->globalCookies);
 
-			if (!empty($_POST['globalCookiesDomain']) && strpos($boardurl, $_POST['globalCookiesDomain']) === false)
+			if (!empty($this->_req->post->globalCookiesDomain) && strpos($boardurl, $this->_req->post->globalCookiesDomain) === false)
 				Errors::fatal_lang_error('invalid_cookie_domain', false);
 
 			//Settings_Form::save_db($config_vars);
 			$this->_cookieSettingsForm->save();
 
 			// If the cookie name was changed, reset the cookie.
-			if ($cookiename != $_POST['cookiename'])
+			if ($cookiename != $this->_req->post->cookiename)
 			{
 				require_once(SUBSDIR . '/Auth.subs.php');
 
@@ -282,7 +296,7 @@ class ManageServer_Controller extends Action_Controller
 				setLoginCookie(-3600, 0);
 
 				// Set the new one.
-				$cookiename = $_POST['cookiename'];
+				$cookiename = $this->_req->post->cookiename;
 				setLoginCookie(60 * $modSettings['cookieTime'], $user_settings['id_member'], hash('sha256', $user_settings['passwd'] . $user_settings['password_salt']));
 
 				redirectexit('action=admin;area=serversettings;sa=cookie;' . $context['session_var'] . '=' . $original_session_id, $context['server']['needs_login_fix']);
@@ -345,14 +359,14 @@ class ManageServer_Controller extends Action_Controller
 		}
 
 		// Saving again?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			call_integration_hook('integrate_save_cache_settings');
 
 			$this->_cacheSettingsForm->save();
 
 			// we need to save the $cache_enable to $modSettings as well
-			updatesettings(array('cache_enable' => (int) $_POST['cache_enable']));
+			updatesettings(array('cache_enable' => (int) $this->_req->post->cache_enable));
 
 			// exit so we reload our new settings on the page
 			redirectexit('action=admin;area=serversettings;sa=cache;' . $context['session_var'] . '=' . $context['session_id']);
@@ -409,24 +423,24 @@ class ManageServer_Controller extends Action_Controller
 		$context['settings_title'] = $txt['load_balancing_settings'];
 
 		// Saving?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			// Stupidity is not allowed.
-			foreach ($_POST as $key => $value)
+			foreach ($this->_req->post as $key => $value)
 			{
 				if (strpos($key, 'loadavg') === 0 || $key === 'loadavg_enable')
 					continue;
 				elseif ($key == 'loadavg_auto_opt' && $value <= 1)
-					$_POST['loadavg_auto_opt'] = '1.0';
+					$this->_req->post->loadavg_auto_opt = '1.0';
 				elseif ($key == 'loadavg_forum' && $value < 10)
-					$_POST['loadavg_forum'] = '10.0';
+					$this->_req->post->loadavg_forum = '10.0';
 				elseif ($value < 2)
-					$_POST[$key] = '2.0';
+					$this->_req->$key = '2.0';
 			}
 
 			call_integration_hook('integrate_save_loadavg_settings');
 
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 			redirectexit('action=admin;area=serversettings;sa=loads;' . $context['session_var'] . '=' . $context['session_id']);
 		}
 
@@ -595,7 +609,7 @@ class ManageServer_Controller extends Action_Controller
 				array('localCookies', $txt['localCookies'], 'subtext' => $txt['localCookies_note'], 'db', 'check', false, 'localCookies'),
 				array('globalCookies', $txt['globalCookies'], 'subtext' => $txt['globalCookies_note'], 'db', 'check', false, 'globalCookies'),
 				array('globalCookiesDomain', $txt['globalCookiesDomain'], 'subtext' => $txt['globalCookiesDomain_note'], 'db', 'text', false, 'globalCookiesDomain'),
-				array('secureCookies', $txt['secureCookies'], 'subtext' => $txt['secureCookies_note'], 'db', 'check', false, 'secureCookies', 'disabled' => !isset($_SERVER['HTTPS']) || !(strtolower($_SERVER['HTTPS']) == 'on' || strtolower($_SERVER['HTTPS']) == '1')),
+				array('secureCookies', $txt['secureCookies'], 'subtext' => $txt['secureCookies_note'], 'db', 'check', false, 'secureCookies', 'disabled' => !isset($this->_req->server->HTTPS) || !(strtolower($this->_req->server->HTTPS) == 'on' || strtolower($this->_req->server->HTTPS) == '1')),
 				array('httponlyCookies', $txt['httponlyCookies'], 'subtext' => $txt['httponlyCookies_note'], 'db', 'check', false, 'httponlyCookies'),
 			'',
 				// Sessions

--- a/sources/admin/ManageSmileys.controller.php
+++ b/sources/admin/ManageSmileys.controller.php
@@ -473,7 +473,7 @@ class ManageSmileys_Controller extends Action_Controller
 	 */
 	private function _subActionModifySet()
 	{
-		global $context, $txt;
+		global $context, $txt, $modSettings;
 
 		if ($context['sub_action'] == 'modifyset')
 		{
@@ -599,9 +599,9 @@ class ManageSmileys_Controller extends Action_Controller
 			$allowedTypes = array('jpeg', 'jpg', 'gif', 'png', 'bmp');
 			$disabledFiles = array('con', 'com1', 'com2', 'com3', 'com4', 'prn', 'aux', 'lpt1', '.htaccess', 'index.php');
 
-			$this->_req->post->smiley_code = htmltrim__recursive($this->_req->post->smiley_code);
+			$this->_req->post->smiley_code = $this->_req->getPost('smiley_code', 'Util::htmltrim', '');
+			$this->_req->post->smiley_filename = $this->_req->getPost('smiley_filename', 'Util::htmltrim', '');
 			$this->_req->post->smiley_location = empty($this->_req->post->smiley_location) || $this->_req->post->smiley_location > 2 || $this->_req->post->smiley_location < 0 ? 0 : (int) $this->_req->post->smiley_location;
-			$this->_req->post->smiley_filename = htmltrim__recursive($this->_req->post->smiley_filename);
 
 			// Make sure some code was entered.
 			if (empty($this->_req->post->smiley_code))
@@ -849,8 +849,8 @@ class ManageSmileys_Controller extends Action_Controller
 				// Otherwise an edit.
 				else
 				{
-					$this->_req->post->smiley_code = htmltrim__recursive($this->_req->post->smiley_code);
-					$this->_req->post->smiley_filename = htmltrim__recursive($this->_req->post->smiley_filename);
+					$this->_req->post->smiley_code = $this->_req->getPost('smiley_code', 'Util::htmltrim', '');
+					$this->_req->post->smiley_filename = $this->_req->getPost('smiley_filename', 'Util::htmltrim', '');
 					$this->_req->post->smiley_location = empty($this->_req->post->smiley_location) || $this->_req->post->smiley_location > 2 || $this->_req->post->smiley_location < 0 ? 0 : (int) $this->_req->post->smiley_location;
 
 					// Make sure some code was entered.

--- a/sources/admin/ManageSmileys.controller.php
+++ b/sources/admin/ManageSmileys.controller.php
@@ -39,6 +39,20 @@ class ManageSmileys_Controller extends Action_Controller
 	private $_smiley_context = array();
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * This is the dispatcher of smileys administration.
 	 *
 	 * @uses ManageSmileys language
@@ -143,20 +157,22 @@ class ManageSmileys_Controller extends Action_Controller
 		$context['permissions_excluded'] = array(-1);
 
 		// Saving the settings?
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			checkSession();
 
-			$_POST['smiley_sets_default'] = empty($this->_smiley_context[$_POST['smiley_sets_default']]) ? 'default' : $_POST['smiley_sets_default'];
+			$this->_req->post->smiley_sets_default = $this->_req->getPost('smiley_sets_default', 'trim|strval', 'default');
 
 			// Make sure that the smileys are in the right order after enabling them.
-			if (isset($_POST['smiley_enable']))
+			if (isset($this->_req->post->smiley_enable))
 				sortSmileyTable();
 
 			call_integration_hook('integrate_save_smiley_settings');
 
-			Settings_Form::save_db($config_vars);
+			// Save away
+			Settings_Form::save_db($config_vars, $this->_req->post);
 
+			// Flush the cache so the new settings take effect
 			cache_put_data('parsing_smileys', null, 480);
 			cache_put_data('posting_smileys', null, 480);
 
@@ -237,77 +253,7 @@ class ManageSmileys_Controller extends Action_Controller
 		$context['sub_template'] = $context['sub_action'];
 
 		// They must've been submitted a form.
-		if (isset($_POST['smiley_save']) || isset($_POST['delete_set']))
-		{
-			checkSession();
-			validateToken('admin-mss', 'request');
-
-			// Delete selected smiley sets.
-			if (!empty($_POST['delete_set']) && !empty($_POST['smiley_set']))
-			{
-				$set_paths = explode(',', $modSettings['smiley_sets_known']);
-				$set_names = explode("\n", $modSettings['smiley_sets_names']);
-				foreach ($_POST['smiley_set'] as $id => $val)
-				{
-					if (isset($set_paths[$id], $set_names[$id]) && !empty($id))
-						unset($set_paths[$id], $set_names[$id]);
-				}
-
-				updateSettings(array(
-					'smiley_sets_known' => implode(',', $set_paths),
-					'smiley_sets_names' => implode("\n", $set_names),
-					'smiley_sets_default' => in_array($modSettings['smiley_sets_default'], $set_paths) ? $modSettings['smiley_sets_default'] : $set_paths[0],
-				));
-			}
-			// Add a new smiley set.
-			elseif (!empty($_POST['add']))
-				$context['sub_action'] = 'modifyset';
-			// Create or modify a smiley set.
-			elseif (isset($_POST['set']))
-			{
-				$set_paths = explode(',', $modSettings['smiley_sets_known']);
-				$set_names = explode("\n", $modSettings['smiley_sets_names']);
-
-				// Create a new smiley set.
-				if ($_POST['set'] == -1 && isset($_POST['smiley_sets_path']))
-				{
-					if (in_array($_POST['smiley_sets_path'], $set_paths))
-						Errors::fatal_lang_error('smiley_set_already_exists');
-
-					updateSettings(array(
-						'smiley_sets_known' => $modSettings['smiley_sets_known'] . ',' . $_POST['smiley_sets_path'],
-						'smiley_sets_names' => $modSettings['smiley_sets_names'] . "\n" . $_POST['smiley_sets_name'],
-						'smiley_sets_default' => empty($_POST['smiley_sets_default']) ? $modSettings['smiley_sets_default'] : $_POST['smiley_sets_path'],
-					));
-				}
-				// Modify an existing smiley set.
-				else
-				{
-					// Make sure the smiley set exists.
-					if (!isset($set_paths[$_POST['set']]) || !isset($set_names[$_POST['set']]))
-						Errors::fatal_lang_error('smiley_set_not_found');
-
-					// Make sure the path is not yet used by another smileyset.
-					if (in_array($_POST['smiley_sets_path'], $set_paths) && $_POST['smiley_sets_path'] != $set_paths[$_POST['set']])
-						Errors::fatal_lang_error('smiley_set_path_already_used');
-
-					$set_paths[$_POST['set']] = $_POST['smiley_sets_path'];
-					$set_names[$_POST['set']] = $_POST['smiley_sets_name'];
-					updateSettings(array(
-						'smiley_sets_known' => implode(',', $set_paths),
-						'smiley_sets_names' => implode("\n", $set_names),
-						'smiley_sets_default' => empty($_POST['smiley_sets_default']) ? $modSettings['smiley_sets_default'] : $_POST['smiley_sets_path']
-					));
-				}
-
-				// The user might have checked to also import smileys.
-				if (!empty($_POST['smiley_sets_import']))
-					$this->importSmileys($_POST['smiley_sets_path']);
-			}
-
-			cache_put_data('parsing_smileys', null, 480);
-			cache_put_data('posting_smileys', null, 480);
-		}
+		$this->_subActionSubmit();
 
 		// Load all available smileysets...
 		$context['smiley_sets'] = explode(',', $modSettings['smiley_sets_known']);
@@ -321,87 +267,10 @@ class ManageSmileys_Controller extends Action_Controller
 			);
 
 		// Importing any smileys from an existing set?
-		if ($context['sub_action'] == 'import')
-		{
-			checkSession('get');
-			validateToken('admin-mss', 'request');
-
-			$_GET['set'] = (int) $_GET['set'];
-
-			// Sanity check - then import.
-			if (isset($context['smiley_sets'][$_GET['set']]))
-				$this->importSmileys(un_htmlspecialchars($context['smiley_sets'][$_GET['set']]['path']));
-
-			// Force the process to continue.
-			$context['sub_action'] = 'modifyset';
-			$context['sub_template'] = 'modifyset';
-		}
+		$this->_subActionImport();
 
 		// If we're modifying or adding a smileyset, some context info needs to be set.
-		if ($context['sub_action'] == 'modifyset')
-		{
-			$_GET['set'] = !isset($_GET['set']) ? -1 : (int) $_GET['set'];
-			if ($_GET['set'] == -1 || !isset($context['smiley_sets'][$_GET['set']]))
-				$context['current_set'] = array(
-					'id' => '-1',
-					'path' => '',
-					'name' => '',
-					'selected' => false,
-					'is_new' => true,
-				);
-			else
-			{
-				$context['current_set'] = &$context['smiley_sets'][$_GET['set']];
-				$context['current_set']['is_new'] = false;
-
-				// Calculate whether there are any smileys in the directory that can be imported.
-				if (!empty($modSettings['smiley_enable']) && !empty($modSettings['smileys_dir']) && is_dir($modSettings['smileys_dir'] . '/' . $context['current_set']['path']))
-				{
-					$smileys = array();
-					$dir = dir($modSettings['smileys_dir'] . '/' . $context['current_set']['path']);
-					while ($entry = $dir->read())
-					{
-						if (in_array(strrchr($entry, '.'), array('.jpg', '.gif', '.jpeg', '.png')))
-							$smileys[strtolower($entry)] = $entry;
-					}
-					$dir->close();
-
-					if (empty($smileys))
-						Errors::fatal_lang_error('smiley_set_dir_not_found', false, array($context['current_set']['name']));
-
-					// Exclude the smileys that are already in the database.
-					$found = smileyExists($smileys);
-					foreach ($found as $smiley)
-					{
-						if (isset($smileys[$smiley]))
-							unset($smileys[$smiley]);
-					}
-
-					$context['current_set']['can_import'] = count($smileys);
-
-					// Setup this string to look nice.
-					$txt['smiley_set_import_multiple'] = sprintf($txt['smiley_set_import_multiple'], $context['current_set']['can_import']);
-				}
-			}
-
-			// Retrieve all potential smiley set directories.
-			$context['smiley_set_dirs'] = array();
-			if (!empty($modSettings['smileys_dir']) && is_dir($modSettings['smileys_dir']))
-			{
-				$dir = dir($modSettings['smileys_dir']);
-				while ($entry = $dir->read())
-				{
-					if (!in_array($entry, array('.', '..')) && is_dir($modSettings['smileys_dir'] . '/' . $entry))
-						$context['smiley_set_dirs'][] = array(
-							'id' => $entry,
-							'path' => $modSettings['smileys_dir'] . '/' . $entry,
-							'selectable' => $entry == $context['current_set']['path'] || !in_array($entry, explode(',', $modSettings['smiley_sets_known'])),
-							'current' => $entry == $context['current_set']['path'],
-						);
-				}
-				$dir->close();
-			}
-		}
+		$this->_subActionModifySet();
 
 		// This is our save haven.
 		createToken('admin-mss', 'request');
@@ -510,6 +379,194 @@ class ManageSmileys_Controller extends Action_Controller
 	}
 
 	/**
+	 * Submitted a smiley form, determine what actions are required.
+	 *
+	 * - Handle deleting of a smiley set
+	 * - Adding a new set
+	 * - Modifying an existing set
+	 */
+	private function _subActionSubmit()
+	{
+		global $context, $modSettings;
+
+		if (isset($this->_req->post->smiley_save) || isset($this->_req->post->delete_set))
+		{
+			// Security first
+			checkSession();
+			validateToken('admin-mss', 'request');
+
+			// Delete selected smiley sets.
+			if (!empty($this->_req->post->delete_set) && !empty($this->_req->post->smiley_set))
+			{
+				$set_paths = explode(',', $modSettings['smiley_sets_known']);
+				$set_names = explode("\n", $modSettings['smiley_sets_names']);
+				foreach ($this->_req->post->smiley_set as $id => $val)
+				{
+					if (isset($set_paths[$id], $set_names[$id]) && !empty($id))
+						unset($set_paths[$id], $set_names[$id]);
+				}
+
+				// Update the modsettings with the new values
+				updateSettings(array(
+					'smiley_sets_known' => implode(',', $set_paths),
+					'smiley_sets_names' => implode("\n", $set_names),
+					'smiley_sets_default' => in_array($modSettings['smiley_sets_default'], $set_paths) ? $modSettings['smiley_sets_default'] : $set_paths[0],
+				));
+			}
+			// Add a new smiley set.
+			elseif (!empty($this->_req->post->add))
+				$context['sub_action'] = 'modifyset';
+			// Create or modify a smiley set.
+			elseif (isset($this->_req->post->set))
+			{
+				$set = $this->_req->getPost('set', 'intval', 0);
+
+				$set_paths = explode(',', $modSettings['smiley_sets_known']);
+				$set_names = explode("\n", $modSettings['smiley_sets_names']);
+
+				// Create a new smiley set.
+				if ($set == -1 && isset($this->_req->post->smiley_sets_path))
+				{
+					if (in_array($this->_req->post->smiley_sets_path, $set_paths))
+						Errors::fatal_lang_error('smiley_set_already_exists');
+
+					updateSettings(array(
+						'smiley_sets_known' => $modSettings['smiley_sets_known'] . ',' . $this->_req->post->smiley_sets_path,
+						'smiley_sets_names' => $modSettings['smiley_sets_names'] . "\n" . $this->_req->post->smiley_sets_name,
+						'smiley_sets_default' => empty($this->_req->post->smiley_sets_default) ? $modSettings['smiley_sets_default'] : $this->_req->post->smiley_sets_path,
+					));
+				}
+				// Modify an existing smiley set.
+				else
+				{
+					// Make sure the smiley set exists.
+					if (!isset($set_paths[$set]) || !isset($set_names[$set]))
+						Errors::fatal_lang_error('smiley_set_not_found');
+
+					// Make sure the path is not yet used by another smileyset.
+					if (in_array($this->_req->post->smiley_sets_path, $set_paths) && $this->_req->post->smiley_sets_path != $set_paths[$set])
+						Errors::fatal_lang_error('smiley_set_path_already_used');
+
+					$set_paths[$set] = $this->_req->post->smiley_sets_path;
+					$set_names[$set] = $this->_req->post->smiley_sets_name;
+					updateSettings(array(
+						'smiley_sets_known' => implode(',', $set_paths),
+						'smiley_sets_names' => implode("\n", $set_names),
+						'smiley_sets_default' => empty($this->_req->post->smiley_sets_default) ? $modSettings['smiley_sets_default'] : $this->_req->post->smiley_sets_path
+					));
+				}
+
+				// The user might have checked to also import smileys.
+				if (!empty($this->_req->post->smiley_sets_import))
+					$this->importSmileys($this->_req->post->smiley_sets_path);
+			}
+
+			// No matter what, reset the cache
+			cache_put_data('parsing_smileys', null, 480);
+			cache_put_data('posting_smileys', null, 480);
+		}
+	}
+
+	/**
+	 * If we're modifying or adding a smileyset, or if we imported from antoher
+	 * set, then some context info needs to be set.
+	 */
+	private function _subActionModifySet()
+	{
+		global $context, $txt;
+
+		if ($context['sub_action'] == 'modifyset')
+		{
+			$set = $this->_req->getQuery('set', 'intval', -1);
+			if ($set == -1 || !isset($context['smiley_sets'][$set]))
+				$context['current_set'] = array(
+					'id' => '-1',
+					'path' => '',
+					'name' => '',
+					'selected' => false,
+					'is_new' => true,
+				);
+			else
+			{
+				$context['current_set'] = &$context['smiley_sets'][$set];
+				$context['current_set']['is_new'] = false;
+
+				// Calculate whether there are any smileys in the directory that can be imported.
+				if (!empty($modSettings['smiley_enable']) && !empty($modSettings['smileys_dir']) && is_dir($modSettings['smileys_dir'] . '/' . $context['current_set']['path']))
+				{
+					$smileys = array();
+					$dir = dir($modSettings['smileys_dir'] . '/' . $context['current_set']['path']);
+					while ($entry = $dir->read())
+					{
+						if (in_array(strrchr($entry, '.'), array('.jpg', '.gif', '.jpeg', '.png')))
+							$smileys[strtolower($entry)] = $entry;
+					}
+					$dir->close();
+
+					if (empty($smileys))
+						Errors::fatal_lang_error('smiley_set_dir_not_found', false, array($context['current_set']['name']));
+
+					// Exclude the smileys that are already in the database.
+					$found = smileyExists($smileys);
+					foreach ($found as $smiley)
+					{
+						if (isset($smileys[$smiley]))
+							unset($smileys[$smiley]);
+					}
+
+					$context['current_set']['can_import'] = count($smileys);
+
+					// Setup this string to look nice.
+					$txt['smiley_set_import_multiple'] = sprintf($txt['smiley_set_import_multiple'], $context['current_set']['can_import']);
+				}
+			}
+
+			// Retrieve all potential smiley set directories.
+			$context['smiley_set_dirs'] = array();
+			if (!empty($modSettings['smileys_dir']) && is_dir($modSettings['smileys_dir']))
+			{
+				$dir = dir($modSettings['smileys_dir']);
+				while ($entry = $dir->read())
+				{
+					if (!in_array($entry, array('.', '..')) && is_dir($modSettings['smileys_dir'] . '/' . $entry))
+						$context['smiley_set_dirs'][] = array(
+							'id' => $entry,
+							'path' => $modSettings['smileys_dir'] . '/' . $entry,
+							'selectable' => $entry == $context['current_set']['path'] || !in_array($entry, explode(',', $modSettings['smiley_sets_known'])),
+							'current' => $entry == $context['current_set']['path'],
+						);
+				}
+				$dir->close();
+			}
+		}
+	}
+
+	/**
+	 * Importing smileys from an existing smiley set
+	 */
+	private function _subActionImport()
+	{
+		global $context;
+
+		// Importing any smileys from an existing set?
+		if ($context['sub_action'] === 'import')
+		{
+			checkSession('get');
+			validateToken('admin-mss', 'request');
+
+			$set = (int) $this->_req->query->set;
+
+			// Sanity check - then import.
+			if (isset($context['smiley_sets'][$set]))
+				$this->importSmileys(un_htmlspecialchars($context['smiley_sets'][$set]['path']));
+
+			// Force the process to continue.
+			$context['sub_action'] = 'modifyset';
+			$context['sub_template'] = 'modifyset';
+		}
+	}
+
+	/**
 	 * Add a smiley, that's right.
 	 */
 	public function action_addsmiley()
@@ -534,7 +591,7 @@ class ManageSmileys_Controller extends Action_Controller
 			);
 
 		// Submitting a form?
-		if (isset($_POST[$context['session_var']], $_POST['smiley_code']))
+		if (isset($this->_req->post->$context['session_var'], $this->_req->post->smiley_code))
 		{
 			checkSession();
 
@@ -542,20 +599,20 @@ class ManageSmileys_Controller extends Action_Controller
 			$allowedTypes = array('jpeg', 'jpg', 'gif', 'png', 'bmp');
 			$disabledFiles = array('con', 'com1', 'com2', 'com3', 'com4', 'prn', 'aux', 'lpt1', '.htaccess', 'index.php');
 
-			$_POST['smiley_code'] = htmltrim__recursive($_POST['smiley_code']);
-			$_POST['smiley_location'] = empty($_POST['smiley_location']) || $_POST['smiley_location'] > 2 || $_POST['smiley_location'] < 0 ? 0 : (int) $_POST['smiley_location'];
-			$_POST['smiley_filename'] = htmltrim__recursive($_POST['smiley_filename']);
+			$this->_req->post->smiley_code = htmltrim__recursive($this->_req->post->smiley_code);
+			$this->_req->post->smiley_location = empty($this->_req->post->smiley_location) || $this->_req->post->smiley_location > 2 || $this->_req->post->smiley_location < 0 ? 0 : (int) $this->_req->post->smiley_location;
+			$this->_req->post->smiley_filename = htmltrim__recursive($this->_req->post->smiley_filename);
 
 			// Make sure some code was entered.
-			if (empty($_POST['smiley_code']))
+			if (empty($this->_req->post->smiley_code))
 				Errors::fatal_lang_error('smiley_has_no_code');
 
 			// Check whether the new code has duplicates. It should be unique.
-			if (validateDuplicateSmiley($_POST['smiley_code']))
+			if (validateDuplicateSmiley($this->_req->post->smiley_code))
 				Errors::fatal_lang_error('smiley_not_unique');
 
 			// If we are uploading - check all the smiley sets are writable!
-			if ($_POST['method'] != 'existing')
+			if ($this->_req->post->method != 'existing')
 			{
 				$writeErrors = array();
 				foreach ($context['smiley_sets'] as $set)
@@ -569,7 +626,7 @@ class ManageSmileys_Controller extends Action_Controller
 			}
 
 			// Uploading just one smiley for all of them?
-			if (isset($_POST['sameall']) && isset($_FILES['uploadSmiley']['name']) && $_FILES['uploadSmiley']['name'] != '')
+			if (isset($this->_req->post->sameall) && isset($_FILES['uploadSmiley']['name']) && $_FILES['uploadSmiley']['name'] != '')
 			{
 				if (!is_uploaded_file($_FILES['uploadSmiley']['tmp_name']) || (ini_get('open_basedir') == '' && !file_exists($_FILES['uploadSmiley']['tmp_name'])))
 					Errors::fatal_lang_error('smileys_upload_error');
@@ -618,10 +675,10 @@ class ManageSmileys_Controller extends Action_Controller
 				}
 
 				// Finally make sure it's saved correctly!
-				$_POST['smiley_filename'] = $destName;
+				$this->_req->post->smiley_filename = $destName;
 			}
 			// What about uploading several files?
-			elseif ($_POST['method'] != 'existing')
+			elseif ($this->_req->post->method != 'existing')
 			{
 				$newName = '';
 				foreach ($_FILES as $name => $dummy)
@@ -671,29 +728,29 @@ class ManageSmileys_Controller extends Action_Controller
 					@chmod($smileyLocation, 0644);
 
 					// Should always be saved correctly!
-					$_POST['smiley_filename'] = $destName;
+					$this->_req->post->smiley_filename = $destName;
 				}
 			}
 
 			// Also make sure a filename was given.
-			if (empty($_POST['smiley_filename']))
+			if (empty($this->_req->post->smiley_filename))
 				Errors::fatal_lang_error('smiley_has_no_filename');
 
 			// Find the position on the right.
 			$smiley_order = '0';
-			if ($_POST['smiley_location'] != 1)
+			if ($this->_req->post->smiley_location != 1)
 			{
-				$_POST['smiley_location'] = (int) $_POST['smiley_location'];
-				$smiley_order = nextSmileyLocation($_POST['smiley_location']);
+				$this->_req->post->smiley_location = (int) $this->_req->post->smiley_location;
+				$smiley_order = nextSmileyLocation($this->_req->post->smiley_location);
 
 				if (empty($smiley_order))
 					$smiley_order = '0';
 			}
 			$param = array(
-				$_POST['smiley_code'],
-				$_POST['smiley_filename'],
-				$_POST['smiley_description'],
-				(int) $_POST['smiley_location'],
+				$this->_req->post->smiley_code,
+				$this->_req->post->smiley_filename,
+				$this->_req->post->smiley_description,
+				(int) $this->_req->post->smiley_location,
 				$smiley_order,
 			);
 			addSmiley($param);
@@ -756,18 +813,18 @@ class ManageSmileys_Controller extends Action_Controller
 		$context['sub_template'] = $context['sub_action'];
 
 		// Submitting a form?
-		if (isset($_POST['smiley_save']) || isset($_POST['smiley_action']))
+		if (isset($this->_req->post->smiley_save) || isset($this->_req->post->smiley_action))
 		{
 			checkSession();
 
 			// Changing the selected smileys?
-			if (isset($_POST['smiley_action']) && !empty($_POST['checked_smileys']))
+			if (isset($this->_req->post->smiley_action) && !empty($this->_req->post->checked_smileys))
 			{
-				foreach ($_POST['checked_smileys'] as $id => $smiley_id)
-					$_POST['checked_smileys'][$id] = (int) $smiley_id;
+				foreach ($this->_req->post->checked_smileys as $id => $smiley_id)
+					$this->_req->post->checked_smileys[$id] = (int) $smiley_id;
 
-				if ($_POST['smiley_action'] == 'delete')
-					deleteSmileys($_POST['checked_smileys']);
+				if ($this->_req->post->smiley_action == 'delete')
+					deleteSmileys($this->_req->post->checked_smileys);
 				// Changing the status of the smiley?
 				else
 				{
@@ -777,43 +834,43 @@ class ManageSmileys_Controller extends Action_Controller
 						'hidden' => 1,
 						'popup' => 2
 					);
-					if (isset($displayTypes[$_POST['smiley_action']]))
-						updateSmileyDisplayType($_POST['checked_smileys'], $displayTypes[$_POST['smiley_action']]);
+					if (isset($displayTypes[$this->_req->post->smiley_action]))
+						updateSmileyDisplayType($this->_req->post->checked_smileys, $displayTypes[$this->_req->post->smiley_action]);
 				}
 			}
 			// Create/modify a smiley.
-			elseif (isset($_POST['smiley']))
+			elseif (isset($this->_req->post->smiley))
 			{
-				$_POST['smiley'] = (int) $_POST['smiley'];
+				$this->_req->post->smiley = (int) $this->_req->post->smiley;
 
 				// Is it a delete?
-				if (!empty($_POST['deletesmiley']))
-					deleteSmileys(array($_POST['smiley']));
+				if (!empty($this->_req->post->deletesmiley))
+					deleteSmileys(array($this->_req->post->smiley));
 				// Otherwise an edit.
 				else
 				{
-					$_POST['smiley_code'] = htmltrim__recursive($_POST['smiley_code']);
-					$_POST['smiley_filename'] = htmltrim__recursive($_POST['smiley_filename']);
-					$_POST['smiley_location'] = empty($_POST['smiley_location']) || $_POST['smiley_location'] > 2 || $_POST['smiley_location'] < 0 ? 0 : (int) $_POST['smiley_location'];
+					$this->_req->post->smiley_code = htmltrim__recursive($this->_req->post->smiley_code);
+					$this->_req->post->smiley_filename = htmltrim__recursive($this->_req->post->smiley_filename);
+					$this->_req->post->smiley_location = empty($this->_req->post->smiley_location) || $this->_req->post->smiley_location > 2 || $this->_req->post->smiley_location < 0 ? 0 : (int) $this->_req->post->smiley_location;
 
 					// Make sure some code was entered.
-					if (empty($_POST['smiley_code']))
+					if (empty($this->_req->post->smiley_code))
 						Errors::fatal_lang_error('smiley_has_no_code');
 
 					// Also make sure a filename was given.
-					if (empty($_POST['smiley_filename']))
+					if (empty($this->_req->post->smiley_filename))
 						Errors::fatal_lang_error('smiley_has_no_filename');
 
 					// Check whether the new code has duplicates. It should be unique.
-					if (validateDuplicateSmiley($_POST['smiley_code'], $_POST['smiley']))
+					if (validateDuplicateSmiley($this->_req->post->smiley_code, $this->_req->post->smiley))
 						Errors::fatal_lang_error('smiley_not_unique');
 
 					$param = array(
-						'smiley_location' => $_POST['smiley_location'],
-						'smiley' => $_POST['smiley'],
-						'smiley_code' => $_POST['smiley_code'],
-						'smiley_filename' => $_POST['smiley_filename'],
-						'smiley_description' => $_POST['smiley_description'],
+						'smiley_location' => $this->_req->post->smiley_location,
+						'smiley' => $this->_req->post->smiley,
+						'smiley_code' => $this->_req->post->smiley_code,
+						'smiley_filename' => $this->_req->post->smiley_filename,
+						'smiley_description' => $this->_req->post->smiley_description,
 					);
 					updateSmiley($param);
 				}
@@ -937,7 +994,7 @@ class ManageSmileys_Controller extends Action_Controller
 							'function' => function ($rowData) {
 								global $context, $txt, $modSettings;
 
-								if (empty($modSettings['smileys_dir']) || !is_dir($modSettings['smileys_dir'])) 
+								if (empty($modSettings['smileys_dir']) || !is_dir($modSettings['smileys_dir']))
 									return htmlspecialchars($rowData['description'], ENT_COMPAT, 'UTF-8');
 
 								// Check if there are smileys missing in some sets.
@@ -1097,8 +1154,8 @@ class ManageSmileys_Controller extends Action_Controller
 				ksort($context['filenames']);
 			}
 
-			$_REQUEST['smiley'] = (int) $_REQUEST['smiley'];
-			$context['current_smiley'] = getSmiley($_REQUEST['smiley']);
+			$this->_req->query->smiley = (int) $this->_req->query->smiley;
+			$context['current_smiley'] = getSmiley($this->_req->query->smiley);
 			$context['current_smiley']['code'] = htmlspecialchars($context['current_smiley']['code'], ENT_COMPAT, 'UTF-8');
 			$context['current_smiley']['filename'] = htmlspecialchars($context['current_smiley']['filename'], ENT_COMPAT, 'UTF-8');
 			$context['current_smiley']['description'] = htmlspecialchars($context['current_smiley']['description'], ENT_COMPAT, 'UTF-8');
@@ -1121,52 +1178,52 @@ class ManageSmileys_Controller extends Action_Controller
 		$context['icons'] = fetchMessageIconsDetails();
 
 		// Submitting a form?
-		if (isset($_POST['icons_save']))
+		if (isset($this->_req->post->icons_save))
 		{
 			checkSession();
 
 			// Deleting icons?
-			if (isset($_POST['delete']) && !empty($_POST['checked_icons']))
+			if (isset($this->_req->post->delete) && !empty($this->_req->post->checked_icons))
 			{
 				$deleteIcons = array();
-				foreach ($_POST['checked_icons'] as $icon)
+				foreach ($this->_req->post->checked_icons as $icon)
 					$deleteIcons[] = (int) $icon;
 
 				// Do the actual delete!
 				deleteMessageIcons($deleteIcons);
 			}
 			// Editing/Adding an icon?
-			elseif ($context['sub_action'] == 'editicon' && isset($_GET['icon']))
+			elseif ($context['sub_action'] == 'editicon' && isset($this->_req->query->icon))
 			{
-				$_GET['icon'] = (int) $_GET['icon'];
+				$this->_req->query->icon = (int) $this->_req->query->icon;
 
 				// Do some preperation with the data... like check the icon exists *somewhere*
-				if (strpos($_POST['icon_filename'], '.png') !== false)
-					$_POST['icon_filename'] = substr($_POST['icon_filename'], 0, -4);
+				if (strpos($this->_req->post->icon_filename, '.png') !== false)
+					$this->_req->post->icon_filename = substr($this->_req->post->icon_filename, 0, -4);
 
-				if (!file_exists($settings['default_theme_dir'] . '/images/post/' . $_POST['icon_filename'] . '.png'))
+				if (!file_exists($settings['default_theme_dir'] . '/images/post/' . $this->_req->post->icon_filename . '.png'))
 					Errors::fatal_lang_error('icon_not_found');
 				// There is a 16 character limit on message icons...
-				elseif (strlen($_POST['icon_filename']) > 16)
+				elseif (strlen($this->_req->post->icon_filename) > 16)
 					Errors::fatal_lang_error('icon_name_too_long');
-				elseif ($_POST['icon_location'] == $_GET['icon'] && !empty($_GET['icon']))
+				elseif ($this->_req->post->icon_location == $this->_req->query->icon && !empty($this->_req->query->icon))
 					Errors::fatal_lang_error('icon_after_itself');
 
 				// First do the sorting... if this is an edit reduce the order of everything after it by one ;)
-				if ($_GET['icon'] != 0)
+				if ($this->_req->query->icon != 0)
 				{
-					$oldOrder = $context['icons'][$_GET['icon']]['true_order'];
+					$oldOrder = $context['icons'][$this->_req->query->icon]['true_order'];
 					foreach ($context['icons'] as $id => $data)
 						if ($data['true_order'] > $oldOrder)
 							$context['icons'][$id]['true_order']--;
 				}
 
 				// If there are no existing icons and this is a new one, set the id to 1 (mainly for non-mysql)
-				if (empty($_GET['icon']) && empty($context['icons']))
-					$_GET['icon'] = 1;
+				if (empty($this->_req->query->icon) && empty($context['icons']))
+					$this->_req->query->icon = 1;
 
 				// Get the new order.
-				$newOrder = $_POST['icon_location'] == 0 ? 0 : $context['icons'][$_POST['icon_location']]['true_order'] + 1;
+				$newOrder = $this->_req->post->icon_location == 0 ? 0 : $context['icons'][$this->_req->post->icon_location]['true_order'] + 1;
 
 				// Do the same, but with the one that used to be after this icon, done to avoid conflict.
 				foreach ($context['icons'] as $id => $data)
@@ -1174,12 +1231,12 @@ class ManageSmileys_Controller extends Action_Controller
 						$context['icons'][$id]['true_order']++;
 
 				// Finally set the current icon's position!
-				$context['icons'][$_GET['icon']]['true_order'] = $newOrder;
+				$context['icons'][$this->_req->query->icon]['true_order'] = $newOrder;
 
 				// Simply replace the existing data for the other bits.
-				$context['icons'][$_GET['icon']]['title'] = $_POST['icon_description'];
-				$context['icons'][$_GET['icon']]['filename'] = $_POST['icon_filename'];
-				$context['icons'][$_GET['icon']]['board_id'] = (int) $_POST['icon_board'];
+				$context['icons'][$this->_req->query->icon]['title'] = $this->_req->post->icon_description;
+				$context['icons'][$this->_req->query->icon]['filename'] = $this->_req->post->icon_filename;
+				$context['icons'][$this->_req->query->icon]['board_id'] = (int) $this->_req->post->icon_board;
 
 				// Do a huge replace ;)
 				$iconInsert = array();
@@ -1202,7 +1259,7 @@ class ManageSmileys_Controller extends Action_Controller
 			sortMessageIconTable();
 
 			// Unless we're adding a new thing, we'll escape
-			if (!isset($_POST['add']))
+			if (!isset($this->_req->post->add))
 				redirectexit('action=admin;area=smileys;sa=editicons');
 		}
 
@@ -1322,15 +1379,15 @@ class ManageSmileys_Controller extends Action_Controller
 		createList($listOptions);
 
 		// If we're adding/editing an icon we'll need a list of boards
-		if ($context['sub_action'] == 'editicon' || isset($_POST['add']))
+		if ($context['sub_action'] == 'editicon' || isset($this->_req->post->add))
 		{
 			// Force the sub_template just in case.
 			$context['sub_template'] = 'editicon';
-			$context['new_icon'] = !isset($_GET['icon']);
+			$context['new_icon'] = !isset($this->_req->query->icon);
 
 			// Get the properties of the current icon from the icon list.
 			if (!$context['new_icon'])
-				$context['icon'] = $context['icons'][$_GET['icon']];
+				$context['icon'] = $context['icons'][$this->_req->query->icon];
 
 			// Get a list of boards needed for assigning this icon to a specific board.
 			$boardListOptions = array(
@@ -1352,38 +1409,38 @@ class ManageSmileys_Controller extends Action_Controller
 		$context['sub_template'] = 'setorder';
 
 		// Move smileys to another position.
-		if (isset($_REQUEST['reorder']))
+		if (isset($this->_req->query->reorder))
 		{
 			checkSession('get');
 
-			$_GET['location'] = empty($_GET['location']) || $_GET['location'] != 'popup' ? 0 : 2;
-			$_GET['source'] = empty($_GET['source']) ? 0 : (int) $_GET['source'];
+			$this->_req->query->location = empty($this->_req->query->location) || $this->_req->query->location != 'popup' ? 0 : 2;
+			$this->_req->query->source = empty($this->_req->query->source) ? 0 : (int) $this->_req->query->source;
 
-			if (empty($_GET['source']))
+			if (empty($this->_req->query->source))
 				Errors::fatal_lang_error('smiley_not_found');
 
 			$smiley = array();
 
-			if (!empty($_GET['after']))
+			if (!empty($this->_req->query->after))
 			{
-				$_GET['after'] = (int) $_GET['after'];
+				$this->_req->query->after = (int) $this->_req->query->after;
 
-				$smiley = getSmileyPosition($_GET['location'], $_GET['after']);
+				$smiley = getSmileyPosition($this->_req->query->location, $this->_req->query->after);
 				if (empty($smiley))
 					Errors::fatal_lang_error('smiley_not_found');
 			}
 			else
 			{
-				$smiley['row'] = (int) $_GET['row'];
+				$smiley['row'] = (int) $this->_req->query->row;
 				$smiley['order'] = -1;
-				$smiley['location'] = (int) $_GET['location'];
+				$smiley['location'] = (int) $this->_req->query->location;
 			}
 
-			moveSmileyPosition($smiley, $_GET['source']);
+			moveSmileyPosition($smiley, $this->_req->query->source);
 		}
 
 		$context['smileys'] = getSmileys();
-		$context['move_smiley'] = empty($_REQUEST['move']) ? 0 : (int) $_REQUEST['move'];
+		$context['move_smiley'] = empty($this->_req->query->move) ? 0 : (int) $this->_req->query->move;
 
 		// Make sure all rows are sequential.
 		foreach (array_keys($context['smileys']) as $location)
@@ -1443,14 +1500,14 @@ class ManageSmileys_Controller extends Action_Controller
 		$destination = '';
 		$name = '';
 
-		if (isset($_REQUEST['set_gz']))
+		if (isset($this->_req->query->set_gz))
 		{
-			$base_name = strtr(basename($_REQUEST['set_gz']), ':/', '-_');
-			$name = Util::htmlspecialchars(strtok(basename($_REQUEST['set_gz']), '.'));
+			$base_name = strtr(basename($this->_req->query->set_gz), ':/', '-_');
+			$name = Util::htmlspecialchars(strtok(basename($this->_req->query->set_gz), '.'));
 			$context['filename'] = $base_name;
 
 			// Check that the smiley is from simplemachines.org, for now... maybe add mirroring later.
-			if (!isAuthorizedServer($_REQUEST['set_gz']) == 0)
+			if (!isAuthorizedServer($this->_req->query->set_gz) == 0)
 				Errors::fatal_lang_error('not_valid_server');
 
 			$destination = BOARDDIR . '/packages/' . $base_name;
@@ -1459,16 +1516,16 @@ class ManageSmileys_Controller extends Action_Controller
 				Errors::fatal_lang_error('package_upload_error_exists');
 
 			// Let's copy it to the packages directory
-			file_put_contents($destination, fetch_web_data($_REQUEST['set_gz']));
+			file_put_contents($destination, fetch_web_data($this->_req->query->set_gz));
 			$testing = true;
 		}
-		elseif (isset($_REQUEST['package']))
+		elseif (isset($this->_req->query->package))
 		{
-			$base_name = basename($_REQUEST['package']);
-			$name = Util::htmlspecialchars(strtok(basename($_REQUEST['package']), '.'));
+			$base_name = basename($this->_req->query->package);
+			$name = Util::htmlspecialchars(strtok(basename($this->_req->query->package), '.'));
 			$context['filename'] = $base_name;
 
-			$destination = BOARDDIR . '/packages/' . basename($_REQUEST['package']);
+			$destination = BOARDDIR . '/packages/' . basename($this->_req->query->package);
 		}
 
 		if (!file_exists($destination))
@@ -1485,7 +1542,7 @@ class ManageSmileys_Controller extends Action_Controller
 			{
 				deltree(BOARDDIR . '/packages/temp', false);
 				// @todo not sure about url in destination_url
-				create_chmod_control(array(BOARDDIR . '/packages/temp/delme.tmp'), array('destination_url' => $scripturl . '?action=admin;area=smileys;sa=install;set_gz=' . $_REQUEST['set_gz'], 'crash_on_error' => true));
+				create_chmod_control(array(BOARDDIR . '/packages/temp/delme.tmp'), array('destination_url' => $scripturl . '?action=admin;area=smileys;sa=install;set_gz=' . $this->_req->query->set_gz, 'crash_on_error' => true));
 
 				deltree(BOARDDIR . '/packages/temp', false);
 				if (!mktree(BOARDDIR . '/packages/temp', 0777))

--- a/sources/admin/ManageThemes.controller.php
+++ b/sources/admin/ManageThemes.controller.php
@@ -48,6 +48,48 @@ if (!defined('ELK'))
 class ManageThemes_Controller extends Action_Controller
 {
 	/**
+	 * Holds the selected theme options
+	 * @var mixed[]
+	 */
+	private $_options;
+
+	/**
+	 * Holds the selected default theme options
+	 * @var mixed[]
+	 */
+	private $_default_options;
+
+	/**
+	 * Holds the selected master options for a theme
+	 * @var mixed[]
+	 */
+	private $_options_master;
+
+	/**
+	 * Holds the selected default master options for a theme
+	 * @var mixed[]
+	 */
+	private $_default_options_master;
+
+	/**
+	 * Name of the theme
+	 * @var string
+	 */
+	private $theme_name;
+
+	/**
+	 * Full path to the theme
+	 * @var string
+	 */
+	private $theme_dir;
+
+	/**
+	 * The themes images url if any
+	 * @var string|null
+	 */
+	private $images_url;
+
+	/**
 	 * Holds instance of HttpReq object
 	 * @var HttpReq
 	 */
@@ -647,6 +689,7 @@ class ManageThemes_Controller extends Action_Controller
 			checkSession();
 			validateToken('admin-sts');
 
+			$options = array();
 			$options['options'] = empty($this->_req->post->options) ? array() : (array) $this->_req->post->options;
 			$options['default_options'] = empty($this->_req->post->default_options) ? array() : (array) $this->_req->post->default_options;
 
@@ -1221,6 +1264,8 @@ class ManageThemes_Controller extends Action_Controller
 	 */
 	public function installFromZip()
 	{
+		global $context;
+
 		// Hopefully the themes directory is writable, or we might have a problem.
 		if (!is_writable(BOARDDIR . '/themes'))
 			Errors::fatal_lang_error('theme_install_write_error', 'critical');
@@ -1266,7 +1311,7 @@ class ManageThemes_Controller extends Action_Controller
 	 */
 	public function copyDefault()
 	{
-		global $boardurl, $modSettings;
+		global $boardurl, $modSettings, $settings;
 
 		// Hopefully the themes directory is writable, or we might have a problem.
 		if (!is_writable(BOARDDIR . '/themes'))

--- a/sources/admin/ManageThemes.controller.php
+++ b/sources/admin/ManageThemes.controller.php
@@ -48,6 +48,20 @@ if (!defined('ELK'))
 class ManageThemes_Controller extends Action_Controller
 {
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Subaction handler - manages the action and delegates control to the proper
 	 * sub-action.
 	 *
@@ -63,7 +77,7 @@ class ManageThemes_Controller extends Action_Controller
 	{
 		global $txt, $context;
 
-		if (isset($_REQUEST['api']))
+		if (isset($this->_req->query->api))
 			return $this->action_index_api();
 
 		// Load the important language files...
@@ -175,8 +189,8 @@ class ManageThemes_Controller extends Action_Controller
 		);
 
 		// Follow the sa or just go to administration.
-		if (isset($_GET['sa']) && !empty($subActions[$_GET['sa']]))
-			$this->{$subActions[$_GET['sa']]}();
+		if (isset($this->_req->query->sa) && !empty($subActions[$this->_req->query->sa]))
+			$this->{$subActions[$this->_req->query->sa]}();
 		else
 		{
 			loadLanguage('Errors');
@@ -207,31 +221,34 @@ class ManageThemes_Controller extends Action_Controller
 		loadLanguage('Admin');
 
 		// Saving?
-		if (isset($_POST['save']))
+		if (isset($this->_req->post->save))
 		{
 			checkSession();
 			validateToken('admin-tm');
 
 			// What themes are being made as known to the members
-			if (isset($_POST['options']['known_themes']))
-				foreach ($_POST['options']['known_themes'] as $key => $id)
-					$_POST['options']['known_themes'][$key] = (int) $id;
+			if (isset($this->_req->post->options['known_themes']))
+			{
+				foreach ($this->_req->post->options['known_themes'] as $key => $id)
+					$this->_req->post->options['known_themes'][$key] = (int) $id;
+			}
 			else
 				Errors::fatal_lang_error('themes_none_selectable', false);
 
-			if (!in_array($_POST['options']['theme_guests'], $_POST['options']['known_themes']))
+			if (!in_array($this->_req->post->options['theme_guests'], $this->_req->post->options['known_themes']))
 					Errors::fatal_lang_error('themes_default_selectable', false);
 
 			// Commit the new settings.
 			updateSettings(array(
-				'theme_allow' => !empty($_POST['options']['theme_allow']),
-				'theme_guests' => $_POST['options']['theme_guests'],
-				'knownThemes' => implode(',', $_POST['options']['known_themes']),
+				'theme_allow' => !empty($this->_req->post->options['theme_allow']),
+				'theme_guests' => $this->_req->post->options['theme_guests'],
+				'knownThemes' => implode(',', $this->_req->post->options['known_themes']),
 			));
-			if ((int) $_POST['theme_reset'] == 0 || in_array($_POST['theme_reset'], $_POST['options']['known_themes']))
+
+			if ((int) $this->_req->post->theme_reset == 0 || in_array($this->_req->post->theme_reset, $this->_req->post->options['known_themes']))
 			{
 				require_once(SUBSDIR . '/Members.subs.php');
-				updateMemberData(null, array('id_theme' => (int) $_POST['theme_reset']));
+				updateMemberData(null, array('id_theme' => (int) $this->_req->post->theme_reset));
 			}
 
 			redirectexit('action=admin;area=theme;' . $context['session_var'] . '=' . $context['session_id'] . ';sa=admin');
@@ -278,11 +295,11 @@ class ManageThemes_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Themes.subs.php');
 		loadLanguage('Admin');
 
-		if (isset($_REQUEST['th']))
+		if (isset($this->_req->query->th))
 			return $this->action_setthemesettings();
 
 		// Saving?
-		if (isset($_POST['save']))
+		if (isset($this->_req->post->save))
 		{
 			checkSession();
 			validateToken('admin-tl');
@@ -292,18 +309,18 @@ class ManageThemes_Controller extends Action_Controller
 			$setValues = array();
 			foreach ($themes as $id => $theme)
 			{
-				if (file_exists($_POST['reset_dir'] . '/' . basename($theme['theme_dir'])))
+				if (file_exists($this->_req->post->reset_dir . '/' . basename($theme['theme_dir'])))
 				{
-					$setValues[] = array($id, 0, 'theme_dir', realpath($_POST['reset_dir'] . '/' . basename($theme['theme_dir'])));
-					$setValues[] = array($id, 0, 'theme_url', $_POST['reset_url'] . '/' . basename($theme['theme_dir']));
-					$setValues[] = array($id, 0, 'images_url', $_POST['reset_url'] . '/' . basename($theme['theme_dir']) . '/' . basename($theme['images_url']));
+					$setValues[] = array($id, 0, 'theme_dir', realpath($this->_req->post->reset_dir . '/' . basename($theme['theme_dir'])));
+					$setValues[] = array($id, 0, 'theme_url', $this->_req->post->reset_url . '/' . basename($theme['theme_dir']));
+					$setValues[] = array($id, 0, 'images_url', $this->_req->post->reset_url . '/' . basename($theme['theme_dir']) . '/' . basename($theme['images_url']));
 				}
 
-				if (isset($theme['base_theme_dir']) && file_exists($_POST['reset_dir'] . '/' . basename($theme['base_theme_dir'])))
+				if (isset($theme['base_theme_dir']) && file_exists($this->_req->post->reset_dir . '/' . basename($theme['base_theme_dir'])))
 				{
-					$setValues[] = array($id, 0, 'base_theme_dir', realpath($_POST['reset_dir'] . '/' . basename($theme['base_theme_dir'])));
-					$setValues[] = array($id, 0, 'base_theme_url', $_POST['reset_url'] . '/' . basename($theme['base_theme_dir']));
-					$setValues[] = array($id, 0, 'base_images_url', $_POST['reset_url'] . '/' . basename($theme['base_theme_dir']) . '/' . basename($theme['base_images_url']));
+					$setValues[] = array($id, 0, 'base_theme_dir', realpath($this->_req->post->reset_dir . '/' . basename($theme['base_theme_dir'])));
+					$setValues[] = array($id, 0, 'base_theme_url', $this->_req->post->reset_url . '/' . basename($theme['base_theme_dir']));
+					$setValues[] = array($id, 0, 'base_images_url', $this->_req->post->reset_url . '/' . basename($theme['base_theme_dir']) . '/' . basename($theme['base_images_url']));
 				}
 
 				cache_put_data('theme_settings-' . $id, null, 90);
@@ -362,9 +379,9 @@ class ManageThemes_Controller extends Action_Controller
 		global $txt, $context, $settings, $modSettings;
 
 		require_once(SUBSDIR . '/Themes.subs.php');
-		$theme = isset($_GET['th']) ? (int) $_GET['th'] : (isset($_GET['id']) ? (int) $_GET['id'] : 0);
+		$theme = $this->_req->getQuery('th', 'intval', $this->_req->getQuery('id', 'intval', 0));
 
-		if (empty($theme) && empty($_GET['id']))
+		if (empty($theme) && empty($this->_req->query->id))
 		{
 			$context['themes'] = installedThemes();
 
@@ -391,24 +408,24 @@ class ManageThemes_Controller extends Action_Controller
 		}
 
 		// Submit?
-		if (isset($_POST['submit']) && empty($_POST['who']))
+		if (isset($this->_req->post->submit) && empty($this->_req->post->who))
 		{
 			checkSession();
 			validateToken('admin-sto');
 
-			if (empty($_POST['options']))
-				$_POST['options'] = array();
+			if (empty($this->_req->post->options))
+				$this->_options = array();
 
-			if (empty($_POST['default_options']))
-				$_POST['default_options'] = array();
+			if (empty($this->_req->post->default_options))
+				$this->_default_options = array();
 
 			// Set up the query values.
 			$setValues = array();
-			foreach ($_POST['options'] as $opt => $val)
+			foreach ($this->_options as $opt => $val)
 				$setValues[] = array($theme, -1, $opt, is_array($val) ? implode(',', $val) : $val);
 
 			$old_settings = array();
-			foreach ($_POST['default_options'] as $opt => $val)
+			foreach ($this->_default_options as $opt => $val)
 			{
 				$old_settings[] = $opt;
 				$setValues[] = array(1, -1, $opt, is_array($val) ? implode(',', $val) : $val);
@@ -431,22 +448,22 @@ class ManageThemes_Controller extends Action_Controller
 			redirectexit('action=admin;area=theme;' . $context['session_var'] . '=' . $context['session_id'] . ';sa=reset');
 		}
 		// Changing the current options for all members using this theme
-		elseif (isset($_POST['submit']) && $_POST['who'] == 1)
+		elseif (isset($this->_req->post->submit) && $this->_req->post->who == 1)
 		{
 			checkSession();
 			validateToken('admin-sto');
 
-			$_POST['options'] = empty($_POST['options']) ? array() : $_POST['options'];
-			$_POST['options_master'] = empty($_POST['options_master']) ? array() : $_POST['options_master'];
-			$_POST['default_options'] = empty($_POST['default_options']) ? array() : $_POST['default_options'];
-			$_POST['default_options_master'] = empty($_POST['default_options_master']) ? array() : $_POST['default_options_master'];
+			$this->_options = empty($this->_req->post->options) ? array() : $this->_req->post->options;
+			$this->_options_master = empty($this->_req->post->options_master) ? array() : $this->_req->post->options_master;
+			$this->_default_options = empty($this->_req->post->default_options) ? array() : $this->_req->post->default_options;
+			$this->_default_options_master = empty($this->_req->post->default_options_master) ? array() : $this->_req->post->default_options_master;
 
 			$old_settings = array();
-			foreach ($_POST['default_options'] as $opt => $val)
+			foreach ($this->_default_options as $opt => $val)
 			{
-				if ($_POST['default_options_master'][$opt] == 0)
+				if ($this->_default_options_master[$opt] == 0)
 					continue;
-				elseif ($_POST['default_options_master'][$opt] == 1)
+				elseif ($this->_default_options_master[$opt] == 1)
 				{
 					// Delete then insert for ease of database compatibility!
 					removeThemeOptions('default', 'members', $opt);
@@ -454,7 +471,7 @@ class ManageThemes_Controller extends Action_Controller
 
 					$old_settings[] = $opt;
 				}
-				elseif ($_POST['default_options_master'][$opt] == 2)
+				elseif ($this->_default_options_master[$opt] == 2)
 					removeThemeOptions('all', 'members', $opt);
 			}
 
@@ -462,24 +479,24 @@ class ManageThemes_Controller extends Action_Controller
 			if (!empty($old_settings))
 				removeThemeOptions('custom', 'members', $old_settings);
 
-			foreach ($_POST['options'] as $opt => $val)
+			foreach ($this->_options as $opt => $val)
 			{
-				if ($_POST['options_master'][$opt] == 0)
+				if ($this->_options_master[$opt] == 0)
 					continue;
-				elseif ($_POST['options_master'][$opt] == 1)
+				elseif ($this->_options_master[$opt] == 1)
 				{
 					// Delete then insert for ease of database compatibility - again!
 					removeThemeOptions($theme, 'non_default', $opt);
 					addThemeOptions($theme, $opt, $val);
 				}
-				elseif ($_POST['options_master'][$opt] == 2)
+				elseif ($this->_options_master[$opt] == 2)
 					removeThemeOptions($theme, 'all', $opt);
 			}
 
 			redirectexit('action=admin;area=theme;' . $context['session_var'] . '=' . $context['session_id'] . ';sa=reset');
 		}
 		// Remove all members options and use the defaults
-		elseif (!empty($_GET['who']) && $_GET['who'] == 2)
+		elseif (!empty($this->_req->query->who) && $this->_req->query->who == 2)
 		{
 			checkSession('get');
 			validateToken('admin-stor', 'request');
@@ -509,7 +526,7 @@ class ManageThemes_Controller extends Action_Controller
 		$context['theme_settings'] = $settings;
 
 		// Load the options for these theme
-		if (empty($_REQUEST['who']))
+		if (empty($this->_req->query->who))
 		{
 			$context['theme_options'] = loadThemeOptionsInto(array(1, $theme), -1, $context['theme_options']);
 			$context['theme_options_reset'] = false;
@@ -574,11 +591,11 @@ class ManageThemes_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Themes.subs.php');
 
 		// Nothing chosen, back to the start you go
-		if (empty($_GET['th']) && empty($_GET['id']))
+		if (empty($this->_req->query->th) && empty($this->_req->query->id))
 			return $this->action_admin();
 
 		// The theme's ID is needed
-		$theme = isset($_GET['th']) ? (int) $_GET['th'] : (int) $_GET['id'];
+		$theme = $this->_req->getQuery('th', 'intval', $this->_req->getQuery('id', 'intval', 0));
 
 		// Validate inputs/user.
 		if (empty($theme))
@@ -624,16 +641,14 @@ class ManageThemes_Controller extends Action_Controller
 		}
 
 		// Submitting!
-		if (isset($_POST['save']))
+		if (isset($this->_req->post->save))
 		{
 			// Allowed?
 			checkSession();
 			validateToken('admin-sts');
 
-			if (empty($_POST['options']))
-				$_POST['options'] = array();
-			if (empty($_POST['default_options']))
-				$_POST['default_options'] = array();
+			$options['options'] = empty($this->_req->post->options) ? array() : (array) $this->_req->post->options;
+			$options['default_options'] = empty($this->_req->post->default_options) ? array() : (array) $this->_req->post->default_options;
 
 			// Make sure items are cast correctly.
 			foreach ($context['theme_settings'] as $item)
@@ -645,23 +660,23 @@ class ManageThemes_Controller extends Action_Controller
 				// Clean them up for the database
 				foreach (array('options', 'default_options') as $option)
 				{
-					if (!isset($_POST[$option][$item['id']]))
+					if (!isset($options[$option][$item['id']]))
 						continue;
 					// Checkbox.
 					elseif (empty($item['type']))
-						$_POST[$option][$item['id']] = $_POST[$option][$item['id']] ? 1 : 0;
+						$options[$option][$item['id']] = $options[$option][$item['id']] ? 1 : 0;
 					// Number
 					elseif ($item['type'] == 'number')
-						$_POST[$option][$item['id']] = (int) $_POST[$option][$item['id']];
+						$options[$option][$item['id']] = (int) $options[$option][$item['id']];
 				}
 			}
 
 			// Set up the sql query.
 			$inserts = array();
-			foreach ($_POST['options'] as $opt => $val)
+			foreach ($options['options'] as $opt => $val)
 				$inserts[] = array($theme, 0, $opt, is_array($val) ? implode(',', $val) : $val);
 
-			foreach ($_POST['default_options'] as $opt => $val)
+			foreach ($options['default_options'] as $opt => $val)
 				$inserts[] = array(1, 0, $opt, is_array($val) ? implode(',', $val) : $val);
 
 			// If we're actually inserting something..
@@ -756,7 +771,7 @@ class ManageThemes_Controller extends Action_Controller
 		validateToken('admin-tr', 'request');
 
 		// The theme's ID must be an integer.
-		$theme = isset($_GET['th']) ? (int) $_GET['th'] : (int) $_GET['id'];
+		$theme = $this->_req->getQuery('th', 'intval', $this->_req->getQuery('id', 'intval', 0));
 
 		// You can't delete the default theme!
 		if ($theme == 1)
@@ -833,7 +848,7 @@ class ManageThemes_Controller extends Action_Controller
 		}
 
 		// The theme's ID must be an integer.
-		$theme = isset($_GET['th']) ? (int) $_GET['th'] : (int) $_GET['id'];
+		$theme = $this->_req->getQuery('th', 'intval', $this->_req->getQuery('id', 'intval', 0));
 
 		// You can't delete the default theme!
 		if ($theme == 1)
@@ -902,46 +917,48 @@ class ManageThemes_Controller extends Action_Controller
 
 		// Build the link tree.
 		$context['linktree'][] = array(
-			'url' => $scripturl . '?action=theme;sa=pick;u=' . (!empty($_REQUEST['u']) ? (int) $_REQUEST['u'] : 0),
+			'url' => $scripturl . '?action=theme;sa=pick;u=' . (!empty($this->_req->query->u) ? (int) $this->_req->query->u : 0),
 			'name' => $txt['theme_pick'],
 		);
 		$context['default_theme_id'] = $modSettings['theme_default'];
 
 		$_SESSION['id_theme'] = 0;
 
-		if (isset($_GET['id']))
-			$_GET['th'] = $_GET['id'];
+		if (isset($this->_req->query->id))
+			$this->_req->query->th = $this->_req->query->id;
 
 		// Saving a variant cause JS doesn't work - pretend it did ;)
-		if (isset($_POST['save']))
+		if (isset($this->_req->post->save))
 		{
 			// Which theme?
-			foreach ($_POST['save'] as $k => $v)
-				$_GET['th'] = (int) $k;
+			foreach ($this->_req->post->save as $k => $v)
+				$this->_req->query->th = (int) $k;
 
-			if (isset($_POST['vrt'][$k]))
-				$_GET['vrt'] = $_POST['vrt'][$k];
+			if (isset($this->_req->post->vrt[$k]))
+				$this->_req->query->vrt = $this->_req->post->vrt[$k];
 		}
 
 		// Have we made a decision, or are we just browsing?
-		if (isset($_GET['th']))
+		if (isset($this->_req->query->th))
 		{
 			checkSession('get');
 
-			$_GET['th'] = (int) $_GET['th'];
+			$th = $this->_req->getQuery('th', 'intval');
+			$vrt = $this->_req->getQuery('vrt', 'intval');
+			$u = $this->_req->getQuery('u', 'intval');
 
 			// Save for this user.
-			if (!isset($_REQUEST['u']) || !allowedTo('admin_forum'))
+			if (!isset($u) || !allowedTo('admin_forum'))
 			{
 				require_once(SUBSDIR . '/Members.subs.php');
-				updateMemberData($user_info['id'], array('id_theme' => (int) $_GET['th']));
+				updateMemberData($user_info['id'], array('id_theme' => $th));
 
 				// A variants to save for the user?
-				if (!empty($_GET['vrt']))
+				if (!empty($vrt))
 				{
-					updateThemeOptions(array($_GET['th'], $user_info['id'], 'theme_variant', $_GET['vrt']));
+					updateThemeOptions(array($th, $user_info['id'], 'theme_variant', $vrt));
 
-					cache_put_data('theme_settings-' . $_GET['th'] . ':' . $user_info['id'], null, 90);
+					cache_put_data('theme_settings-' . $th . ':' . $user_info['id'], null, 90);
 
 					$_SESSION['id_variant'] = 0;
 				}
@@ -950,30 +967,30 @@ class ManageThemes_Controller extends Action_Controller
 			}
 
 			// If changing members or guests - and there's a variant - assume changing default variant.
-			if (!empty($_GET['vrt']) && ($_REQUEST['u'] == '0' || $_REQUEST['u'] == '-1'))
+			if (!empty($vrt) && ($u === 0 || $u === -1))
 			{
-				updateThemeOptions(array($_GET['th'], 0, 'default_variant', $_GET['vrt']));
+				updateThemeOptions(array($th, 0, 'default_variant', $vrt));
 
 				// Make it obvious that it's changed
-				cache_put_data('theme_settings-' . $_GET['th'], null, 90);
+				cache_put_data('theme_settings-' . $th, null, 90);
 			}
 
 			// For everyone.
-			if ($_REQUEST['u'] == '0')
+			if ($u === 0)
 			{
 				require_once(SUBSDIR . '/Members.subs.php');
-				updateMemberData(null, array('id_theme' => (int) $_GET['th']));
+				updateMemberData(null, array('id_theme' => $th));
 
 				// Remove any custom variants.
-				if (!empty($_GET['vrt']))
-					deleteVariants((int) $_GET['th']);
+				if (!empty($vrt))
+					deleteVariants($th);
 
 				redirectexit('action=admin;area=theme;sa=admin;' . $context['session_var'] . '=' . $context['session_id']);
 			}
 			// Change the default/guest theme.
-			elseif ($_REQUEST['u'] == '-1')
+			elseif ($u === -1)
 			{
-				updateSettings(array('theme_guests' => (int) $_GET['th']));
+				updateSettings(array('theme_guests' => $th));
 
 				redirectexit('action=admin;area=theme;sa=admin;' . $context['session_var'] . '=' . $context['session_id']);
 			}
@@ -981,39 +998,41 @@ class ManageThemes_Controller extends Action_Controller
 			else
 			{
 				// The forum's default theme is always 0 and we
-				if (isset($_GET['th']) && $_GET['th'] == 0)
-					$_GET['th'] = $modSettings['theme_guests'];
+				if (isset($th) && $th == 0)
+					$th = $modSettings['theme_guests'];
 
 				require_once(SUBSDIR . '/Members.subs.php');
-				updateMemberData((int) $_REQUEST['u'], array('id_theme' => (int) $_GET['th']));
+				updateMemberData($u, array('id_theme' => $th));
 
-				if (!empty($_GET['vrt']))
+				if (!empty($vrt))
 				{
-					updateThemeOptions(array($_GET['th'], (int) $_REQUEST['u'], 'theme_variant', $_GET['vrt']));
-					cache_put_data('theme_settings-' . $_GET['th'] . ':' . (int) $_REQUEST['u'], null, 90);
+					updateThemeOptions(array($th, $u, 'theme_variant', $vrt));
+					cache_put_data('theme_settings-' . $th . ':' . $u, null, 90);
 
-					if ($user_info['id'] == $_REQUEST['u'])
+					if ($user_info['id'] == $u)
 						$_SESSION['id_variant'] = 0;
 				}
 
-				redirectexit('action=profile;u=' . (int) $_REQUEST['u'] . ';area=theme');
+				redirectexit('action=profile;u=' . $u . ';area=theme');
 			}
 		}
 
+		$u = $this->_req->getQuery('u', 'intval');
+
 		// Figure out who the member of the minute is, and what theme they've chosen.
-		if (!isset($_REQUEST['u']) || !allowedTo('admin_forum'))
+		if (!isset($u) || !allowedTo('admin_forum'))
 		{
 			$context['current_member'] = $user_info['id'];
 			$current_theme = $user_info['theme'];
 		}
 		// Everyone can't chose just one.
-		elseif ($_REQUEST['u'] == '0')
+		elseif ($u === 0)
 		{
 			$context['current_member'] = 0;
 			$current_theme = 0;
 		}
 		// Guests and such...
-		elseif ($_REQUEST['u'] == '-1')
+		elseif ($u === -1)
 		{
 			$context['current_member'] = -1;
 			$current_theme = $modSettings['theme_guests'];
@@ -1021,7 +1040,7 @@ class ManageThemes_Controller extends Action_Controller
 		// Someones else :P.
 		else
 		{
-			$context['current_member'] = (int) $_REQUEST['u'];
+			$context['current_member'] = $u;
 
 			require_once(SUBSDIR . '/Members.subs.php');
 			$member = getBasicMemberData($context['current_member']);
@@ -1033,7 +1052,7 @@ class ManageThemes_Controller extends Action_Controller
 		list ($context['available_themes'], $guest_theme) = availableThemes($current_theme, $context['current_member']);
 
 		// As long as we're not doing the default theme...
-		if (!isset($_REQUEST['u']) || $_REQUEST['u'] >= 0)
+		if (!isset($u) || $u >= 0)
 		{
 			if ($guest_theme != 0)
 				$context['available_themes'][0] = $context['available_themes'][$guest_theme];
@@ -1073,127 +1092,55 @@ class ManageThemes_Controller extends Action_Controller
 		loadTemplate('ManageThemes');
 
 		// Passed an ID, then the install is complete, lets redirect and show them
-		if (isset($_GET['theme_id']))
+		if (isset($this->_req->query->theme_id))
 		{
-			$_GET['theme_id'] = (int) $_GET['theme_id'];
+			$this->_req->query->theme_id = (int) $this->_req->query->theme_id;
 
 			$context['sub_template'] = 'installed';
 			$context['page_title'] = $txt['theme_installed'];
 			$context['installed_theme'] = array(
-				'id' => $_GET['theme_id'],
-				'name' => getThemeName($_GET['theme_id']),
+				'id' => $this->_req->query->theme_id,
+				'name' => getThemeName($this->_req->query->theme_id),
 			);
 
 			return;
 		}
 
 		// How are we going to install this theme, from a dir, zip, copy of default?
-		if ((!empty($_FILES['theme_gz']) && (!isset($_FILES['theme_gz']['error']) || $_FILES['theme_gz']['error'] != 4)) || !empty($_REQUEST['theme_gz']))
+		if ((!empty($_FILES['theme_gz']) && (!isset($_FILES['theme_gz']['error']) || $_FILES['theme_gz']['error'] != 4)) || !empty($this->_req->query->theme_gz))
 			$method = 'upload';
-		elseif (isset($_REQUEST['theme_dir']) && rtrim(realpath($_REQUEST['theme_dir']), '/\\') != realpath(BOARDDIR . '/themes') && file_exists($_REQUEST['theme_dir']))
+		elseif (isset($this->_req->query->theme_dir) && rtrim(realpath($this->_req->query->theme_dir), '/\\') != realpath(BOARDDIR . '/themes') && file_exists($this->_req->query->theme_dir))
 			$method = 'path';
 		else
 			$method = 'copy';
 
 		// Copy the default theme?
-		if (!empty($_REQUEST['copy']) && $method == 'copy')
-		{
-			// Hopefully the themes directory is writable, or we might have a problem.
-			if (!is_writable(BOARDDIR . '/themes'))
-				Errors::fatal_lang_error('theme_install_write_error', 'critical');
-
-			// Make the new directory, standard characters only
-			$theme_dir = BOARDDIR . '/themes/' . preg_replace('~[^A-Za-z0-9_\- ]~', '', $_REQUEST['copy']);
-			umask(0);
-			mkdir($theme_dir, 0777);
-
-			// Get some more time if we can
-			setTimeLimit(600);
-
-			// Create the subdirectories for css, javascript and font files.
-			mkdir($theme_dir . '/css', 0777);
-			mkdir($theme_dir . '/scripts', 0777);
-			mkdir($theme_dir . '/webfonts', 0777);
-
-			// Copy over the default non-theme files.
-			$to_copy = array('/index.php', '/index.template.php', '/scripts/theme.js');
-			foreach ($to_copy as $file)
-			{
-				copy($settings['default_theme_dir'] . $file, $theme_dir . $file);
-				@chmod($theme_dir . $file, 0777);
-			}
-
-			// And now the entire css, images and webfonts directories!
-			copytree($settings['default_theme_dir'] . '/css', $theme_dir . '/css');
-			copytree($settings['default_theme_dir'] . '/images', $theme_dir . '/images');
-			copytree($settings['default_theme_dir'] . '/webfonts', $theme_dir . '/webfonts');
-			package_flush_cache();
-
-			$theme_name = $_REQUEST['copy'];
-			$images_url = $boardurl . '/themes/' . basename($theme_dir) . '/images';
-			$theme_dir = realpath($theme_dir);
-
-			// Lets get some data for the new theme (default theme (1), default settings (0)).
-			$theme_values = loadThemeOptionsInto(1, 0, array(), array('theme_templates', 'theme_layers'));
-
-			// Lets add a theme_info.xml to this theme.
-			write_theme_info($_REQUEST['copy'], $modSettings['elkVersion'], $theme_dir, $theme_values);
-		}
+		if (!empty($this->_req->post->copy) && $method == 'copy')
+			$this->copyDefault();
 		// Install from another directory
-		elseif (isset($_REQUEST['theme_dir']) && $method == 'path')
-		{
-			if (!is_dir($_REQUEST['theme_dir']) || !file_exists($_REQUEST['theme_dir'] . '/theme_info.xml'))
-				Errors::fatal_lang_error('theme_install_error', false);
-
-			$theme_name = basename($_REQUEST['theme_dir']);
-			$theme_dir = $_REQUEST['theme_dir'];
-		}
+		elseif (isset($this->_req->post->theme_dir) && $method == 'path')
+			$this->installFromDir();
 		// Uploaded a zip file to install from
 		elseif ($method == 'upload')
-		{
-			// Hopefully the themes directory is writable, or we might have a problem.
-			if (!is_writable(BOARDDIR . '/themes'))
-				Errors::fatal_lang_error('theme_install_write_error', 'critical');
-
-			// This happens when the admin session is gone and the user has to login again
-			if (empty($_FILES['theme_gz']) && empty($_REQUEST['theme_gz']))
-				redirectexit('action=admin;area=theme;sa=admin;' . $context['session_var'] . '=' . $context['session_id']);
-
-			// Set the default settings...
-			$theme_name = strtok(basename(isset($_FILES['theme_gz']) ? $_FILES['theme_gz']['name'] : $_REQUEST['theme_gz']), '.');
-			$theme_name = preg_replace(array('/\s/', '/\.[\.]+/', '/[^\w_\.\-]/'), array('_', '.', ''), $theme_name);
-			$theme_dir = BOARDDIR . '/themes/' . $theme_name;
-
-			if (isset($_FILES['theme_gz']) && is_uploaded_file($_FILES['theme_gz']['tmp_name']) && (ini_get('open_basedir') != '' || file_exists($_FILES['theme_gz']['tmp_name'])))
-				read_tgz_file($_FILES['theme_gz']['tmp_name'], BOARDDIR . '/themes/' . $theme_name, false, true);
-			elseif (isset($_REQUEST['theme_gz']))
-			{
-				if (!isAuthorizedServer($_REQUEST['theme_gz']))
-					Errors::fatal_lang_error('not_valid_server');
-
-				read_tgz_file($_REQUEST['theme_gz'], BOARDDIR . '/themes/' . $theme_name, false, true);
-			}
-			else
-				redirectexit('action=admin;area=theme;sa=admin;' . $context['session_var'] . '=' . $context['session_id']);
-		}
+			$this->InstallFromZip();
 		else
 			Errors::fatal_lang_error('theme_install_general', false);
 
 		// Something go wrong?
-		if ($theme_dir != '' && basename($theme_dir) != 'themes')
+		if ($this->theme_dir != '' && basename($this->theme_dir) != 'themes')
 		{
 			// Defaults.
 			$install_info = array(
-				'theme_url' => $boardurl . '/themes/' . basename($theme_dir),
-				'images_url' => isset($images_url) ? $images_url : $boardurl . '/themes/' . basename($theme_dir) . '/images',
-				'theme_dir' => $theme_dir,
-				'name' => $theme_name
+				'theme_url' => $boardurl . '/themes/' . basename($this->theme_dir),
+				'images_url' => isset($this->images_url) ? $this->images_url : $boardurl . '/themes/' . basename($this->theme_dir) . '/images',
+				'theme_dir' => $this->theme_dir,
+				'name' => $this->theme_name
 			);
 			$explicit_images = false;
 
-			if (file_exists($theme_dir . '/theme_info.xml'))
+			if (file_exists($this->theme_dir . '/theme_info.xml'))
 			{
-				$theme_info = file_get_contents($theme_dir . '/theme_info.xml');
+				$theme_info = file_get_contents($this->theme_dir . '/theme_info.xml');
 
 				// Parse theme-info.xml into an Xml_Array.
 				$theme_info_xml = new Xml_Array($theme_info);
@@ -1270,6 +1217,100 @@ class ManageThemes_Controller extends Action_Controller
 	}
 
 	/**
+	 * Install a new theme from an uploaded zip archive
+	 */
+	public function installFromZip()
+	{
+		// Hopefully the themes directory is writable, or we might have a problem.
+		if (!is_writable(BOARDDIR . '/themes'))
+			Errors::fatal_lang_error('theme_install_write_error', 'critical');
+
+		// This happens when the admin session is gone and the user has to login again
+		if (empty($_FILES['theme_gz']) && empty($this->_req->post->theme_gz))
+			redirectexit('action=admin;area=theme;sa=admin;' . $context['session_var'] . '=' . $context['session_id']);
+
+		// Set the default settings...
+		$this->theme_name = strtok(basename(isset($_FILES['theme_gz']) ? $_FILES['theme_gz']['name'] : $this->_req->post->theme_gz), '.');
+		$this->theme_name = preg_replace(array('/\s/', '/\.[\.]+/', '/[^\w_\.\-]/'), array('_', '.', ''), $this->theme_name);
+		$this->theme_dir = BOARDDIR . '/themes/' . $this->theme_name;
+
+		if (isset($_FILES['theme_gz']) && is_uploaded_file($_FILES['theme_gz']['tmp_name']) && (ini_get('open_basedir') != '' || file_exists($_FILES['theme_gz']['tmp_name'])))
+			read_tgz_file($_FILES['theme_gz']['tmp_name'], BOARDDIR . '/themes/' . $this->theme_name, false, true);
+		elseif (isset($this->_req->post->theme_gz))
+		{
+			if (!isAuthorizedServer($this->_req->post->theme_gz))
+				Errors::fatal_lang_error('not_valid_server');
+
+			read_tgz_file($this->_req->post->theme_gz, BOARDDIR . '/themes/' . $this->theme_name, false, true);
+		}
+		else
+			redirectexit('action=admin;area=theme;sa=admin;' . $context['session_var'] . '=' . $context['session_id']);
+	}
+
+	/**
+	 * Install a theme from a directory on the server
+	 *
+	 * - Expects the directroy is properly loaded with theme files
+	 */
+	public function installFromDir()
+	{
+		if (!is_dir($this->_req->post->theme_dir) || !file_exists($this->_req->post->theme_dir . '/theme_info.xml'))
+			Errors::fatal_lang_error('theme_install_error', false);
+
+		$this->theme_name = basename($this->_req->post->theme_dir);
+		$this->theme_dir = $this->_req->post->theme_dir;
+	}
+
+	/**
+	 * Make a copy of the default theme in a new directory
+	 */
+	public function copyDefault()
+	{
+		global $boardurl, $modSettings;
+
+		// Hopefully the themes directory is writable, or we might have a problem.
+		if (!is_writable(BOARDDIR . '/themes'))
+			Errors::fatal_lang_error('theme_install_write_error', 'critical');
+
+		// Make the new directory, standard characters only
+		$this->theme_dir = BOARDDIR . '/themes/' . preg_replace('~[^A-Za-z0-9_\- ]~', '', $this->_req->post->copy);
+		umask(0);
+		mkdir($this->theme_dir, 0777);
+
+		// Get some more time if we can
+		setTimeLimit(600);
+
+		// Create the subdirectories for css, javascript and font files.
+		mkdir($this->theme_dir . '/css', 0777);
+		mkdir($this->theme_dir . '/scripts', 0777);
+		mkdir($this->theme_dir . '/webfonts', 0777);
+
+		// Copy over the default non-theme files.
+		$to_copy = array('/index.php', '/index.template.php', '/scripts/theme.js');
+		foreach ($to_copy as $file)
+		{
+			copy($settings['default_theme_dir'] . $file, $this->theme_dir . $file);
+			@chmod($this->theme_dir . $file, 0777);
+		}
+
+		// And now the entire css, images and webfonts directories!
+		copytree($settings['default_theme_dir'] . '/css', $this->theme_dir . '/css');
+		copytree($settings['default_theme_dir'] . '/images', $this->theme_dir . '/images');
+		copytree($settings['default_theme_dir'] . '/webfonts', $this->theme_dir . '/webfonts');
+		package_flush_cache();
+
+		$this->theme_name = $this->_req->post->copy;
+		$this->images_url = $boardurl . '/themes/' . basename($this->theme_dir) . '/images';
+		$this->theme_dir = realpath($this->theme_dir);
+
+		// Lets get some data for the new theme (default theme (1), default settings (0)).
+		$theme_values = loadThemeOptionsInto(1, 0, array(), array('theme_templates', 'theme_layers'));
+
+		// Lets add a theme_info.xml to this theme.
+		write_theme_info($this->_req->query->copy, $modSettings['elkVersion'], $this->theme_dir, $theme_values);
+	}
+
+	/**
 	 * Set a theme option via javascript.
 	 *
 	 * What it does:
@@ -1289,7 +1330,7 @@ class ManageThemes_Controller extends Action_Controller
 		checkSession('get');
 
 		// This good-for-nothing pixel is being used to keep the session alive.
-		if (empty($_GET['var']) || !isset($_GET['val']))
+		if (empty($this->_req->query->var) || !isset($this->_req->query->val))
 			redirectexit($settings['images_url'] . '/blank.png');
 
 		// Sorry, guests can't go any further than this..
@@ -1317,47 +1358,47 @@ class ManageThemes_Controller extends Action_Controller
 		);
 
 		// Can't change reserved vars.
-		if (in_array(strtolower($_GET['var']), $reservedVars))
+		if (in_array(strtolower($this->_req->query->var), $reservedVars))
 			redirectexit($settings['images_url'] . '/blank.png');
 
 		// Use a specific theme?
-		if (isset($_GET['th']) || isset($_GET['id']))
+		if (isset($this->_req->query->th) || isset($this->_req->query->id))
 		{
 			// Invalidate the current themes cache too.
 			if (!empty($modSettings['cache_enable']) && $modSettings['cache_enable'] >= 2)
 				cache_put_data('theme_settings-' . $settings['theme_id'] . ':' . $user_info['id'], null, 60);
 
-			$settings['theme_id'] = isset($_GET['th']) ? (int) $_GET['th'] : (int) $_GET['id'];
+			$settings['theme_id'] = $this->_req->getQuery('th', 'intval', $this->_req->getQuery('id', 'intval'));
 		}
 
 		// If this is the admin preferences the passed value will just be an element of it.
-		if ($_GET['var'] == 'admin_preferences')
+		if ($this->_req->query->var == 'admin_preferences')
 		{
 			$options['admin_preferences'] = !empty($options['admin_preferences']) ? unserialize($options['admin_preferences']) : array();
 
 			// New thingy...
-			if (isset($_GET['admin_key']) && strlen($_GET['admin_key']) < 5)
-				$options['admin_preferences'][$_GET['admin_key']] = $_GET['val'];
+			if (isset($this->_req->query->admin_key) && strlen($this->_req->query->admin_key) < 5)
+				$options['admin_preferences'][$this->_req->query->admin_key] = $this->_req->query->val;
 
 			// Change the value to be something nice,
-			$_GET['val'] = serialize($options['admin_preferences']);
+			$this->_req->query->val = serialize($options['admin_preferences']);
 		}
 		// If this is the window min/max settings, the passed window name will just be an element of it.
-		elseif ($_GET['var'] == 'minmax_preferences')
+		elseif ($this->_req->query->var == 'minmax_preferences')
 		{
 			$options['minmax_preferences'] = !empty($options['minmax_preferences']) ? unserialize($options['minmax_preferences']) : array();
 
 			// New value for them
-			if (isset($_GET['minmax_key']) && strlen($_GET['minmax_key']) < 10)
-				$options['minmax_preferences'][$_GET['minmax_key']] = $_GET['val'];
+			if (isset($this->_req->query->minmax_key) && strlen($this->_req->query->minmax_key) < 10)
+				$options['minmax_preferences'][$this->_req->query->minmax_key] = $this->_req->query->val;
 
 			// Change the value to be something nice,
-			$_GET['val'] = serialize($options['minmax_preferences']);
+			$this->_req->query->val = serialize($options['minmax_preferences']);
 		}
 
 		// Update the option.
 		require_once(SUBSDIR . '/Themes.subs.php');
-		updateThemeOptions(array($settings['theme_id'], $user_info['id'], $_GET['var'], is_array($_GET['val']) ? implode(',', $_GET['val']) : $_GET['val']));
+		updateThemeOptions(array($settings['theme_id'], $user_info['id'], $this->_req->query->var, is_array($this->_req->query->val) ? implode(',', $this->_req->query->val) : $this->_req->query->val));
 
 		if (!empty($modSettings['cache_enable']) && $modSettings['cache_enable'] >= 2)
 			cache_put_data('theme_settings-' . $settings['theme_id'] . ':' . $user_info['id'], null, 60);
@@ -1387,14 +1428,13 @@ class ManageThemes_Controller extends Action_Controller
 		// We'll work hard with them themes!
 		require_once(SUBSDIR . '/Themes.subs.php');
 
-		$selectedTheme = isset($_GET['th']) ? (int) $_GET['th'] : (isset($_GET['id']) ? (int) $_GET['id'] : 0);
+		$selectedTheme = $this->_req->getQuery('th', 'intval', $this->_req->getQuery('id', 'intval', 0));
 
 		// Unfortunately we cannot edit an unkwown theme.. redirect.
 		if (empty($selectedTheme))
 			redirectexit('action=admin;area=theme;sa=themelist');
-
 		// You're browsing around, aren't you
-		elseif (!isset($_REQUEST['filename']))
+		elseif (!isset($this->_req->query->filename) && !isset($this->_req->post->save))
 			redirectexit('action=admin;area=theme;sa=browse;th=' . $selectedTheme);
 
 		// We don't have errors. Yet.
@@ -1403,12 +1443,12 @@ class ManageThemes_Controller extends Action_Controller
 		// We're editing a theme file.
 		// Get the directory of the theme we are editing.
 		$context['theme_id'] = $selectedTheme;
-		$theme_dir = themeDirectory($context['theme_id']);
+		$this->theme_dir = themeDirectory($context['theme_id']);
 
-		$this->prepareThemeEditContext($theme_dir);
+		$this->prepareThemeEditContext();
 
 		// Saving?
-		if (isset($_POST['save']))
+		if (isset($this->_req->post->save))
 		{
 			$this->_action_edit_submit();
 
@@ -1419,26 +1459,24 @@ class ManageThemes_Controller extends Action_Controller
 		// We're editing .css, .template.php, .{language}.php or others.
 		// Note: we're here sending $theme_dir as parameter to action_()
 		// controller functions, which isn't cool. To be refactored.
-		if (substr($_REQUEST['filename'], -4) == '.css')
-			$this->_action_edit_style($theme_dir);
-		elseif (substr($_REQUEST['filename'], -13) == '.template.php')
-			$this->_action_edit_template($theme_dir);
+		if (substr($this->_req->query->filename, -4) == '.css')
+			$this->_action_edit_style();
+		elseif (substr($this->_req->query->filename, -13) == '.template.php')
+			$this->_action_edit_template();
 		else
-			$this->_action_edit_file($theme_dir);
+			$this->_action_edit_file();
 
 		// Create a special token to allow editing of multiple files.
-		createToken('admin-te-' . md5($selectedTheme . '-' . $_REQUEST['filename']));
+		createToken('admin-te-' . md5($selectedTheme . '-' . $this->_req->query->filename));
 	}
 
 	/**
-	 * Displays for edition in admin panel a css file.
+	 * Displays for editing in admin panel a css file.
 	 *
 	 * This function is forwarded to, from
 	 * ?action=admin;area=theme;sa=edit
-	 *
-	 * @param string $theme_dir absolute path of the selected theme directory
 	 */
-	private function _action_edit_style($theme_dir)
+	private function _action_edit_style()
 	{
 		global $context, $settings;
 
@@ -1452,7 +1490,7 @@ class ManageThemes_Controller extends Action_Controller
 
 		// pick the template and send it the file
 		$context['sub_template'] = 'edit_style';
-		$context['entire_file'] = htmlspecialchars(strtr(file_get_contents($theme_dir . '/' . $_REQUEST['filename']), array("\t" => '   ')), ENT_COMPAT, 'UTF-8');
+		$context['entire_file'] = htmlspecialchars(strtr(file_get_contents($this->theme_dir . '/' . $this->_req->query->filename), array("\t" => '   ')), ENT_COMPAT, 'UTF-8');
 	}
 
 	/**
@@ -1460,10 +1498,8 @@ class ManageThemes_Controller extends Action_Controller
 	 *
 	 * This function is forwarded to, from
 	 * ?action=admin;area=theme;sa=edit
-	 *
-	 * @param string $theme_dir absolute path of the selected theme directory
 	 */
-	private function _action_edit_template($theme_dir)
+	private function _action_edit_template()
 	{
 		global $context;
 
@@ -1471,7 +1507,7 @@ class ManageThemes_Controller extends Action_Controller
 		$context['sub_template'] = 'edit_template';
 
 		// Retrieve the contents of the file
-		$file_data = file($theme_dir . '/' . $_REQUEST['filename']);
+		$file_data = file($this->theme_dir . '/' . $this->_req->query->filename);
 
 		// For a PHP template file, we display each function in separate boxes.
 		$j = 0;
@@ -1504,16 +1540,14 @@ class ManageThemes_Controller extends Action_Controller
 	 *
 	 * This function is forwarded to, from
 	 * ?action=admin;area=theme;sa=edit
-	 *
-	 * @param string $theme_dir absolute path of the selected theme directory
 	 */
-	private function _action_edit_file($theme_dir)
+	private function _action_edit_file()
 	{
 		global $context;
 
 		// Simply set the template and the file contents.
 		$context['sub_template'] = 'edit_file';
-		$context['entire_file'] = htmlspecialchars(strtr(file_get_contents($theme_dir . '/' . $_REQUEST['filename']), array("\t" => '   ')), ENT_COMPAT, 'UTF-8');
+		$context['entire_file'] = htmlspecialchars(strtr(file_get_contents($this->theme_dir . '/' . $this->_req->query->filename), array("\t" => '   ')), ENT_COMPAT, 'UTF-8');
 	}
 
 	/**
@@ -1527,7 +1561,7 @@ class ManageThemes_Controller extends Action_Controller
 	{
 		global $context, $settings, $user_info;
 
-		$selectedTheme = isset($_GET['th']) ? (int) $_GET['th'] : (isset($_GET['id']) ? (int) $_GET['id'] : 0);
+		$selectedTheme = $this->_req->getQuery('th', 'intval', $this->_req->getQuery('id', 'intval', 0));
 		if (empty($selectedTheme))
 		{
 			// This should never be happening. Never I say. But... in case it does :P
@@ -1535,7 +1569,7 @@ class ManageThemes_Controller extends Action_Controller
 		}
 
 		$theme_dir = themeDirectory($context['theme_id']);
-		$file = isset($_POST['entire_file']) ? $_POST['entire_file'] : '';
+		$file = isset($this->_req->post->entire_file) ? $this->_req->post->entire_file : '';
 
 		// You did submit *something*, didn't you?
 		if (empty($file))
@@ -1546,12 +1580,12 @@ class ManageThemes_Controller extends Action_Controller
 
 		// Checking PHP syntax on css files is not a most constructive use of processing power :P
 		// We need to know what kind of file we have
-		$is_php = substr($_REQUEST['filename'], -4) == '.php';
-		$is_template = substr($_REQUEST['filename'], -13) == '.template.php';
-		$is_css = substr($_REQUEST['filename'], -4) == '.css';
+		$is_php = substr($this->_req->post->filename, -4) == '.php';
+		$is_template = substr($this->_req->post->filename, -13) == '.template.php';
+		$is_css = substr($this->_req->post->filename, -4) == '.css';
 
 		// Check you up
-		if (checkSession('post', '', false) == '' && validateToken('admin-te-' . md5($selectedTheme . '-' . $_REQUEST['filename']), 'post', false) == true)
+		if (checkSession('post', '', false) == '' && validateToken('admin-te-' . md5($selectedTheme . '-' . $this->_req->post->filename), 'post', false) == true)
 		{
 			// Consolidate the format in which we received the file contents
 			if (is_array($file))
@@ -1584,7 +1618,7 @@ class ManageThemes_Controller extends Action_Controller
 						$theme_info = getBasicThemeInfos($context['theme_id']);
 						emailAdmins('editing_theme', array(
 							'EDIT_REALNAME' => $user_info['name'],
-							'FILE_EDITED' => $_REQUEST['filename'],
+							'FILE_EDITED' => $this->_req->post->filename,
 							'THEME_NAME' => $theme_info[$context['theme_id']],
 						));
 					}
@@ -1604,12 +1638,12 @@ class ManageThemes_Controller extends Action_Controller
 			if (empty($errors))
 			{
 				// Try to save the new file contents
-				$fp = fopen($theme_dir . '/' . $_REQUEST['filename'], 'w');
+				$fp = fopen($theme_dir . '/' . $this->_req->post->filename, 'w');
 				fwrite($fp, $entire_file);
 				fclose($fp);
 
 				// We're done here.
-				redirectexit('action=admin;area=theme;th=' . $selectedTheme . ';' . $context['session_var'] . '=' . $context['session_id'] . ';sa=browse;directory=' . dirname($_REQUEST['filename']));
+				redirectexit('action=admin;area=theme;th=' . $selectedTheme . ';' . $context['session_var'] . '=' . $context['session_id'] . ';sa=browse;directory=' . dirname($this->_req->post->filename));
 			}
 			// I can't let you off the hook yet: syntax errors are a nasty beast.
 			else
@@ -1638,7 +1672,7 @@ class ManageThemes_Controller extends Action_Controller
 				}
 
 				// Re-create token for another try
-				createToken('admin-te-' . md5($selectedTheme . '-' . $_REQUEST['filename']));
+				createToken('admin-te-' . md5($selectedTheme . '-' . $this->_req->post->filename));
 
 				return;
 			}
@@ -1657,7 +1691,7 @@ class ManageThemes_Controller extends Action_Controller
 			else
 				$context['entire_file'] = htmlspecialchars($file, ENT_COMPAT, 'UTF-8');
 
-			$context['edit_filename'] = htmlspecialchars($_POST['filename'], ENT_COMPAT, 'UTF-8');
+			$context['edit_filename'] = htmlspecialchars($this->_req->post->filename, ENT_COMPAT, 'UTF-8');
 
 			// Choose sub-template
 			if ($is_template)
@@ -1677,7 +1711,7 @@ class ManageThemes_Controller extends Action_Controller
 				$context['sub_template'] = 'edit_file';
 
 			// Re-create the token so that it can be used
-			createToken('admin-te-' . md5($selectedTheme . '-' . $_REQUEST['filename']));
+			createToken('admin-te-' . md5($selectedTheme . '-' . $this->_req->post->filename));
 
 			return;
 		}
@@ -1700,13 +1734,12 @@ class ManageThemes_Controller extends Action_Controller
 		// We'll work hard with them themes!
 		require_once(SUBSDIR . '/Themes.subs.php');
 
-		$selectedTheme = isset($_GET['th']) ? (int) $_GET['th'] : (isset($_GET['id']) ? (int) $_GET['id'] : 0);
-
+		$selectedTheme = $this->_req->getQuery('th', 'intval', $this->_req->getQuery('id', 'intval', 0));
 		if (empty($selectedTheme))
 			redirectexit('action=admin;area=theme;sa=themelist');
 
 		// Get first the directory of the theme we are editing.
-		$context['theme_id'] = isset($_GET['th']) ? (int) $_GET['th'] : (isset($_GET['id']) ? (int) $_GET['id'] : 0);
+		$context['theme_id'] = isset($this->_req->query->th) ? (int) $this->_req->query->th : (isset($this->_req->query->id) ? (int) $this->_req->query->id : 0);
 		$theme_dir = themeDirectory($context['theme_id']);
 
 		// Eh? not trying to sneak a peek outside the theme directory are we
@@ -1714,25 +1747,25 @@ class ManageThemes_Controller extends Action_Controller
 			Errors::fatal_lang_error('theme_edit_missing', false);
 
 		// Now, where exactly are you?
-		if (isset($_GET['directory']))
+		if (isset($this->_req->query->directory))
 		{
-			if (substr($_GET['directory'], 0, 1) === '.')
-				$_GET['directory'] = '';
+			if (substr($this->_req->query->directory, 0, 1) === '.')
+				$this->_req->query->directory = '';
 			else
 			{
-				$_GET['directory'] = preg_replace(array('~^[\./\\:\0\n\r]+~', '~[\\\\]~', '~/[\./]+~'), array('', '/', '/'), $_GET['directory']);
+				$this->_req->query->directory = preg_replace(array('~^[\./\\:\0\n\r]+~', '~[\\\\]~', '~/[\./]+~'), array('', '/', '/'), $this->_req->query->directory);
 
-				$temp = realpath($theme_dir . '/' . $_GET['directory']);
+				$temp = realpath($theme_dir . '/' . $this->_req->query->directory);
 				if (empty($temp) || substr($temp, 0, strlen(realpath($theme_dir))) != realpath($theme_dir))
-					$_GET['directory'] = '';
+					$this->_req->query->directory = '';
 			}
 		}
 
-		if (isset($_GET['directory']) && $_GET['directory'] != '')
+		if (isset($this->_req->query->directory) && $this->_req->query->directory != '')
 		{
-			$context['theme_files'] = get_file_listing($theme_dir . '/' . $_GET['directory'], $_GET['directory'] . '/');
+			$context['theme_files'] = get_file_listing($theme_dir . '/' . $this->_req->query->directory, $this->_req->query->directory . '/');
 
-			$temp = dirname($_GET['directory']);
+			$temp = dirname($this->_req->query->directory);
 			array_unshift($context['theme_files'], array(
 				'filename' => $temp == '.' || $temp == '' ? '/ (..)' : $temp . ' (..)',
 				'is_writable' => is_writable($theme_dir . '/' . $temp),
@@ -1816,36 +1849,36 @@ class ManageThemes_Controller extends Action_Controller
 
 		$context[$context['admin_menu_name']]['current_subsection'] = 'edit';
 
-		$context['theme_id'] = isset($_GET['th']) ? (int) $_GET['th'] : (int) $_GET['id'];
+		$context['theme_id'] = isset($this->_req->query->th) ? (int) $this->_req->query->th : (int) $this->_req->query->id;
 
 		$theme_dirs = array();
 		$theme_dirs = loadThemeOptionsInto($context['theme_id'], null, $theme_dirs, array('base_theme_dir', 'theme_dir'));
 
-		if (isset($_REQUEST['template']) && preg_match('~[\./\\\\:\0]~', $_REQUEST['template']) == 0)
+		if (isset($this->_req->query->template) && preg_match('~[\./\\\\:\0]~', $this->_req->query->template) == 0)
 		{
-			if (!empty($theme_dirs['base_theme_dir']) && file_exists($theme_dirs['base_theme_dir'] . '/' . $_REQUEST['template'] . '.template.php'))
-				$filename = $theme_dirs['base_theme_dir'] . '/' . $_REQUEST['template'] . '.template.php';
-			elseif (file_exists($settings['default_theme_dir'] . '/' . $_REQUEST['template'] . '.template.php'))
-				$filename = $settings['default_theme_dir'] . '/' . $_REQUEST['template'] . '.template.php';
+			if (!empty($theme_dirs['base_theme_dir']) && file_exists($theme_dirs['base_theme_dir'] . '/' . $this->_req->query->template . '.template.php'))
+				$filename = $theme_dirs['base_theme_dir'] . '/' . $this->_req->query->template . '.template.php';
+			elseif (file_exists($settings['default_theme_dir'] . '/' . $this->_req->query->template . '.template.php'))
+				$filename = $settings['default_theme_dir'] . '/' . $this->_req->query->template . '.template.php';
 			else
 				Errors::fatal_lang_error('no_access', false);
 
-			$fp = fopen($theme_dirs['theme_dir'] . '/' . $_REQUEST['template'] . '.template.php', 'w');
+			$fp = fopen($theme_dirs['theme_dir'] . '/' . $this->_req->query->template . '.template.php', 'w');
 			fwrite($fp, file_get_contents($filename));
 			fclose($fp);
 
 			redirectexit('action=admin;area=theme;th=' . $context['theme_id'] . ';' . $context['session_var'] . '=' . $context['session_id'] . ';sa=copy');
 		}
-		elseif (isset($_REQUEST['lang_file']) && preg_match('~^[^\./\\\\:\0]\.[^\./\\\\:\0]$~', $_REQUEST['lang_file']) != 0)
+		elseif (isset($this->_req->query->lang_file) && preg_match('~^[^\./\\\\:\0]\.[^\./\\\\:\0]$~', $this->_req->query->lang_file) != 0)
 		{
-			if (!empty($theme_dirs['base_theme_dir']) && file_exists($theme_dirs['base_theme_dir'] . '/languages/' . $_REQUEST['lang_file'] . '.php'))
-				$filename = $theme_dirs['base_theme_dir'] . '/languages/' . $_REQUEST['template'] . '.php';
-			elseif (file_exists($settings['default_theme_dir'] . '/languages/' . $_REQUEST['template'] . '.php'))
-				$filename = $settings['default_theme_dir'] . '/languages/' . $_REQUEST['template'] . '.php';
+			if (!empty($theme_dirs['base_theme_dir']) && file_exists($theme_dirs['base_theme_dir'] . '/languages/' . $this->_req->query->lang_file . '.php'))
+				$filename = $theme_dirs['base_theme_dir'] . '/languages/' . $this->_req->query->template . '.php';
+			elseif (file_exists($settings['default_theme_dir'] . '/languages/' . $this->_req->query->template . '.php'))
+				$filename = $settings['default_theme_dir'] . '/languages/' . $this->_req->query->template . '.php';
 			else
 				Errors::fatal_lang_error('no_access', false);
 
-			$fp = fopen($theme_dirs['theme_dir'] . '/languages/' . $_REQUEST['lang_file'] . '.php', 'w');
+			$fp = fopen($theme_dirs['theme_dir'] . '/languages/' . $this->_req->query->lang_file . '.php', 'w');
 			fwrite($fp, file_get_contents($filename));
 			fclose($fp);
 
@@ -1944,36 +1977,37 @@ class ManageThemes_Controller extends Action_Controller
 	/**
 	* This function makes necessary pre-checks and fills
 	* the contextual data as needed by theme editing functions.
-	*
-	* @param string $theme_dir absolute path of the selected theme directory
 	*/
-	private function prepareThemeEditContext($theme_dir)
+	private function prepareThemeEditContext()
 	{
 		global $context;
 
 		// Eh? not trying to sneak a peek outside the theme directory are we
-		if (!file_exists($theme_dir . '/index.template.php') && !file_exists($theme_dir . '/css/index.css'))
+		if (!file_exists($this->theme_dir . '/index.template.php') && !file_exists($this->theme_dir . '/css/index.css'))
 			Errors::fatal_lang_error('theme_edit_missing', false);
 
+		// Get the filename from the approriate spot
+		$filename = isset($this->_req->post->save) ? $this->_req->getPost('filename', 'strval', '') : $this->_req->getQuery('filename', 'strval', '');
+
 		// You're editing a file: we have extra-checks coming up first.
-		if (substr($_REQUEST['filename'], 0, 1) === '.')
-			$_REQUEST['filename'] = '';
+		if (substr($filename, 0, 1) === '.')
+			$filename = '';
 		else
 		{
-			$_REQUEST['filename'] = preg_replace(array('~^[\./\\:\0\n\r]+~', '~[\\\\]~', '~/[\./]+~'), array('', '/', '/'), $_REQUEST['filename']);
+			$filename = preg_replace(array('~^[\./\\:\0\n\r]+~', '~[\\\\]~', '~/[\./]+~'), array('', '/', '/'), $filename);
 
-			$temp = realpath($theme_dir . '/' . $_REQUEST['filename']);
-			if (empty($temp) || substr($temp, 0, strlen(realpath($theme_dir))) !== realpath($theme_dir))
-				$_REQUEST['filename'] = '';
+			$temp = realpath($this->theme_dir . '/' . $filename);
+			if (empty($temp) || substr($temp, 0, strlen(realpath($this->theme_dir))) !== realpath($this->theme_dir))
+				$filename = '';
 		}
 
 		// We shouldn't end up with no file
-		if (empty($_REQUEST['filename']))
+		if (empty($filename))
 			Errors::fatal_lang_error('theme_edit_missing', false);
 
 		// Initialize context
-		$context['allow_save'] = is_writable($theme_dir . '/' . $_REQUEST['filename']);
-		$context['allow_save_filename'] = strtr($theme_dir . '/' . $_REQUEST['filename'], array(BOARDDIR => '...'));
-		$context['edit_filename'] = htmlspecialchars($_REQUEST['filename'], ENT_COMPAT, 'UTF-8');
+		$context['allow_save'] = is_writable($this->theme_dir . '/' . $filename);
+		$context['allow_save_filename'] = strtr($this->theme_dir . '/' . $filename, array(BOARDDIR => '...'));
+		$context['edit_filename'] = htmlspecialchars($filename, ENT_COMPAT, 'UTF-8');
 	}
 }

--- a/sources/admin/ManageTopics.controller.php
+++ b/sources/admin/ManageTopics.controller.php
@@ -26,6 +26,20 @@ class ManageTopics_Controller extends Action_Controller
 	protected $_topicSettings;
 
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Check permissions and forward to the right method.
 	 *
 	 * @see Action_Controller::action_index()
@@ -77,7 +91,7 @@ class ManageTopics_Controller extends Action_Controller
 		$context['sub_template'] = 'show_settings';
 
 		// Are we saving them - are we??
-		if (isset($_GET['save']))
+		if (isset($this->_req->query->save))
 		{
 			// Security checks
 			checkSession();
@@ -86,7 +100,7 @@ class ManageTopics_Controller extends Action_Controller
 			call_integration_hook('integrate_save_topic_settings');
 
 			// Save the result!
-			Settings_Form::save_db($config_vars);
+			Settings_Form::save_db($config_vars, $this->_req->post);
 
 			// We're done here, pal.
 			redirectexit('action=admin;area=postsettings;sa=topics');

--- a/sources/admin/Modlog.controller.php
+++ b/sources/admin/Modlog.controller.php
@@ -130,7 +130,7 @@ class Modlog_Controller extends Action_Controller
 			$search_params_string = $search_params['string'];
 
 		if (isset($this->_req->post->search_type) || empty($search_params['type']) || !isset($searchTypes[$search_params['type']]))
-			$search_params_type = isset($this->_req->post->search_type) && isset($searchTypes[$this->_req->post->search_type]) ? $this->_req->REQUEST->search_type : $context['order'];
+			$search_params_type = isset($this->_req->post->search_type) && isset($searchTypes[$this->_req->post->search_type]) ? $this->_req->query->search_type : $context['order'];
 		else
 			$search_params_type = $search_params['type'];
 

--- a/sources/admin/Modlog.controller.php
+++ b/sources/admin/Modlog.controller.php
@@ -28,6 +28,20 @@ if (!defined('ELK'))
 class Modlog_Controller extends Action_Controller
 {
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Default method for this controller.
 	 *
 	 * @see Action_Controller::action_index()
@@ -54,13 +68,14 @@ class Modlog_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Modlog.subs.php');
 
 		// Are we looking at the moderation log or the administration log.
-		$context['log_type'] = isset($_REQUEST['sa']) && $_REQUEST['sa'] == 'adminlog' ? 3 : 1;
+		$context['log_type'] = isset($this->_req->query->sa) && $this->_req->query->sa == 'adminlog' ? 3 : 1;
 
+		// Trying to view the admin log, lets check you can.
 		if ($context['log_type'] == 3)
 			isAllowedTo('admin_forum');
 
 		// These change dependant on whether we are viewing the moderation or admin log.
-		if ($context['log_type'] == 3 || $_REQUEST['action'] == 'admin')
+		if ($context['log_type'] == 3 || $this->_req->query->action == 'admin')
 			$context['url_start'] = '?action=admin;area=logs;sa=' . ($context['log_type'] == 3 ? 'adminlog' : 'modlog') . ';type=' . $context['log_type'];
 		else
 			$context['url_start'] = '?action=moderate;area=modlog;type=' . $context['log_type'];
@@ -78,23 +93,23 @@ class Modlog_Controller extends Action_Controller
 		$context['hoursdisable'] = 24;
 
 		// Handle deletion...
-		if (isset($_POST['removeall']) && $context['can_delete'])
+		if (isset($this->_req->post->removeall) && $context['can_delete'])
 		{
 			checkSession();
 			validateToken('mod-ml');
 			deleteLogAction($context['log_type'], $context['hoursdisable']);
 		}
-		elseif (!empty($_POST['remove']) && isset($_POST['delete']) && $context['can_delete'])
+		elseif (!empty($this->_req->post->remove) && isset($this->_req->post->delete) && $context['can_delete'])
 		{
 			checkSession();
 			validateToken('mod-ml');
-			deleteLogAction($context['log_type'], $context['hoursdisable'], $_POST['delete']);
+			deleteLogAction($context['log_type'], $context['hoursdisable'], $this->_req->post->delete);
 		}
 
 		// If we're coming from a search, get the variables.
-		if (!empty($_REQUEST['params']) && empty($_REQUEST['is_search']))
+		if (!empty($this->_req->post->params) && empty($this->_req->post->is_search))
 		{
-			$search_params = base64_decode(strtr($_REQUEST['params'], array(' ' => '+')));
+			$search_params = base64_decode(strtr($this->_req->post->params, array(' ' => '+')));
 			$search_params = @unserialize($search_params);
 		}
 
@@ -107,15 +122,15 @@ class Modlog_Controller extends Action_Controller
 		);
 
 		// Setup the allowed search
-		$context['order'] = isset($_REQUEST['sort']) && isset($searchTypes[$_REQUEST['sort']]) ? $_REQUEST['sort'] : 'member';
+		$context['order'] = isset($this->_req->query->sort) && isset($searchTypes[$this->_req->query->sort]) ? $this->_req->query->sort : 'member';
 
-		if (!isset($search_params['string']) || (!empty($_REQUEST['search']) && $search_params['string'] != $_REQUEST['search']))
-			$search_params_string = empty($_REQUEST['search']) ? '' : $_REQUEST['search'];
+		if (!isset($search_params['string']) || (!empty($this->_req->post->search) && $search_params['string'] != $this->_req->post->search))
+			$search_params_string = $this->_req->getPost('search', 'trim', '');
 		else
 			$search_params_string = $search_params['string'];
 
-		if (isset($_REQUEST['search_type']) || empty($search_params['type']) || !isset($searchTypes[$search_params['type']]))
-			$search_params_type = isset($_REQUEST['search_type']) && isset($searchTypes[$_REQUEST['search_type']]) ? $_REQUEST['search_type'] : $context['order'];
+		if (isset($this->_req->post->search_type) || empty($search_params['type']) || !isset($searchTypes[$search_params['type']]))
+			$search_params_type = isset($this->_req->post->search_type) && isset($searchTypes[$this->_req->post->search_type]) ? $this->_req->REQUEST->search_type : $context['order'];
 		else
 			$search_params_type = $search_params['type'];
 
@@ -159,7 +174,7 @@ class Modlog_Controller extends Action_Controller
 			'width' => '100%',
 			'items_per_page' => $context['displaypage'],
 			'no_items_label' => $txt['modlog_' . ($context['log_type'] == 3 ? 'admin_log_' : '') . 'no_entries_found'],
-			'base_href' => $scripturl . $context['url_start'] . (!empty($context['search_params']) ? ';params=' . $context['search_params'] : ''),
+			'base_href' => $scripturl . $context['url_start'],
 			'default_sort_col' => 'time',
 			'get_items' => array(
 				'function' => array($this, 'getModLogEntries'),

--- a/sources/admin/PackageServers.controller.php
+++ b/sources/admin/PackageServers.controller.php
@@ -36,14 +36,6 @@ class PackageServers_Controller extends Action_Controller
 	protected $_req;
 
 	/**
-	 * Pre Dispatch, called before other methods.  Loads HttpReq
-	 */
-	public function pre_dispatch()
-	{
-		$this->_req = HttpReq::instance();
-	}
-
-	/**
 	 * Called before all other methods when comming from the dispatcher or
 	 * action class.  Loads lanaguage and templates files so they are available
 	 * to the other methods.
@@ -55,6 +47,9 @@ class PackageServers_Controller extends Action_Controller
 
 		// Use the PackageServers template.
 		loadTemplate('PackageServers', 'admin');
+
+		// Load request interface
+		$this->_req = HttpReq::instance();
 	}
 
 	/**

--- a/sources/admin/Packages.controller.php
+++ b/sources/admin/Packages.controller.php
@@ -2145,8 +2145,7 @@ class Packages_Controller extends Action_Controller
 			unset($_SESSION['version_emulate']);
 		elseif (isset($this->_req->query->version_emulate))
 		{
-			if (($_GET['version_emulate'] === 0 || $_GET['version_emulate'] === FORUM_VERSION) && isset($_SESSION['version_emulate']))
-			if (($this->_req->query->version_emulate === 0 || $this->_req->query->version_emulate === $forum_version) && isset($_SESSION['version_emulate']))
+			if (($this->_req->query->version_emulate === 0 || $this->_req->query->version_emulate === FORUM_VERSION) && isset($this->_req->session->version_emulate))
 				unset($_SESSION['version_emulate']);
 			elseif ($this->_req->query->version_emulate !== 0)
 				$_SESSION['version_emulate'] = strtr($this->_req->query->version_emulate, array('-' => ' ', '+' => ' ', $the_brand . ' ' => ''));

--- a/sources/admin/Packages.controller.php
+++ b/sources/admin/Packages.controller.php
@@ -30,6 +30,20 @@ if (!defined('ELK'))
 class Packages_Controller extends Action_Controller
 {
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Entry point, the default method of this controller.
 	 *
 	 * @see Action_Controller::action_index()
@@ -121,13 +135,13 @@ class Packages_Controller extends Action_Controller
 		global $txt, $context, $scripturl, $settings;
 
 		// You have to specify a file!!
-		if (!isset($_REQUEST['package']) || trim($_REQUEST['package']) == '')
+		if (!isset($this->_req->query->package) || trim($this->_req->query->package) == '')
 			redirectexit('action=admin;area=packages');
 
-		$context['filename'] = preg_replace('~[\.]+~', '.', $_REQUEST['package']);
+		$context['filename'] = preg_replace('~[\.]+~', '.', $this->_req->query->package);
 
 		// Do we have an existing id, for uninstalls and the like.
-		$context['install_id'] = isset($_REQUEST['pid']) ? (int) $_REQUEST['pid'] : 0;
+		$context['install_id'] = $this->_req->getQuery('pid', 'intval', 0);
 
 		// These will be needed
 		require_once(SUBSDIR . '/Package.subs.php');
@@ -147,7 +161,7 @@ class Packages_Controller extends Action_Controller
 			if (!mktree(BOARDDIR . '/packages/temp', 0777))
 			{
 				deltree(BOARDDIR . '/packages/temp', false);
-				create_chmod_control(array(BOARDDIR . '/packages/temp/delme.tmp'), array('destination_url' => $scripturl . '?action=admin;area=packages;sa=' . $_REQUEST['sa'] . ';package=' . $context['filename'], 'crash_on_error' => true));
+				create_chmod_control(array(BOARDDIR . '/packages/temp/delme.tmp'), array('destination_url' => $scripturl . '?action=admin;area=packages;sa=' . $this->_req->query->sa . ';package=' . $context['filename'], 'crash_on_error' => true));
 
 				deltree(BOARDDIR . '/packages/temp', false);
 				if (!mktree(BOARDDIR . '/packages/temp', 0777))
@@ -156,7 +170,7 @@ class Packages_Controller extends Action_Controller
 		}
 
 		// Change our last link tree item for more information on this Packages area.
-		$context['uninstalling'] = $_REQUEST['sa'] === 'uninstall';
+		$context['uninstalling'] = $this->_req->query->sa === 'uninstall';
 		$context['linktree'][count($context['linktree']) - 1] = array(
 			'url' => $scripturl . '?action=admin;area=packages;sa=browse',
 			'name' => $context['uninstalling'] ? $txt['package_uninstall_actions'] : $txt['install_actions']
@@ -748,18 +762,18 @@ class Packages_Controller extends Action_Controller
 		checkSession();
 
 		// If there's no file, what are we installing?
-		if (!isset($_REQUEST['package']) || $_REQUEST['package'] == '')
+		if (!isset($this->_req->query->package) || $this->_req->query->package == '')
 			redirectexit('action=admin;area=packages');
-		$context['filename'] = $_REQUEST['package'];
+		$context['filename'] = $this->_req->query->package;
 
 		// If this is an uninstall, we'll have an id.
-		$context['install_id'] = isset($_REQUEST['pid']) ? (int) $_REQUEST['pid'] : 0;
+		$context['install_id'] = $this->_req->getQuery('pid', 'intval', 0);
 
 		require_once(SUBSDIR . '/Package.subs.php');
 		require_once(SUBSDIR . '/Themes.subs.php');
 
 		// @todo Perhaps do it in steps, if necessary?
-		$context['uninstalling'] = $_REQUEST['sa'] == 'uninstall2';
+		$context['uninstalling'] = $this->_req->query->sa === 'uninstall2';
 
 		// Set up the linktree for other.
 		$context['linktree'][count($context['linktree']) - 1] = array(
@@ -773,7 +787,7 @@ class Packages_Controller extends Action_Controller
 			Errors::fatal_lang_error('package_no_file', false);
 
 		// Load up the package FTP information?
-		create_chmod_control(array(), array('destination_url' => $scripturl . '?action=admin;area=packages;sa=' . $_REQUEST['sa'] . ';package=' . $_REQUEST['package']));
+		create_chmod_control(array(), array('destination_url' => $scripturl . '?action=admin;area=packages;sa=' . $this->_req->query->sa . ';package=' . $this->_req->query->package));
 
 		// Make sure temp directory exists and is empty!
 		if (file_exists(BOARDDIR . '/packages/temp'))
@@ -813,9 +827,9 @@ class Packages_Controller extends Action_Controller
 		// Are we installing this into any custom themes?
 		$custom_themes = array(1);
 		$known_themes = explode(',', $modSettings['knownThemes']);
-		if (!empty($_POST['custom_theme']))
+		if (!empty($this->_req->post->custom_theme))
 		{
-			foreach ($_POST['custom_theme'] as $tid)
+			foreach ($this->_req->post->custom_theme as $tid)
 				if (in_array($tid, $known_themes))
 					$custom_themes[] = (int) $tid;
 		}
@@ -830,12 +844,13 @@ class Packages_Controller extends Action_Controller
 			'require-dir' => array(),
 		);
 
-		if (!empty($_POST['theme_changes']))
+		if (!empty($this->_req->post->theme_changes))
 		{
-			foreach ($_POST['theme_changes'] as $change)
+			foreach ($this->_req->post->theme_changes as $change)
 			{
 				if (empty($change))
 					continue;
+
 				$theme_data = unserialize(base64_decode($change));
 				if (empty($theme_data['type']))
 					continue;
@@ -978,7 +993,7 @@ class Packages_Controller extends Action_Controller
 						add_integration_function($action['hook'], $action['function'], $action['include_file']);
 				}
 				// Only do the database changes on uninstall if requested.
-				elseif ($action['type'] == 'database' && !empty($action['filename']) && (!$context['uninstalling'] || !empty($_POST['do_db_changes'])))
+				elseif ($action['type'] === 'database' && !empty($action['filename']) && (!$context['uninstalling'] || !empty($this->_req->post->do_db_changes)))
 				{
 					// These can also be there for database changes.
 					global $txt, $modSettings, $context;
@@ -988,7 +1003,7 @@ class Packages_Controller extends Action_Controller
 						require(BOARDDIR . '/packages/temp/' . $context['base_path'] . $action['filename']);
 				}
 				// Handle a redirect...
-				elseif ($action['type'] == 'redirect' && !empty($action['redirect_url']))
+				elseif ($action['type'] === 'redirect' && !empty($action['redirect_url']))
 				{
 					$context['redirect_url'] = $action['redirect_url'];
 					$context['redirect_text'] = !empty($action['filename']) && file_exists(BOARDDIR . '/packages/temp/' . $context['base_path'] . $action['filename']) ? file_get_contents(BOARDDIR . '/packages/temp/' . $context['base_path'] . $action['filename']) : ($context['uninstalling'] ? $txt['package_uninstall_done'] : $txt['package_installed_done']);
@@ -1076,7 +1091,7 @@ class Packages_Controller extends Action_Controller
 		}
 
 		// If there's database changes - and they want them removed - let's do it last!
-		if (!empty($package_installed['db_changes']) && !empty($_POST['do_db_changes']))
+		if (!empty($package_installed['db_changes']) && !empty($this->_req->post->do_db_changes))
 		{
 			foreach ($package_installed['db_changes'] as $change)
 			{
@@ -1127,18 +1142,18 @@ class Packages_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Package.subs.php');
 
 		// No package?  Show him or her the door.
-		if (!isset($_REQUEST['package']) || $_REQUEST['package'] == '')
+		if (!isset($this->_req->query->package) || $this->_req->query->package == '')
 			redirectexit('action=admin;area=packages');
 
 		$context['linktree'][] = array(
-			'url' => $scripturl . '?action=admin;area=packages;sa=list;package=' . $_REQUEST['package'],
+			'url' => $scripturl . '?action=admin;area=packages;sa=list;package=' . $this->_req->query->package,
 			'name' => $txt['list_file']
 		);
 		$context['page_title'] .= ' - ' . $txt['list_file'];
 		$context['sub_template'] = 'list';
 
 		// The filename...
-		$context['filename'] = $_REQUEST['package'];
+		$context['filename'] = $this->_req->query->package;
 
 		// Let the unpacker do the work.
 		if (is_file(BOARDDIR . '/packages/' . $context['filename']))
@@ -1157,48 +1172,48 @@ class Packages_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Package.subs.php');
 
 		// No package?  Show him or her the door.
-		if (!isset($_REQUEST['package']) || $_REQUEST['package'] == '')
+		if (!isset($this->_req->query->package) || $this->_req->query->package == '')
 			redirectexit('action=admin;area=packages');
 
 		// No file?  Show him or her the door.
-		if (!isset($_REQUEST['file']) || $_REQUEST['file'] == '')
+		if (!isset($this->_req->query->file) || $this->_req->query->file == '')
 			redirectexit('action=admin;area=packages');
 
-		$_REQUEST['package'] = preg_replace('~[\.]+~', '.', strtr($_REQUEST['package'], array('/' => '_', '\\' => '_')));
-		$_REQUEST['file'] = preg_replace('~[\.]+~', '.', $_REQUEST['file']);
+		$this->_req->query->package = preg_replace('~[\.]+~', '.', strtr($this->_req->query->package, array('/' => '_', '\\' => '_')));
+		$this->_req->query->file = preg_replace('~[\.]+~', '.', $this->_req->query->file);
 
-		if (isset($_REQUEST['raw']))
+		if (isset($this->_req->query->raw))
 		{
-			if (is_file(BOARDDIR . '/packages/' . $_REQUEST['package']))
-				echo read_tgz_file(BOARDDIR . '/packages/' . $_REQUEST['package'], $_REQUEST['file'], true);
-			elseif (is_dir(BOARDDIR . '/packages/' . $_REQUEST['package']))
-				echo file_get_contents(BOARDDIR . '/packages/' . $_REQUEST['package'] . '/' . $_REQUEST['file']);
+			if (is_file(BOARDDIR . '/packages/' . $this->_req->query->package))
+				echo read_tgz_file(BOARDDIR . '/packages/' . $this->_req->query->package, $this->_req->query->file, true);
+			elseif (is_dir(BOARDDIR . '/packages/' . $this->_req->query->package))
+				echo file_get_contents(BOARDDIR . '/packages/' . $this->_req->query->package . '/' . $this->_req->query->file);
 
 			obExit(false);
 		}
 
 		$context['linktree'][count($context['linktree']) - 1] = array(
-			'url' => $scripturl . '?action=admin;area=packages;sa=list;package=' . $_REQUEST['package'],
+			'url' => $scripturl . '?action=admin;area=packages;sa=list;package=' . $this->_req->query->package,
 			'name' => $txt['package_examine_file']
 		);
 		$context['page_title'] .= ' - ' . $txt['package_examine_file'];
 		$context['sub_template'] = 'examine';
 
 		// The filename...
-		$context['package'] = $_REQUEST['package'];
-		$context['filename'] = $_REQUEST['file'];
+		$context['package'] = $this->_req->query->package;
+		$context['filename'] = $this->_req->query->file;
 
 		// Let the unpacker do the work.... but make sure we handle images properly.
-		if (in_array(strtolower(strrchr($_REQUEST['file'], '.')), array('.bmp', '.gif', '.jpeg', '.jpg', '.png')))
-			$context['filedata'] = '<img src="' . $scripturl . '?action=admin;area=packages;sa=examine;package=' . $_REQUEST['package'] . ';file=' . $_REQUEST['file'] . ';raw" alt="' . $_REQUEST['file'] . '" />';
+		if (in_array(strtolower(strrchr($this->_req->query->file, '.')), array('.bmp', '.gif', '.jpeg', '.jpg', '.png')))
+			$context['filedata'] = '<img src="' . $scripturl . '?action=admin;area=packages;sa=examine;package=' . $this->_req->query->package . ';file=' . $this->_req->query->file . ';raw" alt="' . $this->_req->query->file . '" />';
 		else
 		{
-			if (is_file(BOARDDIR . '/packages/' . $_REQUEST['package']))
-				$context['filedata'] = htmlspecialchars(read_tgz_file(BOARDDIR . '/packages/' . $_REQUEST['package'], $_REQUEST['file'], true));
-			elseif (is_dir(BOARDDIR . '/packages/' . $_REQUEST['package']))
-				$context['filedata'] = htmlspecialchars(file_get_contents(BOARDDIR . '/packages/' . $_REQUEST['package'] . '/' . $_REQUEST['file']));
+			if (is_file(BOARDDIR . '/packages/' . $this->_req->query->package))
+				$context['filedata'] = htmlspecialchars(read_tgz_file(BOARDDIR . '/packages/' . $this->_req->query->package, $this->_req->query->file, true));
+			elseif (is_dir(BOARDDIR . '/packages/' . $this->_req->query->package))
+				$context['filedata'] = htmlspecialchars(file_get_contents(BOARDDIR . '/packages/' . $this->_req->query->package . '/' . $this->_req->query->file));
 
-			if (strtolower(strrchr($_REQUEST['file'], '.')) == '.php')
+			if (strtolower(strrchr($this->_req->query->file, '.')) == '.php')
 				$context['filedata'] = highlight_php_code($context['filedata']);
 		}
 	}
@@ -1233,21 +1248,23 @@ class Packages_Controller extends Action_Controller
 		checkSession('get');
 
 		// Ack, don't allow deletion of arbitrary files here, could become a security hole somehow!
-		if (!isset($_GET['package']) || $_GET['package'] == 'index.php' || $_GET['package'] == 'installed.list' || $_GET['package'] == 'backups')
+		if (!isset($this->_req->query->package) || $this->_req->query->package == 'index.php' || $this->_req->query->package == 'installed.list' || $this->_req->query->package == 'backups')
 			redirectexit('action=admin;area=packages;sa=browse');
-		$_GET['package'] = preg_replace('~[\.]+~', '.', strtr($_GET['package'], array('/' => '_', '\\' => '_')));
+		$this->_req->query->package = preg_replace('~[\.]+~', '.', strtr($this->_req->query->package, array('/' => '_', '\\' => '_')));
 
 		// Can't delete what's not there.
-		if (file_exists(BOARDDIR . '/packages/' . $_GET['package']) && (substr($_GET['package'], -4) == '.zip' || substr($_GET['package'], -4) == '.tgz' || substr($_GET['package'], -7) == '.tar.gz' || is_dir(BOARDDIR . '/packages/' . $_GET['package'])) && $_GET['package'] != 'backups' && substr($_GET['package'], 0, 1) != '.')
+		if (file_exists(BOARDDIR . '/packages/' . $this->_req->query->package)
+			&& (substr($this->_req->query->package, -4) == '.zip' || substr($this->_req->query->package, -4) == '.tgz' || substr($this->_req->query->package, -7) == '.tar.gz' || is_dir(BOARDDIR . '/packages/' . $this->_req->query->package))
+			&& $this->_req->query->package != 'backups' && substr($this->_req->query->package, 0, 1) != '.')
 		{
-			create_chmod_control(array(BOARDDIR . '/packages/' . $_GET['package']), array('destination_url' => $scripturl . '?action=admin;area=packages;sa=remove;package=' . $_GET['package'], 'crash_on_error' => true));
+			create_chmod_control(array(BOARDDIR . '/packages/' . $this->_req->query->package), array('destination_url' => $scripturl . '?action=admin;area=packages;sa=remove;package=' . $this->_req->query->package, 'crash_on_error' => true));
 
-			if (is_dir(BOARDDIR . '/packages/' . $_GET['package']))
-				deltree(BOARDDIR . '/packages/' . $_GET['package']);
+			if (is_dir(BOARDDIR . '/packages/' . $this->_req->query->package))
+				deltree(BOARDDIR . '/packages/' . $this->_req->query->package);
 			else
 			{
-				@chmod(BOARDDIR . '/packages/' . $_GET['package'], 0777);
-				unlink(BOARDDIR . '/packages/' . $_GET['package']);
+				@chmod(BOARDDIR . '/packages/' . $this->_req->query->package, 0777);
+				unlink(BOARDDIR . '/packages/' . $this->_req->query->package);
 			}
 		}
 
@@ -1377,7 +1394,9 @@ class Packages_Controller extends Action_Controller
 					array(
 						'position' => 'bottom_of_list',
 						'class' => 'submitbutton',
-						'value' => ($context['sub_action'] == 'browse' ? '<div class="smalltext">' . $txt['package_installed_key'] . '<img src="' . $settings['images_url'] . '/icons/package_installed.png" alt="" class="centericon" /> ' . $txt['package_installed_current'] . '<img src="' . $settings['images_url'] . '/icons/package_old.png" alt="" class="centericon" /> ' . $txt['package_installed_old'] . '</div>' : '<a class="linkbutton" href="' . $scripturl . '?action=admin;area=packages;sa=flush;' . $context['session_var'] . '=' . $context['session_id'] . '" onclick="return confirm(\'' . $txt['package_delete_list_warning'] . '\');">' . $txt['delete_list'] . '</a>'),
+						'value' => ($context['sub_action'] == 'browse'
+							? '<div class="smalltext">' . $txt['package_installed_key'] . '<img src="' . $settings['images_url'] . '/icons/package_installed.png" alt="" class="centericon" /> ' . $txt['package_installed_current'] . '<img src="' . $settings['images_url'] . '/icons/package_old.png" alt="" class="centericon" /> ' . $txt['package_installed_old'] . '</div>'
+							: '<a class="linkbutton" href="' . $scripturl . '?action=admin;area=packages;sa=flush;' . $context['session_var'] . '=' . $context['session_id'] . '" onclick="return confirm(\'' . $txt['package_delete_list_warning'] . '\');">' . $txt['delete_list'] . '</a>'),
 					),
 				),
 			);
@@ -1431,22 +1450,22 @@ class Packages_Controller extends Action_Controller
 	{
 		global $txt, $context, $modSettings;
 
-		if (isset($_POST['save']))
+		if (isset($this->_req->post->save))
 		{
 			checkSession('post');
 
 			updateSettings(array(
-				'package_server' => trim(Util::htmlspecialchars($_POST['pack_server'])),
-				'package_port' => trim(Util::htmlspecialchars($_POST['pack_port'])),
-				'package_username' => trim(Util::htmlspecialchars($_POST['pack_user'])),
-				'package_make_backups' => !empty($_POST['package_make_backups']),
-				'package_make_full_backups' => !empty($_POST['package_make_full_backups'])
+				'package_server' => $this->_req->getPost('pack_server', 'trim|Util::htmlspecialchars'),
+				'package_port' => $this->_req->getPost('pack_port', 'trim|Util::htmlspecialchars'),
+				'package_username' => $this->_req->getPost('pack_user', 'trim|Util::htmlspecialchars'),
+				'package_make_backups' => !empty($this->_req->post->package_make_backups),
+				'package_make_full_backups' => !empty($this->_req->post->package_make_full_backups)
 			));
 
 			redirectexit('action=admin;area=packages;sa=options');
 		}
 
-		if (preg_match('~^/home\d*/([^/]+?)/public_html~', $_SERVER['DOCUMENT_ROOT'], $match))
+		if (preg_match('~^/home\d*/([^/]+?)/public_html~', $this->_req->server->DOCUMENT_ROOT, $match))
 			$default_username = $match[1];
 		else
 			$default_username = '';
@@ -1471,7 +1490,7 @@ class Packages_Controller extends Action_Controller
 		isAllowedTo('admin_forum');
 
 		// We need to know the operation key for the search and replace, mod file looking at, is it a board mod?
-		if (!isset($_REQUEST['operation_key'], $_REQUEST['filename']) && !is_numeric($_REQUEST['operation_key']))
+		if (!isset($this->_req->query->operation_key, $this->_req->query->filename) && !is_numeric($this->_req->query->operation_key))
 			Errors::fatal_lang_error('operation_invalid', 'general');
 
 		// Load the required file.
@@ -1479,10 +1498,10 @@ class Packages_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Themes.subs.php');
 
 		// Uninstalling the mod?
-		$reverse = isset($_REQUEST['reverse']) ? true : false;
+		$reverse = isset($this->_req->query->reverse) ? true : false;
 
 		// Get the base name.
-		$context['filename'] = preg_replace('~[\.]+~', '.', $_REQUEST['package']);
+		$context['filename'] = preg_replace('~[\.]+~', '.', $this->_req->query->package);
 
 		// We need to extract this again.
 		if (is_file(BOARDDIR . '/packages/' . $context['filename']))
@@ -1512,9 +1531,9 @@ class Packages_Controller extends Action_Controller
 		$theme_paths = getThemesPathbyID();
 
 		// For uninstall operations we only consider the themes in which the package is installed.
-		if (isset($_REQUEST['reverse']) && !empty($_REQUEST['install_id']))
+		if (isset($this->_req->query->reverse) && !empty($this->_req->query->install_id))
 		{
-			$install_id = (int) $_REQUEST['install_id'];
+			$install_id = (int) $this->_req->query->install_id;
 			if ($install_id > 0)
 			{
 				$old_themes = loadThemesAffected($install_id);
@@ -1527,16 +1546,16 @@ class Packages_Controller extends Action_Controller
 		}
 
 		// Boardmod?
-		if (isset($_REQUEST['boardmod']))
-			$mod_actions = parseBoardMod(@file_get_contents(BOARDDIR . '/packages/temp/' . $context['base_path'] . $_REQUEST['filename']), true, $reverse, $theme_paths);
+		if (isset($this->_req->query->boardmod))
+			$mod_actions = parseBoardMod(@file_get_contents(BOARDDIR . '/packages/temp/' . $context['base_path'] . $this->_req->query->filename), true, $reverse, $theme_paths);
 		else
-			$mod_actions = parseModification(@file_get_contents(BOARDDIR . '/packages/temp/' . $context['base_path'] . $_REQUEST['filename']), true, $reverse, $theme_paths);
+			$mod_actions = parseModification(@file_get_contents(BOARDDIR . '/packages/temp/' . $context['base_path'] . $this->_req->query->filename), true, $reverse, $theme_paths);
 
 		// Ok lets get the content of the file.
 		$context['operations'] = array(
-			'search' => strtr(htmlspecialchars($mod_actions[$_REQUEST['operation_key']]['search_original'], ENT_COMPAT, 'UTF-8'), array('[' => '&#91;', ']' => '&#93;')),
-			'replace' => strtr(htmlspecialchars($mod_actions[$_REQUEST['operation_key']]['replace_original'], ENT_COMPAT, 'UTF-8'), array('[' => '&#91;', ']' => '&#93;')),
-			'position' => $mod_actions[$_REQUEST['operation_key']]['position'],
+			'search' => strtr(htmlspecialchars($mod_actions[$this->_req->query->operation_key]['search_original'], ENT_COMPAT, 'UTF-8'), array('[' => '&#91;', ']' => '&#93;')),
+			'replace' => strtr(htmlspecialchars($mod_actions[$this->_req->query->operation_key]['replace_original'], ENT_COMPAT, 'UTF-8'), array('[' => '&#91;', ']' => '&#93;')),
+			'position' => $mod_actions[$this->_req->query->operation_key]['position'],
 		);
 
 		// Let's do some formatting...
@@ -1560,7 +1579,7 @@ class Packages_Controller extends Action_Controller
 		checkSession('get');
 
 		// If we're restoring permissions this is just a pass through really.
-		if (isset($_GET['restore']))
+		if (isset($this->_req->query->restore))
 		{
 			create_chmod_control(array(), array(), true);
 			Errors::fatal_lang_error('no_access', false);
@@ -1573,7 +1592,7 @@ class Packages_Controller extends Action_Controller
 		// Load up some FTP stuff.
 		create_chmod_control();
 
-		if (empty($package_ftp) && !isset($_POST['skip_ftp']))
+		if (empty($package_ftp) && !isset($this->_req->post->skip_ftp))
 		{
 			$ftp = new Ftp_Connection(null);
 			list ($username, $detect_path, $found_path) = $ftp->detect_path(BOARDDIR);
@@ -1780,36 +1799,36 @@ class Packages_Controller extends Action_Controller
 		}
 
 		// If we're submitting then let's move on to another function to keep things cleaner..
-		if (isset($_POST['action_changes']))
+		if (isset($this->_req->post->action_changes))
 			return $this->action_perms_save();
 
 		$context['look_for'] = array();
 
 		// Are we looking for a particular tree - normally an expansion?
-		if (!empty($_REQUEST['find']))
-			$context['look_for'][] = base64_decode($_REQUEST['find']);
+		if (!empty($this->_req->query->find))
+			$context['look_for'][] = base64_decode($this->_req->query->find);
 
 		// Only that tree?
-		$context['only_find'] = isset($_GET['xml']) && !empty($_REQUEST['onlyfind']) ? $_REQUEST['onlyfind'] : '';
+		$context['only_find'] = isset($this->_req->query->xml) && !empty($this->_req->query->onlyfind) ? $this->_req->query->onlyfind : '';
 		if ($context['only_find'])
 			$context['look_for'][] = $context['only_find'];
 
 		// Have we got a load of back-catalogue trees to expand from a submit etc?
-		if (!empty($_GET['back_look']))
+		if (!empty($this->_req->query->back_look))
 		{
-			$potententialTrees = unserialize(base64_decode($_GET['back_look']));
+			$potententialTrees = unserialize(base64_decode($this->_req->query->back_look));
 			foreach ($potententialTrees as $tree)
 				$context['look_for'][] = $tree;
 		}
 
 		// ... maybe posted?
-		if (!empty($_POST['back_look']))
-			$context['only_find'] = array_merge($context['only_find'], $_POST['back_look']);
+		if (!empty($this->_req->post->back_look))
+			$context['only_find'] = array_merge($context['only_find'], $this->_req->post->back_look);
 
 		$context['back_look_data'] = base64_encode(serialize(array_slice($context['look_for'], 0, 15)));
 
 		// Are we finding more files than first thought?
-		$context['file_offset'] = !empty($_REQUEST['fileoffset']) ? (int) $_REQUEST['fileoffset'] : 0;
+		$context['file_offset'] = !empty($this->_req->query->fileoffset) ? (int) $this->_req->query->fileoffset : 0;
 
 		// Don't list more than this many files in a directory.
 		$context['file_limit'] = 150;
@@ -1850,7 +1869,7 @@ class Packages_Controller extends Action_Controller
 		}
 
 		// Is this actually xml?
-		if (isset($_GET['xml']))
+		if (isset($this->_req->query->xml))
 		{
 			loadTemplate('Xml');
 			$context['sub_template'] = 'generic_xml';
@@ -1868,8 +1887,8 @@ class Packages_Controller extends Action_Controller
 		umask(0);
 
 		$timeout_limit = 5;
-		$context['method'] = $_POST['method'] === 'individual' ? 'individual' : 'predefined';
-		$context['back_look_data'] = isset($_POST['back_look']) ? $_POST['back_look'] : array();
+		$context['method'] = $this->_req->post->method === 'individual' ? 'individual' : 'predefined';
+		$context['back_look_data'] = isset($this->_req->post->back_look) ? $this->_req->post->back_look : array();
 
 		// Skipping use of FTP?
 		if (empty($package_ftp))
@@ -1880,17 +1899,17 @@ class Packages_Controller extends Action_Controller
 		{
 			// Only these path roots are legal.
 			$legal_roots = array_keys($context['file_tree']);
-			$context['custom_value'] = (int) $_POST['custom_value'];
+			$context['custom_value'] = (int) $this->_req->post->custom_value;
 
 			// Continuing?
-			if (isset($_POST['toProcess']))
-				$_POST['permStatus'] = unserialize(base64_decode($_POST['toProcess']));
+			if (isset($this->_req->post->toProcess))
+				$this->_req->post->permStatus = unserialize(base64_decode($this->_req->post->toProcess));
 
-			if (isset($_POST['permStatus']))
+			if (isset($this->_req->post->permStatus))
 			{
 				$context['to_process'] = array();
 				$validate_custom = false;
-				foreach ($_POST['permStatus'] as $path => $status)
+				foreach ($this->_req->post->permStatus as $path => $status)
 				{
 					// Nothing to see here?
 					if ($status === 'no_change')
@@ -1914,7 +1933,7 @@ class Packages_Controller extends Action_Controller
 					// Now add it.
 					$context['to_process'][$path] = $status;
 				}
-				$context['total_items'] = isset($_POST['totalItems']) ? (int) $_POST['totalItems'] : count($context['to_process']);
+				$context['total_items'] = isset($this->_req->post->totalItems) ? (int) $this->_req->post->totalItems : count($context['to_process']);
 
 				// Make sure the chmod status is valid?
 				if ($validate_custom)
@@ -1962,10 +1981,10 @@ class Packages_Controller extends Action_Controller
 		// If predefined this is a little different.
 		else
 		{
-			$context['predefined_type'] = isset($_POST['predefined']) ? $_POST['predefined'] : 'restricted';
-			$context['total_items'] = isset($_POST['totalItems']) ? (int) $_POST['totalItems'] : 0;
-			$context['directory_list'] = isset($_POST['dirList']) ? unserialize(base64_decode($_POST['dirList'])) : array();
-			$context['file_offset'] = isset($_POST['fileOffset']) ? (int) $_POST['fileOffset'] : 0;
+			$context['predefined_type'] = $this->_req->getPost('predefined', 'trim|strval', 'restricted');
+			$context['total_items'] = $this->_req->getPost('totalItems', 'intval', 0);
+			$context['directory_list'] = isset($this->_req->post->dirList) ? unserialize(base64_decode($this->_req->post->dirList)) : array();
+			$context['file_offset'] = $this->_req->getPost('fileOffset', 'intval', 0);
 
 			// Haven't counted the items yet?
 			if (empty($context['total_items']))
@@ -1982,7 +2001,7 @@ class Packages_Controller extends Action_Controller
 			}
 
 			// Have we built up our list of special files?
-			if (!isset($_POST['specialFiles']) && $context['predefined_type'] != 'free')
+			if (!isset($this->_req->post->specialFiles) && $context['predefined_type'] != 'free')
 			{
 				$context['special_files'] = array();
 
@@ -1993,7 +2012,7 @@ class Packages_Controller extends Action_Controller
 			elseif ($context['predefined_type'] === 'free')
 				$context['special_files'] = array();
 			else
-				$context['special_files'] = unserialize(base64_decode($_POST['specialFiles']));
+				$context['special_files'] = unserialize(base64_decode($this->_req->post->specialFiles));
 
 			// Now we definitely know where we are, we need to go through again doing the chmod!
 			foreach ($context['directory_list'] as $path => $dummy)
@@ -2122,14 +2141,15 @@ class Packages_Controller extends Action_Controller
 		list ($the_brand, $the_version) = explode(' ', FORUM_VERSION, 2);
 
 		// Here we have a little code to help those who class themselves as something of gods, version emulation ;)
-		if (isset($_GET['version_emulate']) && strtr($_GET['version_emulate'], array($the_brand => '')) == $the_version)
+		if (isset($this->_req->query->version_emulate) && strtr($this->_req->query->version_emulate, array($the_brand => '')) == $the_version)
 			unset($_SESSION['version_emulate']);
-		elseif (isset($_GET['version_emulate']))
+		elseif (isset($this->_req->query->version_emulate))
 		{
 			if (($_GET['version_emulate'] === 0 || $_GET['version_emulate'] === FORUM_VERSION) && isset($_SESSION['version_emulate']))
+			if (($this->_req->query->version_emulate === 0 || $this->_req->query->version_emulate === $forum_version) && isset($_SESSION['version_emulate']))
 				unset($_SESSION['version_emulate']);
-			elseif ($_GET['version_emulate'] !== 0)
-				$_SESSION['version_emulate'] = strtr($_GET['version_emulate'], array('-' => ' ', '+' => ' ', $the_brand . ' ' => ''));
+			elseif ($this->_req->query->version_emulate !== 0)
+				$_SESSION['version_emulate'] = strtr($this->_req->query->version_emulate, array('-' => ' ', '+' => ' ', $the_brand . ' ' => ''));
 		}
 
 		if (!empty($_SESSION['version_emulate']))
@@ -2368,9 +2388,9 @@ class Packages_Controller extends Action_Controller
 			closedir($dir);
 		}
 
-		if (isset($_GET['type']) && $_GET['type'] == $params)
+		if (isset($this->_req->query->type) && $this->_req->query->type == $params)
 		{
-			if (isset($_GET['desc']))
+			if (isset($this->_req->query->desc))
 				krsort($packages[$params]);
 			else
 				ksort($packages[$params]);
@@ -2394,8 +2414,10 @@ function fetchPerms__recursive($path, &$data, $level)
 
 	$isLikelyPath = false;
 	foreach ($context['look_for'] as $possiblePath)
+	{
 		if (substr($possiblePath, 0, strlen($path)) == $path)
 			$isLikelyPath = true;
+	}
 
 	// Is this where we stop?
 	if (isset($_GET['xml']) && !empty($context['look_for']) && !$isLikelyPath)

--- a/sources/admin/RepairBoards.controller.php
+++ b/sources/admin/RepairBoards.controller.php
@@ -27,6 +27,20 @@ if (!defined('ELK'))
 class RepairBoards_Controller extends Action_Controller
 {
 	/**
+	 * Holds instance of HttpReq object
+	 * @var HttpReq
+	 */
+	protected $_req;
+
+	/**
+	 * Pre Dispatch, called before other methods.  Loads HttpReq
+	 */
+	public function pre_dispatch()
+	{
+		$this->_req = HttpReq::instance();
+	}
+
+	/**
 	 * Default method.
 	 *
 	 * @see Action_Controller::action_index()
@@ -74,7 +88,7 @@ class RepairBoards_Controller extends Action_Controller
 		);
 
 		// Start displaying errors without fixing them.
-		if (isset($_GET['fixErrors']))
+		if (isset($this->_req->query->fixErrors))
 			checkSession('get');
 
 		// Will want this.
@@ -82,7 +96,7 @@ class RepairBoards_Controller extends Action_Controller
 
 		// Giant if/else. The first displays the forum errors if a variable is not set and asks
 		// if you would like to continue, the other fixes the errors.
-		if (!isset($_GET['fixErrors']))
+		if (!isset($this->_req->query->fixErrors))
 		{
 			$context['error_search'] = true;
 			$context['repair_errors'] = array();
@@ -108,7 +122,7 @@ class RepairBoards_Controller extends Action_Controller
 		else
 		{
 			$context['error_search'] = false;
-			$context['to_fix'] = isset($_SESSION['repairboards_to_fix']) ? $_SESSION['repairboards_to_fix'] : array();
+			$context['to_fix'] = isset($this->_req->session->repairboards_to_fix) ? $this->_req->session->repairboards_to_fix : array();
 
 			require_once(SUBSDIR . '/Boards.subs.php');
 
@@ -126,18 +140,19 @@ class RepairBoards_Controller extends Action_Controller
 			updateSettings(array(
 				'settings_updated' => time(),
 			));
+
 			require_once(SUBSDIR . '/Messages.subs.php');
 			updateMessageStats();
+
 			require_once(SUBSDIR . '/Topic.subs.php');
 			updateTopicStats();
+
 			updateSettings(array(
 				'calendar_updated' => time(),
 			));
 
 			if (!empty($salvageBoardID))
-			{
 				$context['redirect_to_recount'] = true;
-			}
 
 			$_SESSION['repairboards_to_fix'] = null;
 			$_SESSION['repairboards_to_fix2'] = null;

--- a/sources/subs/DataValidator.class.php
+++ b/sources/subs/DataValidator.class.php
@@ -151,7 +151,7 @@ class Data_Validator
 
 		// Replace the data
 		if (!empty($sanitation_rules))
-			$data = $validator->_array_replace($data, $validator->validation_data());
+			$data = array_replace($data, $validator->validation_data());
 
 		// Return true or false on valid data
 		return $result;
@@ -229,9 +229,13 @@ class Data_Validator
 	 */
 	public function validate($input)
 	{
+		// If its an object, convert it to an array
+		if (is_object($input))
+			$input = (array) $input;
+
 		// @todo this won't work, $input[$field] will be undefined
 		if (!is_array($input))
-			$input = array($input);
+			$input[$input] = array($input);
 
 		// Clean em
 		$this->_data = $this->_sanitize($input, $this->_sanitation_rules);
@@ -269,21 +273,6 @@ class Data_Validator
 			return $this->_data;
 
 		return isset($this->_data[$key]) ? $this->_data[$key] : null;
-	}
-
-	/**
-	 * array_replace is a php 5.3+ function, this is needed to support the oldies
-	 */
-	private function _array_replace()
-	{
-		$array = array();
-		$n = func_num_args();
-
-		// Union each array passed
-		while ($n-- > 0)
-			$array += func_get_arg($n);
-
-		return $array;
 	}
 
 	/**

--- a/sources/subs/DataValidator.class.php
+++ b/sources/subs/DataValidator.class.php
@@ -134,7 +134,7 @@ class Data_Validator
 	/**
 	 * Shorthand static method for simple inline validation
 	 *
-	 * @param mixed[] $data generally $_POST data for this method
+	 * @param mixed[]|object $data generally $_POST data for this method
 	 * @param mixed[] $validation_rules assoicative array of field => rules
 	 * @param mixed[] $sanitation_rules assoicative array of field => rules
 	 */
@@ -225,7 +225,7 @@ class Data_Validator
 	/**
 	 * Run the sanitation and validation on the data
 	 *
-	 * @param mixed[] $input associative array of data to process name => value
+	 * @param mixed[]|object $input associative array or object of data to process name => value
 	 */
 	public function validate($input)
 	{

--- a/sources/subs/DataValidator.class.php
+++ b/sources/subs/DataValidator.class.php
@@ -450,7 +450,7 @@ class Data_Validator
 						$sanitation_method = '_sanitation_' . $match[1];
 						$sanitation_parameters = $match[2];
 						$sanitation_function = $match[1];
-						$sanitation_parameters_function = explode(',', $match[2]);
+						$sanitation_parameters_function = explode(',', defined($match[2]) ? constant($match[2]) : $match[2]);
 					}
 					// Or just a predefined rule e.g. trim
 					else

--- a/sources/subs/EmailSettings.class.php
+++ b/sources/subs/EmailSettings.class.php
@@ -38,9 +38,14 @@ class Email_Settings extends Settings_Form
 	 * @param integer $editid -1 add a row, otherwise edit a row with the supplied key value
 	 * @param string $editname used when editing a row, needs to be the name of the col to find $editid key value
 	 */
-	public static function saveTableSettings($config_vars, $tablename, $index = array(), $editid = -1, $editname = '')
+	public static function saveTableSettings($config_vars, $tablename, $config_values = null, $index = array(), $editid = -1, $editname = '')
 	{
 		$db = database();
+
+		if ($config_values === null)
+			$config_values = $_POST;
+		elseif (is_object($config_values))
+			$config_values = (array) $config_values;
 
 		// Init
 		$insert_type = array();
@@ -50,26 +55,26 @@ class Email_Settings extends Settings_Form
 		// Cast all the config vars as defined
 		foreach ($config_vars as $var)
 		{
-			if (!isset($var[1]) || (!isset($_POST[$var[1]]) && $var[0] !== 'check'))
+			if (!isset($var[1]) || (!isset($config_values[$var[1]]) && $var[0] !== 'check'))
 				continue;
 
 			// Checkboxes ...
 			elseif ($var[0] === 'check')
 			{
 				$insert_type[$var[1]] = 'int';
-				$insert_value[] = !empty($_POST[$var[1]]) ? 1 : 0;
+				$insert_value[] = !empty($config_values[$var[1]]) ? 1 : 0;
 			}
 			// Or maybe even select boxes
-			elseif ($var[0] === 'select' && in_array($_POST[$var[1]], array_keys($var[2])))
+			elseif ($var[0] === 'select' && in_array($config_values[$var[1]], array_keys($var[2])))
 			{
 				$insert_type[$var[1]] = 'string';
-				$insert_value[] = $_POST[$var[1]];
+				$insert_value[] = $config_values[$var[1]];
 			}
-			elseif ($var[0] === 'select' && !empty($var['multiple']) && array_intersect($_POST[$var[1]], array_keys($var[2])) != array())
+			elseif ($var[0] === 'select' && !empty($var['multiple']) && array_intersect($config_values[$var[1]], array_keys($var[2])) != array())
 			{
 				// For security purposes we need to validate this line by line.
 				$options = array();
-				foreach ($_POST[$var[1]] as $invar)
+				foreach ($config_values[$var[1]] as $invar)
 				{
 					if (in_array($invar, array_keys($var[2])))
 						$options[] = $invar;
@@ -82,19 +87,19 @@ class Email_Settings extends Settings_Form
 			elseif ($var[0] == 'int')
 			{
 				$insert_type[$var[1]] = 'int';
-				$insert_value[] = (int) $_POST[$var[1]];
+				$insert_value[] = (int) $config_values[$var[1]];
 			}
 			// Floating points are easy
 			elseif ($var[0] === 'float')
 			{
 				$insert_type[$var[1]] = 'float';
-				$insert_value[] = (float) $_POST[$var[1]];
+				$insert_value[] = (float) $config_values[$var[1]];
 			}
 			// Text is fine too!
 			elseif ($var[0] === 'text' || $var[0] === 'large_text')
 			{
 				$insert_type[$var[1]] = 'string';
-				$insert_value[] = $_POST[$var[1]];
+				$insert_value[] = $config_values[$var[1]];
 			}
 		}
 

--- a/sources/subs/Error.subs.php
+++ b/sources/subs/Error.subs.php
@@ -21,7 +21,7 @@ if (!defined('ELK'))
  * Redirects back to the error log when done.
  *
  * @param string $type action
- * @param mixed[]|null $filter db query of the view filter being used
+ * @param array|null $filter db query of the view filter being used
  * @param int[]|null $error_list int list of error ID's to work on
  */
 function deleteErrors($type, $filter = null, $error_list = null)
@@ -86,7 +86,7 @@ function numErrors($filter = array())
  *
  * @param int $start
  * @param string $sort_direction
- * @param mixed[]|null $filter
+ * @param array|null $filter
  */
 function getErrorLogData($start, $sort_direction = 'DESC', $filter = null)
 {

--- a/sources/subs/HttpRequest.class.php
+++ b/sources/subs/HttpRequest.class.php
@@ -82,6 +82,7 @@ class HttpReq
 
 	/**
 	 * Generic access values contained in the superglobals
+	 * - gets in order of param, get and post
 	 *
 	 * @param string $key
 	 */
@@ -90,8 +91,6 @@ class HttpReq
 		switch (true) {
 			case isset($this->_param[$key]):
 				return $this->_param[$key];
-			case isset($this->request->$key):
-				return $this->request->$key;
 			case isset($this->query->$key):
 				return $this->query->$key;
 			case isset($this->post->$key):
@@ -114,14 +113,14 @@ class HttpReq
 	/**
 	 * Generic check to see if a property is set
 	 *
+	 * - checks in order of param, get, post
+	 *
 	 * @param string $key
 	 */
 	public function __isset($key)
 	{
 		switch (true) {
 			case isset($this->_param[$key]):
-				return true;
-			case isset($this->request->$key):
 				return true;
 			case isset($this->query->$key):
 				return true;
@@ -151,10 +150,11 @@ class HttpReq
 	 *
 	 * @param string $name The key name of the value to return
 	 * @param string|null $sanitize a comma separated list of sanitation rules to apply
+	 * @param mixed|null $default default value to return if key value is not found
 	 */
-	public function getRequest($name = '', $sanitize = null)
+	public function getRequest($name = '', $sanitize = null, $default = null)
 	{
-		$this->_param[$name] = null;
+		$this->_param[$name] = $default;
 
 		if (isset($this->request->$name))
 		{
@@ -174,10 +174,11 @@ class HttpReq
 	 *
 	 * @param string $name The key name of the value to return
 	 * @param string|null $sanitize a comma separated list of sanitation rules to apply
+	 * @param mixed|null $default default value to return if key value is not found
 	 */
-	public function getQuery($name = '', $sanitize = null)
+	public function getQuery($name = '', $sanitize = null, $default = null)
 	{
-		$this->_param[$name] = null;
+		$this->_param[$name] = $default;
 
 		if (isset($this->query->$name))
 		{
@@ -197,10 +198,11 @@ class HttpReq
 	 *
 	 * @param string $name The key name of the value to return
 	 * @param string|null $sanitize a comma separated list of sanitation rules to apply
+	 * @param mixed|null $default default value to return if key value is not found
 	 */
-	public function getPost($name = '', $sanitize = null)
+	public function getPost($name = '', $sanitize = null, $default = null)
 	{
-		$this->_param[$name] = null;
+		$this->_param[$name] = $default;
 
 		if (isset($this->post->$name))
 		{

--- a/sources/subs/HttpRequest.class.php
+++ b/sources/subs/HttpRequest.class.php
@@ -217,20 +217,32 @@ class HttpReq
 	 * Method to return a $_COOKIE value
 	 *
 	 * @param string $name the name of the value to return
+	 * @param mixed|null $default default value to return if key value is not found
 	 */
-	public function getCookie($name = '')
+	public function getCookie($name = '', $default = null)
 	{
-		return (isset($this->cookie->$name)) ? $this->cookie->$name : null;
+		if (isset($this->cookie->$name))
+			return $this->cookie->$name;
+		elseif ($default !== null)
+			return $default;
+		else
+			return null;
 	}
 
 	/**
 	 * Method to get a $_SESSION value
 	 *
 	 * @param string $name the name of the value to return
+	 * @param mixed|null $default default value to return if key value is not found
 	 */
-	public function getSession($name = '')
+	public function getSession($name = '', $default = null)
 	{
-		return (isset($this->session->$name)) ? $this->session->$name : null;
+		if (isset($this->session->$name))
+			return $this->session->$name;
+		elseif ($default !== null)
+			return $default;
+		else
+			return null;
 	}
 
 	/**

--- a/sources/subs/HttpRequest.class.php
+++ b/sources/subs/HttpRequest.class.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * Http Request class for providing global vars to class for improved
+ * encapsulation
+ *
+ * @name      ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause
+ *
+ * @version 1.1
+ *
+ */
+
+/**
+ *
+ */
+class HttpReq
+{
+	/**
+	 * The returned POST values
+	 * @var object
+	 */
+	public $post;
+
+	/**
+	 * The returned GET values
+	 * @var object
+	 */
+	public $query;
+
+	/**
+	 * The returned REQUEST values
+	 * @var object
+	 */
+	public $request;
+
+	/**
+	 * The returned COOKIE values
+	 * @var object
+	 */
+	public $cookie;
+
+	/**
+	 * The returned SESSION values
+	 * @var object
+	 */
+	public $session;
+
+	/**
+	 * Sole private HttpReq instance
+	 * @var HttpReq
+	 */
+	private static $_req = null;
+
+	/**
+	 * Class constructor, sets PHP gobals to class members
+	 */
+	public function __construct()
+	{
+		$this->post = new ArrayObject($_POST, ArrayObject::ARRAY_AS_PROPS);
+		$this->query = new ArrayObject($_GET, ArrayObject::ARRAY_AS_PROPS);
+		$this->request = new ArrayObject($_REQUEST, ArrayObject::ARRAY_AS_PROPS);
+		$this->cookie = new ArrayObject($_COOKIE, ArrayObject::ARRAY_AS_PROPS);
+		$this->session = new ArrayObject($_SESSION, ArrayObject::ARRAY_AS_PROPS);
+	}
+
+	/**
+	 * Generic access values contained in the superglobals
+	 *
+	 * @param string $key
+	 */
+	public function __get($key)
+	{
+		switch (true) {
+			case isset($this->request->$key):
+				return $this->request->$key;
+			case isset($this->query->$key):
+				return $this->query->$key;
+			case isset($this->post->$key):
+				return $this->post->$key;
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Alias to __get
+	 *
+	 * @param string $key
+	 */
+	public function get($key)
+	{
+		return $this->__get($key);
+	}
+
+	/**
+	 * Generic check to see if a property is set
+	 *
+	 * @param string $key
+	 */
+	public function __isset($key)
+	{
+		switch (true) {
+			case isset($this->request->$key):
+				return true;
+			case isset($this->query->$key):
+				return true;
+			case isset($this->post->$key):
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * Alias to __isset()
+	 *
+	 * @param string $key
+	 */
+	public function is_set($key)
+	{
+		return $this->__isset($key);
+	}
+
+	/**
+	 * Method to set, clean, sanitize a $_GET value if set
+	 *
+	 * @param string $name The name of the value to return
+	 */
+	public function getRequest($name = '')
+	{
+		return (isset($this->request->$name)) ? $this->request->$name : null;
+	}
+	
+	/**
+	 * Method to return a $_GET value
+	 *
+	 * @param string $name The name of the value to return
+	 */
+	public function getQuery($name = '')
+	{
+		return (isset($this->query->$name)) ? $this->query->$name : null;
+	}
+
+	/**
+	 * Method to return a $_POST value
+	 *
+	 * @param string $name the name of the value to return
+	 */
+	public function getPost($name = '')
+	{
+		return (isset($this->post->$name)) ? $this->post->$name : null;
+	}
+
+	/**
+	 * Method to return a $_COOKIE value
+	 *
+	 * @param string $name the name of the value to return
+	 */
+	public function getCookie($name = '')
+	{
+		return (isset($this->cookie->$name)) ? $this->cookie->$name : null;
+	}
+
+	/**
+	 * Method to get a $_SESSION value
+	 *
+	 * @param string $name the name of the value to return
+	 */
+	public function getSession($name = '')
+	{
+		$this->session->$name = (isset($this->session->$name)) ? $this->session->$name : null;
+
+		return $this->session;
+	}
+
+	public function cleanValue($value)
+	{
+		return Util::htmlspecialchars($value, ENT_QUOTES);
+	}
+
+	/**
+	 * Retrieve the sole instance of this class.
+	 *
+	 * @return HttpReq
+	 */
+	public static function instance()
+	{
+		if (self::$_req === null)
+			self::$_req = new HttpReq();
+
+		return self::$_req;
+	}
+}

--- a/sources/subs/ManageFeatures.subs.php
+++ b/sources/subs/ManageFeatures.subs.php
@@ -41,7 +41,7 @@ function getSignatureFromMembers($start_member)
 			AND id_group != {int:admin_group}
 			AND FIND_IN_SET({int:admin_group}, additional_groups) = 0',
 		array(
-			'admin_group' => 1,
+			'admin_group' => 11,
 		)
 	);
 	while ($result = $db->fetch_assoc($request))
@@ -63,6 +63,238 @@ function updateSignature($id_member, $signature)
 {
 	require_once(SUBSDIR . '/Members.subs.php');
 	updateMemberData($id_member, array('signature' => $signature));
+}
+
+/**
+ * Update all signautes given a new set of constraints
+ */
+function updateAllSignatures($applied_sigs)
+{
+	global $context, $sig_start, $modSettings;
+
+	require_once(SUBSDIR . '/Members.subs.php');
+	$sig_start = time();
+
+	// This is horrid - but I suppose some people will want the option to do it.
+	$done = false;
+	$context['max_member'] = maxMemberID();
+
+	// Load all the signature settings.
+	list ($sig_limits, $sig_bbc) = explode(':', $modSettings['signature_settings']);
+	$sig_limits = explode(',', $sig_limits);
+	$disabledTags = !empty($sig_bbc) ? explode(',', $sig_bbc) : array();
+
+	while (!$done)
+	{
+		// No changed signatures yet
+		$changes = array();
+
+		// Get a group of member signatures, 50 at a clip
+		$update_sigs = getSignatureFromMembers($applied_sigs);
+
+		if (empty($update_sigs))
+			$done = true;
+
+		foreach ($update_sigs as $row)
+		{
+			// Apply all the rules we can realistically do.
+			$sig = strtr($row['signature'], array('<br />' => "\n"));
+
+			// Max characters...
+			if (!empty($sig_limits[1]))
+				$sig = Util::substr($sig, 0, $sig_limits[1]);
+
+			// Max lines...
+			if (!empty($sig_limits[2]))
+			{
+				$count = 0;
+				$str_len = strlen($sig);
+				for ($i = 0; $i < $str_len; $i++)
+				{
+					if ($sig[$i] == "\n")
+					{
+						$count++;
+						if ($count >= $sig_limits[2])
+							$sig = substr($sig, 0, $i) . strtr(substr($sig, $i), array("\n" => ' '));
+					}
+				}
+			}
+
+			// Max text size
+			if (!empty($sig_limits[7]) && preg_match_all('~\[size=([\d\.]+)?(px|pt|em|x-large|larger)?~i', $sig, $matches) !== false && isset($matches[2]))
+			{
+				foreach ($matches[1] as $ind => $size)
+				{
+					$limit_broke = 0;
+
+					// Attempt to allow all sizes of abuse, so to speak.
+					if ($matches[2][$ind] == 'px' && $size > $sig_limits[7])
+						$limit_broke = $sig_limits[7] . 'px';
+					elseif ($matches[2][$ind] == 'pt' && $size > ($sig_limits[7] * 0.75))
+						$limit_broke = ((int) $sig_limits[7] * 0.75) . 'pt';
+					elseif ($matches[2][$ind] == 'em' && $size > ((float) $sig_limits[7] / 16))
+						$limit_broke = ((float) $sig_limits[7] / 16) . 'em';
+					elseif ($matches[2][$ind] != 'px' && $matches[2][$ind] != 'pt' && $matches[2][$ind] != 'em' && $sig_limits[7] < 18)
+						$limit_broke = 'large';
+
+					if ($limit_broke)
+						$sig = str_replace($matches[0][$ind], '[size=' . $sig_limits[7] . 'px', $sig);
+				}
+			}
+
+			// Stupid images - this is stupidly, stupidly challenging.
+			if ((!empty($sig_limits[3]) || !empty($sig_limits[5]) || !empty($sig_limits[6])))
+			{
+				$replaces = array();
+				$img_count = 0;
+
+				// Get all BBC tags...
+				preg_match_all('~\[img(\s+width=([\d]+))?(\s+height=([\d]+))?(\s+width=([\d]+))?\s*\](?:<br />)*([^<">]+?)(?:<br />)*\[/img\]~i', $sig, $matches);
+
+				// ... and all HTML ones.
+				preg_match_all('~&lt;img\s+src=(?:&quot;)?((?:http://|ftp://|https://|ftps://).+?)(?:&quot;)?(?:\s+alt=(?:&quot;)?(.*?)(?:&quot;)?)?(?:\s?/)?&gt;~i', $sig, $matches2, PREG_PATTERN_ORDER);
+
+				// And stick the HTML in the BBC.
+				if (!empty($matches2))
+				{
+					foreach ($matches2[0] as $ind => $dummy)
+					{
+						$matches[0][] = $matches2[0][$ind];
+						$matches[1][] = '';
+						$matches[2][] = '';
+						$matches[3][] = '';
+						$matches[4][] = '';
+						$matches[5][] = '';
+						$matches[6][] = '';
+						$matches[7][] = $matches2[1][$ind];
+					}
+				}
+
+				// Try to find all the images!
+				if (!empty($matches))
+				{
+					$image_count_holder = array();
+					foreach ($matches[0] as $key => $image)
+					{
+						$width = -1; $height = -1;
+						$img_count++;
+
+						// Too many images?
+						if (!empty($sig_limits[3]) && $img_count > $sig_limits[3])
+						{
+							// If we've already had this before we only want to remove the excess.
+							if (isset($image_count_holder[$image]))
+							{
+								$img_offset = -1;
+								$rep_img_count = 0;
+								while ($img_offset !== false)
+								{
+									$img_offset = strpos($sig, $image, $img_offset + 1);
+									$rep_img_count++;
+									if ($rep_img_count > $image_count_holder[$image])
+									{
+										// Only replace the excess.
+										$sig = substr($sig, 0, $img_offset) . str_replace($image, '', substr($sig, $img_offset));
+
+										// Stop looping.
+										$img_offset = false;
+									}
+								}
+							}
+							else
+								$replaces[$image] = '';
+
+							continue;
+						}
+
+						// Does it have predefined restraints? Width first.
+						if ($matches[6][$key])
+							$matches[2][$key] = $matches[6][$key];
+
+						if ($matches[2][$key] && $sig_limits[5] && $matches[2][$key] > $sig_limits[5])
+						{
+							$width = $sig_limits[5];
+							$matches[4][$key] = $matches[4][$key] * ($width / $matches[2][$key]);
+						}
+						elseif ($matches[2][$key])
+							$width = $matches[2][$key];
+
+						// ... and height.
+						if ($matches[4][$key] && $sig_limits[6] && $matches[4][$key] > $sig_limits[6])
+						{
+							$height = $sig_limits[6];
+							if ($width != -1)
+								$width = $width * ($height / $matches[4][$key]);
+						}
+						elseif ($matches[4][$key])
+							$height = $matches[4][$key];
+
+						// If the dimensions are still not fixed - we need to check the actual image.
+						if (($width == -1 && $sig_limits[5]) || ($height == -1 && $sig_limits[6]))
+						{
+							// We'll mess up with images, who knows.
+							require_once(SUBSDIR . '/Attachments.subs.php');
+
+							$sizes = url_image_size($matches[7][$key]);
+							if (is_array($sizes))
+							{
+								// Too wide?
+								if ($sizes[0] > $sig_limits[5] && $sig_limits[5])
+								{
+									$width = $sig_limits[5];
+									$sizes[1] = $sizes[1] * ($width / $sizes[0]);
+								}
+
+								// Too high?
+								if ($sizes[1] > $sig_limits[6] && $sig_limits[6])
+								{
+									$height = $sig_limits[6];
+									if ($width == -1)
+										$width = $sizes[0];
+									$width = $width * ($height / $sizes[1]);
+								}
+								elseif ($width != -1)
+									$height = $sizes[1];
+							}
+						}
+
+						// Did we come up with some changes? If so remake the string.
+						if ($width != -1 || $height != -1)
+							$replaces[$image] = '[img' . ($width != -1 ? ' width=' . round($width) : '') . ($height != -1 ? ' height=' . round($height) : '') . ']' . $matches[7][$key] . '[/img]';
+
+						// Record that we got one.
+						$image_count_holder[$image] = isset($image_count_holder[$image]) ? $image_count_holder[$image] + 1 : 1;
+					}
+
+					if (!empty($replaces))
+						$sig = str_replace(array_keys($replaces), array_values($replaces), $sig);
+				}
+			}
+
+			// Try to fix disabled tags.
+			if (!empty($disabledTags))
+			{
+				$sig = preg_replace('~\[(?:' . implode('|', $disabledTags) . ').+?\]~i', '', $sig);
+				$sig = preg_replace('~\[/(?:' . implode('|', $disabledTags) . ')\]~i', '', $sig);
+			}
+
+			$sig = strtr($sig, array("\n" => '<br />'));
+			call_integration_hook('integrate_apply_signature_settings', array(&$sig, $sig_limits, $disabledTags));
+			if ($sig != $row['signature'])
+				$changes[$row['id_member']] = $sig;
+		}
+
+		// Do we need to delete what we have?
+		if (!empty($changes))
+		{
+			foreach ($changes as $id => $sig)
+				updateSignature($id, $sig);
+		}
+
+		$applied_sigs += 50;
+		if (!$done)
+			pauseSignatureApplySettings($applied_sigs);
+	}
 }
 
 /**

--- a/sources/subs/ManageSearch.subs.php
+++ b/sources/subs/ManageSearch.subs.php
@@ -433,7 +433,7 @@ function removeCommonWordsFromIndex($start, $column_definition)
 		$db->free_result($request);
 
 		updateSettings(array('search_stopwords' => implode(',', $stop_words)));
-
+var_dump($stop_words);
 		if (!empty($stop_words))
 			$db->query('', '
 				DELETE FROM {db_prefix}log_search_words

--- a/sources/subs/ManageSearch.subs.php
+++ b/sources/subs/ManageSearch.subs.php
@@ -433,7 +433,7 @@ function removeCommonWordsFromIndex($start, $column_definition)
 		$db->free_result($request);
 
 		updateSettings(array('search_stopwords' => implode(',', $stop_words)));
-var_dump($stop_words);
+
 		if (!empty($stop_words))
 			$db->query('', '
 				DELETE FROM {db_prefix}log_search_words

--- a/sources/subs/RepairBoards.subs.php
+++ b/sources/subs/RepairBoards.subs.php
@@ -1350,7 +1350,7 @@ function pauseRepairProcess($to_fix, $current_step_description, $max_substep = 0
 	setTimeLimit(600);
 
 	// Errr, wait.  How much time has this taken already?
-	if (!$force && time() - array_sum(explode(' ', $time_start)) < 3)
+	if (!$force && microtime(true) - $time_start > 3)
 		return;
 
 	// Restore the query cache if interested.
@@ -1417,6 +1417,7 @@ function findForumErrors($do_fix = false)
 	// For all the defined error types do the necessary tests.
 	$current_step = -1;
 	$total_queries = 0;
+
 	foreach ($errorTests as $error_type => $test)
 	{
 		$current_step++;

--- a/sources/subs/SettingsForm.class.php
+++ b/sources/subs/SettingsForm.class.php
@@ -515,9 +515,13 @@ class Settings_Form
 	 *
 	 * @param mixed[] $config_vars
 	 */
-	public static function save_db(&$config_vars)
+	public static function save_db(&$config_vars, $post_object = null)
 	{
 		static $known_rules = null;
+
+		// Just look away if you have a weak stomach
+		if ($post_object !== null && is_object($post_object))
+			$_POST = array_replace($_POST, (array) $post_object);
 
 		if ($known_rules === null)
 			$known_rules = array(

--- a/themes/default/ManageLanguages.template.php
+++ b/themes/default/ManageLanguages.template.php
@@ -351,7 +351,7 @@ function template_modify_language_entries()
 
 		echo '
 				</ul>
-				<input type="submit" name="save_entries" value="', $txt['save'], '"', !empty($context['entries_not_writable_message']) ? ' disabled="disabled"' : '', ' class="button_submit" />
+				<input type="submit" name="save_entries" value="', $txt['save'], '"', !empty($context['entries_not_writable_message']) ? ' disabled="disabled"' : '', ' class="right_submit" />
 			</div>';
 	}
 


### PR DESCRIPTION
Not wanting to let @emanuele45 get to big a lead on how to break things, I present this PR :bomb: 

The general idea is to move all super global interaction out of the controllers, this PR addresses the admin controllers.

It makes use of a new http request class, that at the current time, is simply a getter of values, raw or sanitized (via the data validator), It does no setting of (super global) values at this time.  The existing super global s are copied to local objects during the start up, at that point you can freely read or write to the now "local" vars.

I removed all $_REQUEST calls in place of GET or POST (or ->query  and ->post now) so that execution paths are known.  I'd guess this was 20% of the calls used request, the rest used get or post already.  Of course in some instances it starts off in a get and moves to a post var, so some things may have broken here and there.

I also broke down just a few of the super long methods so they are just too long now :P ... but don't worry there are lots more to fix.  Some use of the global s was removed for use of class variables since there was no reason at all to be writing back to them anyway.. Any that's just a bonus in this PR, there is plenty of more to do.

Note since the class does not (yet?) write back to the super globals there are a couple of areas where you will still see them in use, notably $_SESSION setting was left in the controllers.  When it comes to writing the forms to the db good old save_db does the dirty deed for taking the "local" post object and merging it back to $_POST for processing.  That function should be updated as well I think, but thats another day.