### PR TITLE
Package server updates

### DIFF
--- a/install/install_1-0_mysql.sql
+++ b/install/install_1-0_mysql.sql
@@ -1554,7 +1554,7 @@ CREATE TABLE {$db_prefix}package_servers (
 
 INSERT INTO {$db_prefix}package_servers
 	(name, url)
-VALUES ('ElkArte Third-party Add-ons Site', 'https://github.com/elkarte/addons/tree/master/packages');
+VALUES ('ElkArte Third-party Add-ons Site', 'http://addons.elkarte.net/package.json');
 # --------------------------------------------------------
 
 #

--- a/install/install_1-0_postgresql.sql
+++ b/install/install_1-0_postgresql.sql
@@ -2070,7 +2070,7 @@ CREATE TABLE {$db_prefix}package_servers (
 
 INSERT INTO {$db_prefix}package_servers
 	(name, url)
-VALUES ('ElkArte Third-party Add-ons Site', 'https://github.com/elkarte/addons/tree/master/packages');
+VALUES ('ElkArte Third-party Add-ons Site', 'http://addons.elkarte.net/package.json');
 # --------------------------------------------------------
 
 #

--- a/install/upgrade_elk_1-0_mysql.sql
+++ b/install/upgrade_elk_1-0_mysql.sql
@@ -855,3 +855,20 @@ upgrade_query("
 	('avatar_upload_enabled', '1')");
 ---}
 ---#
+
+/******************************************************************************/
+--- Changes for 1.0.4
+/******************************************************************************/
+---# Update to new package server...
+---{
+upgrade_query("
+	UPDATE {$db_prefix}package_servers
+	SET url = {string:value}
+	WHERE name = {string:name}",
+	array(
+		'value' => 'http://addons.elkarte.net/package.json',
+		'name' => 'ElkArte Third-party Add-ons Site'
+	)
+);
+---}
+---#

--- a/install/upgrade_elk_1-0_postgresql.sql
+++ b/install/upgrade_elk_1-0_postgresql.sql
@@ -1020,3 +1020,20 @@ upgrade_query("
 	('avatar_upload_enabled', '1')");
 ---}
 ---#
+
+/******************************************************************************/
+--- Changes for 1.0.4
+/******************************************************************************/
+---# Update to new package server...
+---{
+upgrade_query("
+	UPDATE {$db_prefix}package_servers
+	SET url = {string:value}
+	WHERE name = {string:name}",
+	array(
+		'value' => 'http://addons.elkarte.net/package.json',
+		'name' => 'ElkArte Third-party Add-ons Site'
+	)
+);
+---}
+---#

--- a/sources/admin/PackageServers.controller.php
+++ b/sources/admin/PackageServers.controller.php
@@ -294,6 +294,9 @@ class PackageServers_Controller extends Action_Controller
 				}
 			}
 		}
