### PR TITLE
For Review

### DIFF
--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -947,9 +947,9 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			),
 			array(
 				'tag' => 'center',
-				'before' => '<div class="centertext">',
-				'after' => '</div>',
-				'block_level' => true,
+				'before' => '<span style="display:block" class="centertext">',
+				'after' => '</span>',
+				'block_level' => false,
 			),
 			array(
 				'tag' => 'code',

--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -683,47 +683,86 @@ function un_htmlspecialchars($string)
  * - A combinations without repetition N! function so 3! = 6 and 10! = 3,628,800 combinations
  * - Used by parse_bbc to allow bbc tag parameters to be in any order and still be
  * parsed properly
- * - Caution: If passed > 8 (default) elements, will only permute the first 8 and append on the remaining elements
- * as such it will not return a proper N!
  *
+ * @deprecated since 1.0.5
  * @param mixed[] $array index array of values
- * @param int $max maximum sized array to allow, 9 will require ~ 225M, 10 ~ 2G of memory
- *
- * @return mixed[] array representing all premutations of the supplied array
+ * @return mixed[] array representing all permutations of the supplied array
  */
-function permute($array, $max = 8)
+function permute($array)
 {
 	$orders = array($array);
-	$append = false;
 
-	// Check if this will require more memory than available
 	$n = count($array);
-	if ($n > $max)
-	{
-		// Only permute the first "max" array elements and then append on the remaining
-		// @todo temporary measure to prevent wsod, needs to be properly handled
-		$append = array_slice($array, $max, $n);
-		$array = array_slice($array, 0, $max);
-		$n = $max;
-	}
-
 	$p = range(0, $n);
 	for ($i = 1; $i < $n; null)
 	{
 		$p[$i]--;
-		$j = ($i % 2 !== 0) ? $p[$i] : 0;
+		$j = $i % 2 != 0 ? $p[$i] : 0;
 
 		$temp = $array[$i];
 		$array[$i] = $array[$j];
 		$array[$j] = $temp;
 
-		for ($i = 1; $p[$i] === 0; $i++)
+		for ($i = 1; $p[$i] == 0; $i++)
 			$p[$i] = $i;
 
-		$orders[] = $append ? array_merge($array, $append) : $array;
+		$orders[] = $array;
 	}
 
 	return $orders;
+}
+
+/**
+ * Lexicographic permutation function.
+ *
+ * This is a special type of permutation which involves the order of the set. The next
+ * lexicographic permutation of '32541' is '34125'. Numerically, it is simply the smallest
+ * set larger than the current one.
+ *
+ * The benefit of this over a recursive solution is that the whole list does NOT need
+ * to be held in memory. So it's actually possible to run 30! permutations without
+ * causing a memory overflow.
+ *
+ * Source: O'Reilly PHP Cookbook
+ *
+ * @param mixed[] $p
+ * @param int $size
+ *
+ * @return mixed[] the next permutation of the passed array $p
+ */
+function pc_next_permutation($p, $size)
+{
+	// Slide down the array looking for where we're smaller than the next guy
+	for ($i = $size - 1; isset($p[$i]) && $p[$i] >= $p[$i + 1]; --$i)
+	{
+	}
+
+	// If this doesn't occur, we've finished our permutations
+	// the array is reversed: (1, 2, 3, 4) => (4, 3, 2, 1)
+	if ($i === -1)
+	{
+		return false;
+	}
+
+	// Slide down the array looking for a bigger number than what we found before
+	for ($j = $size; $p[$j] <= $p[$i]; --$j)
+	{
+	}
+
+	// Swap them
+	$tmp = $p[$i];
+	$p[$i] = $p[$j];
+	$p[$j] = $tmp;
+
+	// Now reverse the elements in between by swapping the ends
+	for (++$i, $j = $size; $i < $j; ++$i, --$j)
+	{
+		$tmp = $p[$i];
+		$p[$i] = $p[$j];
+		$p[$j] = $tmp;
+	}
+
+	return $p;
 }
 
 /**
@@ -1160,7 +1199,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			array(
 				'tag' => 'quote',
 				'parameters' => array(
-					'author' => array('match' => '(.{1,192}?)'),
+					'author' => array('match' => '(.{1,192}?\]?)'),
 				),
 				'before' => '<div class="quoteheader">' . $txt['quote_from'] . ': {author}</div><blockquote>',
 				'after' => '</blockquote>',
@@ -1738,20 +1777,31 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			// This is long, but it makes things much easier and cleaner.
 			if (!empty($possible['parameters']))
 			{
+				// Build a regular expression for each parameter for the current tag
 				$preg = array();
 				foreach ($possible['parameters'] as $p => $info)
 					$preg[] = '(\s+' . $p . '=' . (empty($info['quoted']) ? '' : '&quot;') . (isset($info['match']) ? $info['match'] : '(.+?)') . (empty($info['quoted']) ? '' : '&quot;') . ')' . (empty($info['optional']) ? '' : '?');
 
 				// Okay, this may look ugly and it is, but it's not going to happen much and it is the best way
 				// of allowing any order of parameters but still parsing them right.
-				$match = false;
-				$orders = permute($preg);
-				foreach ($orders as $p)
-					if (preg_match('~^' . implode('', $p) . '\]~i', substr($message, $pos1 - 1), $matches) != 0)
-					{
-						$match = true;
-						break;
-					}
+				$param_size = count($preg) - 1;
+				$preg_keys = range(0, $param_size);
+				$message_stub = substr($message, $pos1 - 1);
+
+				// If an addon adds many parameters we can exceed max_execution time, lets prevent that
+				// 5040 = 7, 40,320 = 8, (N!) etc
+				$max_iterations = 5040;
+
+				// Step, one by one, through all possible permutations of the parameters until we have a match
+				do {
+					$match_preg = '~^';
+					foreach ($preg_keys as $key)
+						$match_preg .= $preg[$key];
+					$match_preg .= '\]~i';
+
+					// Check if this combination of parameters matches the user input
+					$match = preg_match($match_preg, $message_stub, $matches) !== 0;
+				} while (!$match && --$max_iterations && ($preg_keys = pc_next_permutation($preg_keys, $param_size)));
 
 				// Didn't match our parameter list, try the next possible.
 				if (!$match)

--- a/sources/controllers/PersonalMessage.controller.php
+++ b/sources/controllers/PersonalMessage.controller.php
@@ -887,7 +887,7 @@ class PersonalMessage_Controller extends Action_Controller
 		{
 			// Set everything up to be displayed.
 			$context['preview_subject'] = Util::htmlspecialchars($_REQUEST['subject']);
-			$context['preview_message'] = Util::htmlspecialchars($_REQUEST['message'], ENT_QUOTES);
+			$context['preview_message'] = Util::htmlspecialchars($_REQUEST['message'], ENT_QUOTES, 'UTF-8', true);
 			preparsecode($context['preview_message'], true);
 
 			// Parse out the BBC if it is enabled.
@@ -2595,7 +2595,7 @@ function messagePostError($named_recipients, $recipient_ids = array())
 
 	// Set everything up like before....
 	$context['subject'] = isset($_REQUEST['subject']) ? Util::htmlspecialchars($_REQUEST['subject']) : '';
-	$context['message'] = isset($_REQUEST['message']) ? str_replace(array('  '), array('&nbsp; '), Util::htmlspecialchars($_REQUEST['message'])) : '';
+	$context['message'] = isset($_REQUEST['message']) ? str_replace(array('  '), array('&nbsp; '), Util::htmlspecialchars($_REQUEST['message'], ENT_QUOTES, 'UTF-8', true)) : '';
 	$context['reply'] = !empty($_REQUEST['replied_to']);
 
 	// If this is a reply to message, we need to reload the quote

--- a/sources/controllers/Post.controller.php
+++ b/sources/controllers/Post.controller.php
@@ -391,7 +391,7 @@ class Post_Controller extends Action_Controller
 
 			// Set up the inputs for the form.
 			$form_subject = strtr(Util::htmlspecialchars($_REQUEST['subject']), array("\r" => '', "\n" => '', "\t" => ''));
-			$form_message = Util::htmlspecialchars($_REQUEST['message'], ENT_QUOTES);
+			$form_message = Util::htmlspecialchars($_REQUEST['message'], ENT_QUOTES, 'UTF-8', true);
 
 			// Make sure the subject isn't too long - taking into account special characters.
 			if (Util::strlen($form_subject) > 100)
@@ -1398,7 +1398,7 @@ class Post_Controller extends Action_Controller
 		else
 		{
 			// Prepare the message a bit for some additional testing.
-			$_POST['message'] = Util::htmlspecialchars($_POST['message'], ENT_QUOTES);
+			$_POST['message'] = Util::htmlspecialchars($_POST['message'], ENT_QUOTES, 'UTF-8', true);
 
 			// Preparse code. (Zef)
 			if ($user_info['is_guest'])
@@ -2065,7 +2065,7 @@ class Post_Controller extends Action_Controller
 			}
 			else
 			{
-				$_POST['message'] = Util::htmlspecialchars($_POST['message'], ENT_QUOTES);
+				$_POST['message'] = Util::htmlspecialchars($_POST['message'], ENT_QUOTES, 'UTF-8', true);
 
 				preparsecode($_POST['message']);
 

--- a/sources/ext/bad-behavior/badbehavior-plugin.php
+++ b/sources/ext/bad-behavior/badbehavior-plugin.php
@@ -190,10 +190,13 @@ function bb2_insert($settings, $package, $key)
 		foreach ($package['request_entity'] as $h => $v)
 		{
 			if (is_array($v))
-				$v = bb2_multi_implode(' | ', $v);
+				$v = bb2_multi_implode($v, ' | ');
 
 			$request_entity .= bb2_db_escape("$h: $v\n");
 		}
+
+		// Only such much space in this column, so brutally cut it
+		// @todo in 1.1 improve logging or drop this?
 		$request_entity = substr($request_entity, 0, 254);
 	}
 
@@ -204,19 +207,27 @@ function bb2_insert($settings, $package, $key)
 }
 
 /**
- * Recursive implode for multi-dimensional arrays
+ * Implode that is multi dimensional array aware
  *
- * @param string $glue
- * @param mixed[] $array
+ * - Recursively calls itself to return a single string from a multi dimensional
+ * array
+ *
+ * @param mixed[] $array array to recursively implode
+ * @param string $glue value that glues elements together
+ * @param bool $trim_all trim ALL whitespace from string
+ *
  * @return string
  */
-function bb2_multi_implode($glue, $array)
+function bb2_multi_implode($array, $glue = ',', $trim_all = false)
 {
-	foreach ($array as $h => $v)
+	foreach ($array as $key => $value)
 	{
-		if (is_array($v))
-			$array[$h] = bb2_multi_implode($v);
+		if (is_array($value))
+			$array[$key] = bb2_multi_implode($value, $glue, $trim_all);
 	}
+
+	if ($trim_all)
+		$array = array_map('trim', $array);
 
 	return implode($glue, $array);
 }

--- a/sources/subs/Drafts.subs.php
+++ b/sources/subs/Drafts.subs.php
@@ -462,7 +462,7 @@ function saveDraft()
 		'locked' => isset($_POST['lock']) ? (int) $_POST['lock'] : 0,
 		'sticky' => isset($_POST['sticky']) && !empty($modSettings['enableStickyTopics']) ? (int) $_POST['sticky'] : 0,
 		'subject' => strtr(Util::htmlspecialchars($_POST['subject']), array("\r" => '', "\n" => '', "\t" => '')),
-		'body' => Util::htmlspecialchars($_POST['message'], ENT_QUOTES),
+		'body' => Util::htmlspecialchars($_POST['message'], ENT_QUOTES, 'UTF-8', true),
 		'id_member' => $user_info['id'],
 	);
 
