### PR TITLE
Fixed package id of the 1.0.4 patch

### DIFF
--- a/install/patch_1-0-4/package-info.xml
+++ b/install/patch_1-0-4/package-info.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <!DOCTYPE package-info SYSTEM "http://www.elkarte.net/site/package-info">
 <package-info xmlns="http://www.elkarte.net/site/package-info" xmlns:elk="http://www.elkarte.net/">
-	<id>Elkarte Contributors:ElkArte_103_patch</id>
+	<id>Elkarte Contributors:ElkArte_104_patch</id>
 	<name>ElkArte 1.0.4 patch</name>
-	<version>1.0</version>
+	<version>1.0.1</version>
 	<type>modification</type>
 		<install for="1.0.3">
 			<modification>modifications.xml</modification>


### PR DESCRIPTION
Post-release fix, I would avoid call it 1.0.5 or repeat the 1.0.4 release as "b" just for that, I guess bring it to 1.0.5 is good enough. :innocent: 