### PR TITLE
fix #2077 no preview, scroll error box to top, on post2 error

### DIFF
--- a/sources/controllers/Memberlist.controller.php
+++ b/sources/controllers/Memberlist.controller.php
@@ -454,7 +454,7 @@ class Memberlist_Controller extends Action_Controller
 
 			$customJoin = array();
 			$customCount = 10;
-			$validFields = array();
+			$validFields = isset($input_fields) ? $input_fields : array();
 
 			// Any custom fields to search for - these being tricky?
 			foreach ($input_fields as $field)
@@ -472,6 +472,7 @@ class Memberlist_Controller extends Action_Controller
 			if (empty($fields))
 				redirectexit('action=memberlist');
 
+			$validFields = array_unique($validFields);
 			$query = $search == '' ? '= {string:blank_string}' : (defined('DB_CASE_SENSITIVE') ? 'LIKE LOWER({string:search})' : 'LIKE {string:search}');
 			$where = implode(' ' . $query . ' OR ', $fields) . ' ' . $query . $condition;
 

--- a/sources/controllers/Post.controller.php
+++ b/sources/controllers/Post.controller.php
@@ -1210,7 +1210,12 @@ class Post_Controller extends Action_Controller
 			// If the number of replies has changed, if the setting is enabled, go back to action_post() - which handles the error.
 			if (empty($options['no_new_reply_warning']) && isset($_POST['last_msg']) && $topic_info['id_last_msg'] > $_POST['last_msg'])
 			{
-				$_REQUEST['preview'] = true;
+				addInlineJavascript('
+					$(document).ready(function () {
+						$("html,body").scrollTop($(\'.category_header:visible:first\').offset().top);
+					});'
+				);
+
 				return $this->action_post();
 			}
 
@@ -1475,8 +1480,11 @@ class Post_Controller extends Action_Controller
 		// Any mistakes?
 		if ($post_errors->hasErrors() || $attach_errors->hasErrors())
 		{
-			// Previewing.
-			$_REQUEST['preview'] = true;
+			addInlineJavascript('
+				$(document).ready(function () {
+					$("html,body").scrollTop($(\'.category_header:visible:first\').offset().top);
+				});'
+			);
 
 			return $this->action_post();
 		}


### PR DESCRIPTION
Removed the preview call, added a JS scroll to the top of the error box, really the category header, so its in yer face.

I did not clean up all those return $this->action_post(); which should not have the return on them, more for 1.1 unless they were done already.