@@ -566,7 +566,7 @@ function savePMDraft($recipientList)
 	$draft = array(
 		'id_pm_draft' => $id_pm_draft,
 		'reply_id' => empty($_POST['replied_to']) ? 0 : (int) $_POST['replied_to'],
-		'body' => Util::htmlspecialchars($_POST['message'], ENT_QUOTES),
+		'body' => Util::htmlspecialchars($_POST['message'], ENT_QUOTES, 'UTF-8', true),
 		'subject' => strtr(Util::htmlspecialchars($_POST['subject']), array("\r" => '', "\n" => '', "\t" => '')),
 		'id_member' => $user_info['id'],
 	);

--- a/sources/subs/PersonalMessage.subs.php
+++ b/sources/subs/PersonalMessage.subs.php
@@ -526,7 +526,7 @@ function sendpm($recipients, $subject, $message, $store_outbox = true, $from = n
 		$user_info['name'] = $from['name'];
 
 	// This is the one that will go in their inbox.
-	$htmlmessage = Util::htmlspecialchars($message, ENT_QUOTES);
+	$htmlmessage = Util::htmlspecialchars($message, ENT_QUOTES, 'UTF-8', true);
 	preparsecode($htmlmessage);
 	$htmlsubject = strtr(Util::htmlspecialchars($subject), array("\r" => '', "\n" => '', "\t" => ''));
 	if (Util::strlen($htmlsubject) > 100)

--- a/sources/subs/Post.subs.php
+++ b/sources/subs/Post.subs.php
@@ -219,11 +219,10 @@ function preparsetable($message)
 
 	// Define the allowable tags after a give tag
 	$table_order = array(
-		'table' => 'td',
-		'table' => 'th',
-		'tr' => 'table',
-		'td' => 'tr',
-		'th' => 'tr',
+		'table' => array('tr'),
+		'tr' => array('td', 'th'),
+		'td' => array('table'),
+		'th' => array(''),
 	);
 
 	// Find all closing tags (/table /tr /td etc)
@@ -237,7 +236,7 @@ function preparsetable($message)
 		if ($matches[1] != '/')
 		{
 			// If the previous table tag isn't correct simply remove it.
-			if ((!empty($table_array) && $table_array[0] != $table_order[$matches[2]]) || (empty($table_array) && $matches[2] != 'table'))
+			if ((!empty($table_array) && !in_array($matches[2], $table_order[$table_array[0]])) || (empty($table_array) && $matches[2] != 'table'))
 				$remove_tag = true;
 			// Record this was the last tag.
 			else


### PR DESCRIPTION
Some potentially controversial :bomb: things here so proceed with caution :skull: 

1) https://github.com/elkarte/Elkarte/commit/b0f48e8928d7acea7a352ef6defc3db8b4a9e104 Fix and depreciate the permute function.  It was not returning the correct N! results, now it does but it can be dangerous to addon authors and sites in general.

2) https://github.com/elkarte/Elkarte/commit/2363cab836b490645ebec41c13d0b140b5b71dfa Add a  new permute function to allow returning of sets in place of the old function which had to compute a complete solution before returning which for sets > 3 would start to consume memory very quickly.  

