### PR TITLE
Like counts were not updated correctly

### DIFF
--- a/sources/subs/Likes.subs.php
+++ b/sources/subs/Likes.subs.php
@@ -333,7 +333,7 @@ function likesCount($memberID, $given = true)
  */
 function likesPostsGiven($start, $items_per_page, $sort, $memberID)
 {
-	global $scripturl, $context;
+	global $scripturl, $context, $modSettings;
 
 	$db = database();
 	$likes = array();
@@ -347,7 +347,8 @@ function likesPostsGiven($start, $items_per_page, $sort, $memberID)
 		FROM {db_prefix}message_likes AS l
 			LEFT JOIN {db_prefix}messages AS m ON (m.id_msg = l.id_msg)
 			LEFT JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board)
-		WHERE l.id_member = {int:id_member}
+		WHERE l.id_member = {int:id_member}' . (!empty($modSettings['recycle_enable']) ? ('
+			AND b.id_board != ' . $modSettings['recycle_board']) : '') . '
 		ORDER BY {raw:sort}
 		LIMIT {int:start}, {int:per_page}',
 		array(
@@ -384,7 +385,7 @@ function likesPostsGiven($start, $items_per_page, $sort, $memberID)
  */
 function likesPostsReceived($start, $items_per_page, $sort, $memberID)
 {
-	global $scripturl;
+	global $scripturl, $modSettings;
 
 	$db = database();
 	$likes = array();
@@ -397,7 +398,8 @@ function likesPostsReceived($start, $items_per_page, $sort, $memberID)
 		FROM {db_prefix}message_likes AS l
 			LEFT JOIN {db_prefix}messages AS m ON (m.id_msg = l.id_msg)
 			LEFT JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board)
-		WHERE l.id_poster = {int:id_member}
+		WHERE l.id_poster = {int:id_member}' . (!empty($modSettings['recycle_enable']) ? ('
+			AND b.id_board != ' . $modSettings['recycle_board']) : '') . '
 		GROUP BY (l.id_msg)
 		ORDER BY {raw:sort}
 		LIMIT {int:start}, {int:per_page}',

--- a/sources/subs/Likes.subs.php
+++ b/sources/subs/Likes.subs.php
@@ -531,7 +531,8 @@ function decreaseLikeCounts($messages)
 		SELECT
 			DISTINCT(id_member) AS id_member, id_poster
 		FROM {db_prefix}message_likes
-		WHERE id_msg IN ({array_int:messages})',
+		WHERE id_msg IN ({array_int:messages})
+		GROUP BY id_member, id_poster',
 		array(
 			'messages' => $messages,
 		)
@@ -550,12 +551,12 @@ function decreaseLikeCounts($messages)
 	// Re-count the "likes given" totals for the likers
 	if (!empty($likers))
 	{
-		$request = $db->query('', '
-		SELECT
-			COUNT(id_msg) AS likes, id_member
-		FROM {db_prefix}message_likes
-		WHERE id_member IN ({array_int:members})
-		GROUP BY id_member',
+ 		$request = $db->query('', '
+			SELECT
+				COUNT(id_msg) AS likes, id_member
+			FROM {db_prefix}message_likes
+			WHERE id_member IN ({array_int:members})
+			GROUP BY id_member',
 			array(
 				'members' => $likers,
 			)
@@ -570,11 +571,11 @@ function decreaseLikeCounts($messages)
 	if (!empty($posters))
 	{
 		$request = $db->query('', '
-		SELECT
-			COUNT(id_msg) AS likes, id_poster
-		FROM {db_prefix}message_likes
-		WHERE id_poster IN ({array_int:members})
-		GROUP BY id_poster',
+			SELECT
+				COUNT(id_msg) AS likes, id_poster
+			FROM {db_prefix}message_likes
+			WHERE id_poster IN ({array_int:members})
+			GROUP BY id_poster',
 			array(
 				'members' => $posters,
 			)
@@ -590,7 +591,7 @@ function decreaseLikeCounts($messages)
 			COUNT(id_msg) AS likes, id_poster, id_msg
 		FROM {db_prefix}message_likes
 		WHERE id_msg IN ({array_int:messages})
-		GROUP BY id_msg',
+		GROUP BY id_msg, id_poster',
 		array(
 			'messages' => $messages,
 		)

--- a/sources/subs/Messages.subs.php
+++ b/sources/subs/Messages.subs.php
@@ -599,6 +599,10 @@ function removeMessage($message, $decreasePostCount = true)
 	// Only remove posts if they're not recycled.
 	if (!$recycle)
 	{
+		// Update the like counts
+		require_once(SUBSDIR . '/Likes.subs.php');
+		decreaseLikeCounts($message);
+
 		// Remove the likes!
 		$db->query('', '
 			DELETE FROM {db_prefix}message_likes

--- a/sources/subs/Topic.subs.php
+++ b/sources/subs/Topic.subs.php
@@ -311,6 +311,10 @@ function removeTopics($topics, $decreasePostCount = true, $ignoreRecycling = fal
 	// If there are messages left in this topic
 	if (!empty($messages))
 	{
+		// Decrease / Update the member like counts
+		require_once(SUBSDIR . '/Likes.subs.php');
+		decreaseLikeCounts($messages);
+
 		// Remove all likes now that the topic is gone
 		$db->query('', '
 			DELETE FROM {db_prefix}message_likes


### PR DESCRIPTION
When removing a post, the likes given / received counts were not updated.  

Please look at the proposed fix in like subs.  I did it more as a maintenance function, as its recounts the values, vs an update like_xxxx '-' style.   

There are a couple of complications so I'm really not sure this is the best approach, but you need to reduce the likes given for all members that liked a post that is being deleted.  You then need to reduce the likes received of the post originator by the number of likes the message had received.  To do that given an array of messages id's required a few query's, of course they only happen on delete. 

So message id -> who liked it and who posted it.  Count likes given for them and reduce by one and save.  For the poster, get the number of likes a post received and remove that from thier re-counted likes revived value.  Save that.

Also fixed the showing of liked posts that were in the stupid recycle bin

#fix2184
#fix2185