+
+		// Good time to sort the categories, packages inside cats will be by last date.
+		asort($context['package_list']);
 /* @todo ... not sure we really want to do all this ... maybe ?
 		// Lets make sure we get a nice new spiffy clean $package to work with.  Otherwise we get PAIN!
 		unset($package);

--- a/sources/subs/Package.subs.php
+++ b/sources/subs/Package.subs.php
@@ -224,6 +224,8 @@ function loadInstalledPackages()
  */
 function getPackageInfo($gzfilename)
 {
+	$gzfilename = trim($gzfilename);
+
 	// Extract package-info.xml from downloaded file. (*/ is used because it could be in any directory.)
 	if (preg_match('~^https?://~i', $gzfilename) === 1)
 		$packageInfo = read_tgz_data(fetch_web_data($gzfilename, '', true), '*/package-info.xml', true);

--- a/themes/default/PackageServers.template.php
+++ b/themes/default/PackageServers.template.php
@@ -134,7 +134,6 @@ function template_package_list()
 	echo '
 	<div id="admincenter">
 		<h2 class="category_header">' . $context['page_title'] . '</h2>
-		<div class="windowbg">
 			<div class="content">';
 
 	// No packages, as yet.
@@ -148,6 +147,7 @@ function template_package_list()
 	{
 		echo '
 				<ul id="package_list">';
+
 		foreach ($context['package_list'] as $i => $packageSection)
 		{
 			echo '
@@ -167,32 +167,13 @@ function template_package_list()
 			{
 				echo '
 							<li>';
-				// Textual message. Could be empty just for a blank line...
-				if ($package['is_text'])
-					echo '
-								', empty($package['name']) ? '&nbsp;' : $package['name'];
-				// This is supposed to be a rule..
-				elseif ($package['is_line'])
-					echo '
-							<hr />';
-				// A remote link.
-				elseif ($package['is_remote'])
-					echo '
-							<strong>', $package['link'], '</strong>';
-				// A title?
-				elseif ($package['is_heading'] || $package['is_title'])
-					echo '
-							<strong>', $package['name'], '</strong>';
-				// Otherwise, it's a package.
-				else
-				{
 					// 1. Some addon [ Download ].
 					echo '
 							<strong><img id="ps_img_', $i, '_pkg_', $id, '" src="', $settings['images_url'], '/selected_open.png" alt="*" style="display: none;" /> ', $package['can_install'] ? '<strong>' . $package['name'] . '</strong> <a href="' . $package['download']['href'] . '">[ ' . $txt['download'] . ' ]</a>' : $package['name'];
 
 					// Mark as installed and current?
 					if ($package['is_installed'] && !$package['is_newer'])
-						echo '<img src="', $settings['images_url'], '/icons/package_', $package['is_current'] ? 'installed' : 'old', '.png" class="centericon" style="width: 12px; height: 11px; margin-left: 2ex;" alt="', $package['is_current'] ? $txt['package_installed_current'] : $txt['package_installed_old'], '" />';
+						echo '<img src="', $settings['images_url'], '/icons/package_', $package['is_current'] ? 'installed' : 'old', '.png" class="centericon package_img" alt="', $package['is_current'] ? $txt['package_installed_current'] : $txt['package_installed_old'], '" />';
 
 					echo '
 							</strong>
@@ -202,26 +183,47 @@ function template_package_list()
 					if ($package['type'] != '')
 						echo '
 								<li class="package_section">', $txt['package_type'], ':&nbsp; ', Util::ucwords(Util::strtolower($package['type'])), '</li>';
+
 					// Show the version number?
 					if ($package['version'] != '')
 						echo '
 								<li class="package_section">', $txt['mod_version'], ':&nbsp; ', $package['version'], '</li>';
-					// How 'bout the author?
-					if (!empty($package['author']) && $package['author']['name'] != '' && isset($package['author']['link']))
-						echo '
-								<li class="package_section">', $txt['mod_author'], ':&nbsp; ', $package['author']['link'], '</li>';
-					// The homepage....
-					if ($package['author']['website']['link'] != '')
-						echo '
-								<li class="package_section">', $txt['author_website'], ':&nbsp; ', $package['author']['website']['link'], '</li>';
 
-					// Description: bleh bleh!
+					// Show the last date?
+					if ($package['date'] != '')
+						echo '
+								<li class="package_section">', $txt['mod_date'], ':&nbsp; ', $package['date'], '</li>';
+
+					// How 'bout the author?
+					if (!empty($package['author']))
+						echo '
+								<li class="package_section">', $txt['mod_author'], ':&nbsp; ', $package['author'], '</li>';
+
+					// Nothing but hooks ?
+					if ($package['hooks'] != '' && in_array($package['hooks'] , array('yes', 'true')))
+						echo '
+								<li class="package_section">', $txt['mod_hooks'], ' <i class="fa fa-check-circle-o"></i></li>';
+
 					// Location of file: http://someplace/.
 					echo '
-								<li class="package_section">', $txt['file_location'], ':&nbsp; <a href="', $package['href'], '">', $package['href'], '</a></li>
-								<li class="package_section"><div class="information">', $txt['package_description'], ':&nbsp; ', $package['description'], '</div></li>
+								<ul style="margin-left: 5em">
+									<li class="package_section"><i class="fa fa-cloud-download"></i> ', $txt['file_location'], ':&nbsp; <a href="', $package['server']['download'], '">', $package['server']['download'], '</a></li>';
+
+					// Location of issues?
+					if (!empty($package['server']['bugs']))
+						echo '
+									<li class="package_section"><i class="fa fa-bug"></i> ', $txt['bug_location'], ':&nbsp; <a href="', $package['server']['bugs'], '">', $package['server']['bugs'], '</a></li>';
+
+					// Location of support?
+					if (!empty($package['server']['support']))
+						echo '
+									<li class="package_section"><i class="fa fa-support"></i> ', $txt['support_location'], ':&nbsp; <a href="', $package['server']['support'], '">', $package['server']['support'], '</a></li>';
+
+					// Description: bleh bleh!
+					echo '
+								</ul>
+								<li class="package_section"><div class="infobox">', $txt['package_description'], ':&nbsp; ', $package['description'], '</div></li>
 							</ul>';
-				}
 
 				$alt = !$alt;
 				echo '
@@ -238,7 +240,6 @@ function template_package_list()
 	}
 
 	echo '
-			</div>
 		</div>
 		<div>
 			', $txt['package_installed_key'], '
@@ -250,7 +251,6 @@ function template_package_list()
 	// Now go through and turn off / collapse all the sections.
 	if (!empty($context['package_list']))
 	{
-		$section_count = count($context['package_list']);
 		echo '
 			<script><!-- // --><![CDATA[';
 		foreach ($context['package_list'] as $section => $ps)
@@ -258,7 +258,7 @@ function template_package_list()
 			echo '
 				var oPackageServerToggle_', $section, ' = new elk_Toggle({
 					bToggleEnabled: true,
-					bCurrentlyCollapsed: ', count($ps['items']) == 1 || $section_count == 1 ? 'false' : 'true', ',
+					bCurrentlyCollapsed: true,
 					aSwappableContainers: [
 						\'package_section_', $section, '\'
 					],
@@ -275,8 +275,7 @@ function template_package_list()
 
 			foreach ($ps['items'] as $id => $package)
 			{
-				if (!$package['is_text'] && !$package['is_line'] && !$package['is_remote'])
-					echo '
+				echo '
 				var oPackageToggle_', $section, '_pkg_', $id, ' = new elk_Toggle({
 					bToggleEnabled: true,
 					bCurrentlyCollapsed: true,
@@ -295,6 +294,7 @@ function template_package_list()
 				});';
 			}
 		}
+
 		echo '
 			// ]]></script>';
 	}

--- a/themes/default/PackageServers.template.php
+++ b/themes/default/PackageServers.template.php
@@ -36,70 +36,72 @@ function template_servers()
 		template_ftp_form_required();
 
 	echo '
-		<div class="windowbg2">
-			<div class="content">
-				<fieldset>
-					<legend>' . $txt['package_servers'] . '</legend>
-					<ul class="package_servers">';
+		<div class="content">
+			<fieldset>
+				<legend>' . $txt['package_servers'] . '</legend>
+				<ul class="package_servers">';
 
 	foreach ($context['servers'] as $server)
 		echo '
-						<li class="flow_auto">
-							<span class="floatleft">' . $server['name'] . '</span>
-							<span class="package_server floatright"><a href="' . $scripturl . '?action=admin;area=packageservers;sa=remove;server=' . $server['id'] . ';', $context['session_var'], '=', $context['session_id'], '">[ ' . $txt['delete'] . ' ]</a></span>
-							<span class="package_server floatright"><a href="' . $scripturl . '?action=admin;area=packageservers;sa=browse;server=' . $server['id'] . '">[ ' . $txt['package_browse'] . ' ]</a></span>
-						</li>';
+					<li class="flow_auto">
+						<strong>' . $server['name'] . '</strong>
+						<span class="package_server floatright">
+							<a class="linkbutton" href="' . $scripturl . '?action=admin;area=packageservers;sa=browse;server=' . $server['id'] . '">' . $txt['package_browse'] . '</a>
+							&nbsp;<a class="linkbutton" href="' . $scripturl . '?action=admin;area=packageservers;sa=remove;server=' . $server['id'] . ';', $context['session_var'], '=', $context['session_id'], '">' . $txt['delete'] . '</a>
+						</span>
+					</li>';
 
 	echo '
-					</ul>
-				</fieldset>
-				<fieldset>
-					<legend>' . $txt['add_server'] . '</legend>
-					<form action="' . $scripturl . '?action=admin;area=packageservers;sa=add" method="post" accept-charset="UTF-8">
-						<dl class="settings">
-							<dt>
-								<strong><label for="servername">' . $txt['server_name'] . '</label>:</strong>
-							</dt>
-							<dd>
-								<input type="text" id="servername" name="servername" size="44" value="ElkArte" class="input_text" />
-							</dd>
-							<dt>
-								<strong><label for="serverurl">' . $txt['serverurl'] . '</label>:</strong>
-							</dt>
-							<dd>
-								<input type="text" id="serverurl" name="serverurl" size="44" value="http://" class="input_text" />
-							</dd>
-						</dl>
-						<div class="submitbutton">
-							<input type="submit" value="' . $txt['add_server'] . '" class="button_submit" />
-							<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />
-						</div>
-					</form>
-				</fieldset>
-				<fieldset>
-					<legend>', $txt['package_download_by_url'], '</legend>
-					<form action="', $scripturl, '?action=admin;area=packageservers;sa=download;byurl;', $context['session_var'], '=', $context['session_id'], '" method="post" accept-charset="UTF-8">
-						<dl class="settings">
-							<dt>
-								<strong><label for="package">' . $txt['serverurl'] . '</label>:</strong>
-							</dt>
-							<dd>
-								<input type="text" id="package" name="package" size="44" value="http://" class="input_text" />
-							</dd>
-							<dt>
-								<strong><label for="filename">', $txt['package_download_filename'], '</label>:</strong>
-							</dt>
-							<dd>
-								<input type="text" id="filename" name="filename" size="44" class="input_text" /><br />
-								<span class="smalltext">', $txt['package_download_filename_info'], '</span>
-							</dd>
-						</dl>
-						<div class="submitbutton">
-							<input type="submit" value="', $txt['download'], '" class="button_submit" />
-						</div>
-					</form>
-				</fieldset>
-			</div>
+				</ul>
+			</fieldset>
+			<fieldset>
+				<legend>' . $txt['add_server'] . '</legend>
+				<form action="' . $scripturl . '?action=admin;area=packageservers;sa=add" method="post" accept-charset="UTF-8">
+					<dl class="settings">
+						<dt>
+							<strong><label for="servername">' . $txt['server_name'] . '</label>:</strong>
+						</dt>
+						<dd>
+							<input type="text" id="servername" name="servername" size="44" value="ElkArte" class="input_text" />
+						</dd>
+						<dt>
+							<strong><label for="serverurl">' . $txt['serverurl'] . '</label>:</strong>
+						</dt>
+						<dd>
+							<input type="text" id="serverurl" name="serverurl" size="44" value="http://" class="input_text" />
+						</dd>
+					</dl>
+					<div class="submitbutton">
+						<input type="submit" value="' . $txt['add_server'] . '" class="button_submit" />
+						<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />
+					</div>
+				</form>
+			</fieldset>
+			<fieldset>
+				<legend>', $txt['package_download_by_url'], '</legend>
+				<form action="', $scripturl, '?action=admin;area=packageservers;sa=download" method="post" accept-charset="UTF-8">
+					<dl class="settings">
+						<dt>
+							<strong><label for="package">' . $txt['serverurl'] . '</label>:</strong>
+						</dt>
+						<dd>
+							<input type="text" id="package" name="package" size="44" value="http://" class="input_text" />
+						</dd>
+						<dt>
+							<strong><label for="filename">', $txt['package_download_filename'], '</label>:</strong>
+						</dt>
+						<dd>
+							<input type="text" id="filename" name="filename" size="44" class="input_text" /><br />
+							<span class="smalltext">', $txt['package_download_filename_info'], '</span>
+						</dd>
+					</dl>
+					<div class="submitbutton">
+						<input type="submit" value="', $txt['download'], '" class="button_submit" />
+						<input type="hidden" value="byurl" name="byurl" />
+						<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />
+					</div>
+				</form>
+			</fieldset>
 		</div>
 	</div>';
 }
@@ -152,14 +154,18 @@ function template_package_list()
 		{
 			echo '
 					<li>
-						<img id="ps_img_', $i, '" src="', $settings['images_url'], '/collapse.png" class="floatright" alt="*" style="display: none;" /><strong>', $packageSection['title'], '</strong>';
+						<span class="package_toggle">&nbsp;
+							<span id="ps_img_', $i, '" class="collapse" style="display: none;" title="', $txt['hide'], '"></span>
+						</span>
+						<a href="#" id="upshrink_link_', $i, '" class="highlight">', $packageSection['title'], '</a>';
 
 			if (!empty($packageSection['text']))
 				echo '
-						<div class="information">', $packageSection['text'], '</div>';
+						<div class="content">', $packageSection['text'], '</div>';
 
+			// List of addons available in this section
 			echo '
-						<', $context['list_type'], ' id="package_section_', $i, '" class="packages">';
+						<ol id="package_section_', $i, '" class="packages">';
 
 			$alt = false;
 
@@ -169,7 +175,9 @@ function template_package_list()
 							<li>';
 					// 1. Some addon [ Download ].
 					echo '
-							<strong><img id="ps_img_', $i, '_pkg_', $id, '" src="', $settings['images_url'], '/selected_open.png" alt="*" style="display: none;" /> ', $package['can_install'] ? '<strong>' . $package['name'] . '</strong> <a href="' . $package['download']['href'] . '">[ ' . $txt['download'] . ' ]</a>' : $package['name'];
+							<strong>
+								<img id="ps_img_', $i, '_pkg_', $id, '" src="', $settings['images_url'], '/selected_open.png" alt="*" style="display: none;" /> ',
+								$package['can_install'] ? '<strong>' . $package['name'] . '</strong> <a class="linkbutton" href="' . $package['download']['href'] . '">' . $txt['download'] . '</a>' : $package['name'];
 
 					// Mark as installed and current?
 					if ($package['is_installed'] && !$package['is_newer'])
@@ -231,7 +239,7 @@ function template_package_list()
 			}
 
 			echo '
-					</', $context['list_type'], '>
+					</ol>
 						</li>';
 		}
 
@@ -262,13 +270,20 @@ function template_package_list()
 					aSwappableContainers: [
 						\'package_section_', $section, '\'
 					],
-					aSwapImages: [
+					aSwapClasses: [
 						{
 							sId: \'ps_img_', $section, '\',
-							srcExpanded: elk_images_url + \'/collapse.png\',
-							altExpanded: \'*\',
-							srcCollapsed: elk_images_url + \'/expand.png\',
-							altCollapsed: \'*\'
+							classExpanded: \'collapse\',
+							titleExpanded: ', JavaScriptEscape($txt['hide']), ',
+							classCollapsed: \'expand\',
+							titleCollapsed: ', JavaScriptEscape($txt['show']), '
+						}
+					],
+					aSwapLinks: [
+						{
+							sId: \'upshrink_link_', $section, '\',
+							msgExpanded: ', JavaScriptEscape($ps['title']), ',
+							msgCollapsed: ', JavaScriptEscape($ps['title']), '
 						}
 					]
 				});';

--- a/themes/default/css/admin.css
+++ b/themes/default/css/admin.css
@@ -394,6 +394,7 @@ div.quick_tasks {
 #package_list ol ul, #package_list ol ul li {
 	margin-left: 0;
 	list-style: none;
+	border-radius: 3px;
 }
 #package_list {
 	list-style-type: none;
@@ -426,6 +427,11 @@ div.quick_tasks {
 }
 .package_server {
 	padding: 0 3em;
+}
+.package_image {
+	width: 12px;
+	height: 11px;
+	margin-left: 2ex;
 }
 ul.package_servers {
 	margin: 0;

--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -484,14 +484,14 @@ h2 a.collapse {
 }
 
 /* Upshrink image in the general category headers */
-#category_toggle, #category_toggle_more, #upshrink_header {
+#category_toggle, #category_toggle_more, #upshrink_header, .package_toggle {
 	display: block;
 	float: right;
 	padding: 0 16px;
 	overflow: hidden;
 	position: relative;
 }
-#category_toggle span, #category_toggle_more span, #upshrink_header span {
+#category_toggle span, #category_toggle_more span, #upshrink_header span, .package_toggle span {
 	background-repeat: no-repeat;
 	background-image: url(../images/_light/expcol.png);
 	position: absolute;

--- a/themes/default/languages/english/Packages.english.php
+++ b/themes/default/languages/english/Packages.english.php
@@ -49,7 +49,11 @@ $txt['mod_author'] = 'Author';
 $txt['author_website'] = 'Author\'s Homepage';
 $txt['package_no_description'] = 'No description given';
 $txt['package_description'] = 'Description';
-$txt['file_location'] = 'Location of file';
+$txt['file_location'] = 'Download';
+$txt['bug_location'] = 'Issue tracker';
+$txt['support_location'] = 'Support';
+$txt['mod_hooks'] = 'No source edits';
+$txt['mod_date'] = 'Last updated';
 
 $txt['package_installed_key'] = 'Installed addons:';
 $txt['package_installed_current'] = 'current version';

--- a/themes/default/languages/english/Packages.english.php
+++ b/themes/default/languages/english/Packages.english.php
@@ -54,6 +54,7 @@ $txt['bug_location'] = 'Issue tracker';
 $txt['support_location'] = 'Support';
 $txt['mod_hooks'] = 'No source edits';
 $txt['mod_date'] = 'Last updated';
+$txt['mod_section_count'] = 'Browse the (%1d) addons in this section';
 
 $txt['package_installed_key'] = 'Installed addons:';
 $txt['package_installed_current'] = 'current version';


### PR DESCRIPTION
First steps on fixing #1876

The yaml front matter on the addon site should have a new tag added to them for best support, otherwise it may not correctly identify a package as installed from this interface.
`pkid: "same as the package id in the xml file`
which is generall along the lines of
`pkid: "Author:XYZ"`