This new function should be speed transparent for 99+% of real world usage,  but it will allow a larger parameter list without memory exhaustion unlike the original.  It has clamp value to prevent max execution time issues as well.  Set up to work fully through 7 parameters, the old function did not work past 3 (pre fix) and would likely run in to memory issues at 7 parameters on low cost shared hosting.

 3) https://github.com/elkarte/Elkarte/commit/e7448637adc6247c5e70e10dcdb7990965e2bd61 The "second" table repair function was over writing the keys (my dumb mistake, thank you very much) plus the allowed tag nesting definition did not seem correct.  Generally this error did not show up as preparse does most of the table repair *cough* however preparse would / could mess up tables with code in cells, and other edge cases, which this function either fixes or infuriates the user.

4) https://github.com/elkarte/Elkarte/commit/23cf58bd0261d199f015cd93d1b89b470e1c913c One thing we often see is ```[b][i][center] bla [/center][/i][/b]``` which does not render correctly since center is a block level tag :triumph:, yeah try explaining that to the end user :tomato: 

So I changed that to not be block level and used a span with display:block, yes I know, but if someone has other ideas let me know.  The change allows the above to render, as well as things like ```[size=14pt][center]TEST[/center][/size]``` etc.  

Defined as not a block for the parser simply allows it to be nested inside other tags.  The HTML that is output is span span /span /span (which I believe is valid, ie nested spans, vs a span div /div /span which would not be valid.  

5) Multi implode was on recursion passing the value as the glue, so I fixed that and added a trim function as well.

6) https://github.com/elkarte/Elkarte/commit/ffa8263452174a3bf85796fd7aa48368a698f2f6 allowed for the double encoding of entities such that they will display as the entered text.  ie ```&quot;``` will display instead of " ... Tired to address PM's and Posts only

7) https://github.com/Spuds/Elkarte/commit/017c815b10e783278051f09043f76ab03e6b62fc this is to improve the font capture and rejection when cut and paste is used in wizzy. http://www.elkarte.net/community/index.php?topic=2754