### PR TITLE
Mail bounce notify - Prep

### DIFF
--- a/sources/subs/EmailParse.class.php
+++ b/sources/subs/EmailParse.class.php
@@ -808,6 +808,28 @@ class Email_Parse
 
 		/** Add non-header-based detection **/
 	}
+	
+	/**
+	 * Tries to find the original intended recipient that failed to deliver
+	 *
+	 * What it does:
+	 * - Checks the headers of a DSN for the various ways that the intended recipient
+	 *   Might have been included in the DSN headers
+	 *
+	 * @return string or null
+	 */
+	public function get_failed_dest()
+	{
+		/** Body->Original-Recipient Header **/
+		if (isset($this->_dsn['body']['original-recipient']['value']))
+			return $this->_dsn['body']['original-recipient']['value'];
+		
+		/** Body->Final-recipient Header **/
+		if (isset($this->_dsn['body']['final-recipient']['value']))
+			return $this->_dsn['body']['final-recipient']['value'];
+		
+		return null;
+	}
 
 	/**
 	 * Find the message return_path and well return it

--- a/sources/subs/Emailpost.subs.php
+++ b/sources/subs/Emailpost.subs.php
@@ -997,6 +997,8 @@ function pbe_prepare_text(&$message, &$subject = '', &$signature = '')
  * For the user in question to disable Board and Post notifications. Do not clear
  * Notification subscriptions.
  *
+ * When finished, fire off a site notification informing the user of the action and reason
+ *
  * @package Maillist
  * @param Email_Parse $email_message
  */
@@ -1004,8 +1006,8 @@ function pbe_disable_user_notify($email_message)
 {
 	$db = database();
 
-	$email = $email_message->_dsn['body']['original-recipient']['value'];
-
+	$email = $email_message->get_failed_dest();
+	
 	$request = $db->query('', '
 		SELECT
 			id_member
@@ -1033,7 +1035,14 @@ function pbe_disable_user_notify($email_message)
 				'id_member' => $id_member
 			)
 		);
-	}
+		/*$n = Notifications($db); //Grab a reference to the singleton
+		$n->add(new Notifications_Task("nomail",
+			$id_member, //The member to notify
+			0,  //Not sure what to use for system-triggered messages
+			array('id_members'=>array($id_member)) //Haven't the foggiest what all goes in here yet
+			));
+		*/
+	}	
 }
 
 /**

--- a/sources/subs/Emailpost.subs.php
+++ b/sources/subs/Emailpost.subs.php
@@ -1033,15 +1033,8 @@ function pbe_disable_user_notify($email_message)
 			WHERE id_member = {int:id_member}',
 			array(
 				'id_member' => $id_member
-			)
-		);
-		/*$n = Notifications($db); //Grab a reference to the singleton
-		$n->add(new Notifications_Task("nomail",
-			$id_member, //The member to notify
-			0,  //Not sure what to use for system-triggered messages
-			array('id_members'=>array($id_member)) //Haven't the foggiest what all goes in here yet
-			));
-		*/
+			)		
+		);		
 	}	
 }
 

--- a/sources/subs/Emailpost.subs.php
+++ b/sources/subs/Emailpost.subs.php
@@ -1007,7 +1007,7 @@ function pbe_disable_user_notify($email_message)
 	$db = database();
 
 	$email = $email_message->get_failed_dest();
-	
+
 	$request = $db->query('', '
 		SELECT
 			id_member
@@ -1033,9 +1033,9 @@ function pbe_disable_user_notify($email_message)
 			WHERE id_member = {int:id_member}',
 			array(
 				'id_member' => $id_member
-			)		
-		);		
-	}	
+			)
+		);
+	}
 }
 
 /**


### PR DESCRIPTION
Still running into issues with getting notifications to function, so all attempts to send disable notifications failing to show results are indeterminate. In the process, discovered another variant DSN (final-recipient instead of original-recipient header), and modified the DSN parser to provide either, if available. 