### PR TITLE
Fixed #2146 - undefined index in Poll module as guest

### DIFF
--- a/sources/modules/Poll/PollDisplayModule.class.php
+++ b/sources/modules/Poll/PollDisplayModule.class.php
@@ -59,7 +59,7 @@ class Poll_Display_Module implements ElkArte\sources\modules\Module_Interface
 			'can_remove_poll' => 'poll_remove',
 		);
 		foreach ($anyown_permissions as $contextual => $perm)
-			$context[$contextual] = allowedTo($perm . '_any') || ($context['user']['started'] && allowedTo($perm . '_own'));
+			$context[$contextual] = allowedTo($perm . '_any') || (allowedTo($perm . '_own') && $context['user']['started']);
 
 		$context['can_add_poll'] &= self::$_enabled && $topicinfo['id_poll'] <= 0;
 		$context['can_remove_poll'] &= self::$_enabled && $topicinfo['id_poll'] > 0;


### PR DESCRIPTION
Swapped the user context key to the other side of the && operator. PHP checks the allowedTo function, fails for guests, and no longer proceeds with the && operation, alleviating the issue.