### PR TITLE
Only emit session id in query parameters when cookie is not set.

### DIFF
--- a/sources/QueryString.php
+++ b/sources/QueryString.php
@@ -289,11 +289,10 @@ function ob_sessrewrite($buffer)
 function buffer_callback($matches)
 {
 	global $scripturl;
-	static $robotset = false;
-	static $isarobot;
-	if (!$robotset)
+	static $isarobot = null;
+
+	if ($isarobot === null)
 	{
-		$robotset = true;
 		$isarobot = isBrowser('possibly_robot');
 	}
 

--- a/sources/QueryString.php
+++ b/sources/QueryString.php
@@ -289,8 +289,9 @@ function ob_sessrewrite($buffer)
 function buffer_callback($matches)
 {
 	global $scripturl;
+	static $isarobot = isBrowser('possibly_robot');
 
-	if (empty($_COOKIE) && defined('SID') && SID != '')
+	if (!$isarobot && empty($_COOKIE) && defined('SID') && SID != '')
 		return '"' . $scripturl . '/' . strtr($matches[1], '&;=', '//,') . '.html?' . SID . (isset($matches[2]) ? $matches[2] : '') . '"';
 	else
 		return '"' . $scripturl . '/' . strtr($matches[1], '&;=', '//,') . '.html' . (isset($matches[2]) ? $matches[2] : '') . '"';

--- a/sources/QueryString.php
+++ b/sources/QueryString.php
@@ -289,7 +289,13 @@ function ob_sessrewrite($buffer)
 function buffer_callback($matches)
 {
 	global $scripturl;
-	static $isarobot = isBrowser('possibly_robot');
+	static $robotset = false;
+	static $isarobot;
+	if (!$robotset)
+	{
+		$robotset = true;
+		$isarobot = isBrowser('possibly_robot');
+	}
 
 	if (!$isarobot && empty($_COOKIE) && defined('SID') && SID != '')
 		return '"' . $scripturl . '/' . strtr($matches[1], '&;=', '//,') . '.html?' . SID . (isset($matches[2]) ? $matches[2] : '') . '"';

--- a/sources/QueryString.php
+++ b/sources/QueryString.php
@@ -290,7 +290,7 @@ function buffer_callback($matches)
 {
 	global $scripturl;
 
-	if (defined('SID') && SID != '')
+	if (empty($_COOKIE) && defined('SID') && SID != '')
 		return '"' . $scripturl . '/' . strtr($matches[1], '&;=', '//,') . '.html?' . SID . (isset($matches[2]) ? $matches[2] : '') . '"';
 	else
 		return '"' . $scripturl . '/' . strtr($matches[1], '&;=', '//,') . '.html' . (isset($matches[2]) ? $matches[2] : '') . '"';

--- a/sources/QueryString.php
+++ b/sources/QueryString.php
@@ -289,14 +289,8 @@ function ob_sessrewrite($buffer)
 function buffer_callback($matches)
 {
 	global $scripturl;
-	static $isarobot = null;
 
-	if ($isarobot === null)
-	{
-		$isarobot = isBrowser('possibly_robot');
-	}
-
-	if (!$isarobot && empty($_COOKIE) && defined('SID') && SID != '')
+	if (!isBrowser('possibly_robot') && empty($_COOKIE) && defined('SID') && SID != '')
 		return '"' . $scripturl . '/' . strtr($matches[1], '&;=', '//,') . '.html?' . SID . (isset($matches[2]) ? $matches[2] : '') . '"';
 	else
 		return '"' . $scripturl . '/' . strtr($matches[1], '&;=', '//,') . '.html' . (isset($matches[2]) ? $matches[2] : '') . '"';


### PR DESCRIPTION
This changes the regular expression replace function used by the queryless URLs option, so that it doesn't insert the SID parameter if a cookie is set.