### PR TITLE
Fix all variable variables for PHP 7

### DIFF
--- a/sources/Action.controller.php
+++ b/sources/Action.controller.php
@@ -190,7 +190,7 @@ abstract class Action_Controller
 	{
 		if (property_exists($this, $dep))
 		{
-			$dependencies[$dep] = &$this->$dep;
+			$dependencies[$dep] = &$this->{$dep};
 		}
 		elseif (property_exists($this, '_' . $dep))
 		{

--- a/sources/admin/AdminLog.controller.php
+++ b/sources/admin/AdminLog.controller.php
@@ -178,7 +178,7 @@ class AdminLog_Controller extends Action_Controller
 					if (!is_array($dummy) || $index == 'pruningOptions')
 						continue;
 
-					$vals[] = empty($this->_req->post->$dummy[1]) || $this->_req->post->$dummy[1] < 0 ? 0 : $this->_req->getPost($dummy[1], 'intval');
+					$vals[] = empty($this->_req->post->{$dummy[1]}) || $this->_req->post->{$dummy[1]} < 0 ? 0 : $this->_req->getPost($dummy[1], 'intval');
 				}
 				$_POST['pruningOptions'] = implode(',', $vals);
 			}

--- a/sources/admin/BBC.controller.php
+++ b/sources/admin/BBC.controller.php
@@ -591,7 +591,7 @@ class ManageBBC_Controller extends Action_Controller
 			);
 
 		// Submitting a form?
-		if (isset($this->_req->post->$context['session_var'], $this->_req->post->smiley_code))
+		if (isset($this->_req->post->{$context['session_var']}, $this->_req->post->smiley_code))
 		{
 			checkSession();
 

--- a/sources/admin/ManageCalendarModule.controller.php
+++ b/sources/admin/ManageCalendarModule.controller.php
@@ -278,7 +278,7 @@ class ManageCalendarModule_Controller extends Action_Controller
 
 		// Submitting?
 
-		if (isset($this->_req->post->$context['session_var']) && (isset($this->_req->post->delete) || $this->_req->post->title != ''))
+		if (isset($this->_req->post->{$context['session_var']}) && (isset($this->_req->post->delete) || $this->_req->post->title != ''))
 		{
 			checkSession();
 

--- a/sources/admin/ManageMembers.controller.php
+++ b/sources/admin/ManageMembers.controller.php
@@ -283,8 +283,8 @@ class ManageMembers_Controller extends Action_Controller
 				$search_params['types'] = $this->_req->post->types;
 				foreach ($params as $param_name => $param_info)
 				{
-					if (isset($this->_req->post->$param_name))
-						$search_params[$param_name] = $this->_req->post->$param_name;
+					if (isset($this->_req->post->{$param_name}))
+						$search_params[$param_name] = $this->_req->post->{$param_name};
 				}
 			}
 

--- a/sources/admin/ManageNews.controller.php
+++ b/sources/admin/ManageNews.controller.php
@@ -488,10 +488,10 @@ class ManageNews_Controller extends Action_Controller
 			foreach ($toClean as $key => $type)
 			{
 				// Remove the quotes.
-				$temp = strtr((string) $this->_req->post->$type, array('\\"' => '"'));
+				$temp = strtr((string) $this->_req->post->{$type}, array('\\"' => '"'));
 
 				// Break it up in to an array for processing
-				preg_match_all('~"([^"]+)"~', $this->_req->post->$type, $matches);
+				preg_match_all('~"([^"]+)"~', $this->_req->post->{$type}, $matches);
 				$temp = array_unique(array_merge($matches[1], explode(',', preg_replace('~"[^"]+"~', '', $temp))));
 
 				// Clean the valid ones, drop the mangled ones
@@ -504,7 +504,7 @@ class ManageNews_Controller extends Action_Controller
 				}
 
 				// Find the members
-				$this->$key = array_keys(findMembers($temp));
+				$this->{$key} = array_keys(findMembers($temp));
 			}
 		}
 	}

--- a/sources/admin/ManagePermissions.controller.php
+++ b/sources/admin/ManagePermissions.controller.php
@@ -1099,7 +1099,7 @@ class ManagePermissions_Controller extends Action_Controller
 			{
 				foreach ($mappings as $index => $data)
 				{
-					$temp = $this->_req->post->$index;
+					$temp = $this->_req->post->{$index};
 					if (isset($temp[$group['id']]))
 					{
 						if ($temp[$group['id']] == 'allow')

--- a/sources/admin/ManageSearch.controller.php
+++ b/sources/admin/ManageSearch.controller.php
@@ -274,7 +274,7 @@ class ManageSearch_Controller extends Action_Controller
 
 			$changes = array();
 			foreach ($factors as $factor)
-				$changes[$factor] = (int) $this->_req->post->$factor;
+				$changes[$factor] = (int) $this->_req->post->{$factor};
 
 			updateSettings($changes);
 		}

--- a/sources/admin/ManageSecurity.controller.php
+++ b/sources/admin/ManageSecurity.controller.php
@@ -354,10 +354,10 @@ class ManageSecurity_Controller extends Action_Controller
 				$this_list = array();
 				$this_desc = array();
 
-				if (isset($this->_req->post->$list))
+				if (isset($this->_req->post->{$list}))
 				{
 					// Clear blanks from the data field, only grab the comments that don't have blank data value
-					$this_list = array_map('trim', array_filter($this->_req->post->$list));
+					$this_list = array_map('trim', array_filter($this->_req->post->{$list}));
 					$this_desc = array_intersect_key($this->_req->post->{$list . '_desc'}, $this_list);
 				}
 

--- a/sources/admin/ManageServer.controller.php
+++ b/sources/admin/ManageServer.controller.php
@@ -421,7 +421,7 @@ class ManageServer_Controller extends Action_Controller
 				elseif ($key == 'loadavg_forum' && $value < 10)
 					$this->_req->post->loadavg_forum = '10.0';
 				elseif ($value < 2)
-					$this->_req->$key = '2.0';
+					$this->_req->{$key} = '2.0';
 			}
 
 			call_integration_hook('integrate_save_loadavg_settings');

--- a/sources/admin/ManageSmileys.controller.php
+++ b/sources/admin/ManageSmileys.controller.php
@@ -575,7 +575,7 @@ class ManageSmileys_Controller extends Action_Controller
 			);
 
 		// Submitting a form?
-		if (isset($this->_req->post->$context['session_var'], $this->_req->post->smiley_code))
+		if (isset($this->_req->post->{$context['session_var']}, $this->_req->post->smiley_code))
 		{
 			checkSession();
 

--- a/sources/admin/PackageServers.controller.php
+++ b/sources/admin/PackageServers.controller.php
@@ -387,7 +387,7 @@ class PackageServers_Controller extends Action_Controller
 
 			// Find the requested package by section and number, make sure it matches
 			$section = $this->_req->query->section;
-			$section = $listing->$section;
+			$section = $listing->{$section};
 
 			// This is what they requested, yes?
 			if (basename($section[$this->_req->query->num]->server[0]->download) === $this->_req->query->package)

--- a/sources/controllers/Emailuser.controller.php
+++ b/sources/controllers/Emailuser.controller.php
@@ -457,7 +457,7 @@ class Emailuser_Controller extends Action_Controller
 		);
 
 		// If they're posting, it should be processed by action_reporttm2.
-		if ((isset($this->_req->post->$context['session_var']) || isset($this->_req->post->save)) && !$report_errors->hasErrors())
+		if ((isset($this->_req->post->{$context['session_var']}) || isset($this->_req->post->save)) && !$report_errors->hasErrors())
 			$this->action_reporttm2();
 
 		// We need a message ID to check!

--- a/sources/controllers/Groups.controller.php
+++ b/sources/controllers/Groups.controller.php
@@ -442,7 +442,7 @@ class Groups_Controller extends Action_Controller
 		$where_parameters = array();
 
 		// We've submitted?
-		if (isset($this->_req->post->$context['session_var'])
+		if (isset($this->_req->post->{$context['session_var']})
 			&& !empty($this->_req->post->groupr)
 			&& !empty($this->_req->post->req_action))
 		{

--- a/sources/controllers/News.controller.php
+++ b/sources/controllers/News.controller.php
@@ -190,8 +190,8 @@ class News_Controller extends Action_Controller
 		$cachekey = array($xml_format, $this->_req->query->action, $this->_limit, $subAction);
 		foreach (array('board', 'boards', 'c') as $var)
 		{
-			if (isset($this->_req->query->$var))
-				$cachekey[] = $this->_req->query->$var;
+			if (isset($this->_req->query->{$var}))
+				$cachekey[] = $this->_req->query->{$var};
 		}
 
 		$cachekey = md5(serialize($cachekey) . (!empty($this->_query_this_board) ? $this->_query_this_board : ''));
@@ -245,9 +245,9 @@ class News_Controller extends Action_Controller
 			$url_parts = array();
 			foreach (array('board', 'boards', 'c') as $var)
 			{
-				if (isset($this->_req->query->$var))
+				if (isset($this->_req->query->{$var}))
 				{
-					$url_parts[] = $var . '=' . (is_array( $this->_req->query->$var) ? implode(',',  $this->_req->query->$var) : $this->_req->query->$var);
+					$url_parts[] = $var . '=' . (is_array( $this->_req->query->{$var}) ? implode(',',  $this->_req->query->{$var}) : $this->_req->query->{$var});
 				}
 			}
 

--- a/sources/controllers/OpenID.controller.php
+++ b/sources/controllers/OpenID.controller.php
@@ -65,9 +65,9 @@ class OpenID_Controller extends Action_Controller
 		// This has annoying habit of removing the + from the base64 encoding.  So lets put them back.
 		foreach (array('openid_assoc_handle', 'openid_invalidate_handle', 'openid_sig', 'sf') as $key)
 		{
-			if (isset($this->_req->query->$key))
+			if (isset($this->_req->query->{$key}))
 			{
-				$this->_req->query->$key = str_replace(' ', '+', $this->_req->query->$key);
+				$this->_req->query->{$key} = str_replace(' ', '+', $this->_req->query->{$key});
 			}
 		}
 
@@ -144,7 +144,7 @@ class OpenID_Controller extends Action_Controller
 				if (!empty($openid_save_fields))
 				{
 					foreach ($openid_save_fields as $id => $value)
-						$this->_req->post->$id = $value;
+						$this->_req->post->{$id} = $value;
 				}
 
 				$controller = new Register_Controller(new Event_Manager());
@@ -207,7 +207,7 @@ class OpenID_Controller extends Action_Controller
 		foreach ($signed as $sign)
 		{
 			$sign_key = 'openid_' . str_replace('.', '_', $sign);
-			$verify_str .= $sign . ':' . strtr($this->_req->query->$sign_key, array('&amp;' => '&')) . "\n";
+			$verify_str .= $sign . ':' . strtr($this->_req->query->{$sign_key}, array('&amp;' => '&')) . "\n";
 		}
 
 		$verify_str = base64_encode(hash_hmac('sha1', $verify_str, $this->_secret, true));

--- a/sources/controllers/PersonalMessage.controller.php
+++ b/sources/controllers/PersonalMessage.controller.php
@@ -1008,16 +1008,16 @@ class PersonalMessage_Controller extends Action_Controller
 			// First, let's see if there's user ID's given.
 			$recipientList[$recipientType] = array();
 			$type = 'recipient_' . $recipientType;
-			if (!empty($this->_req->post->$type) && is_array($this->_req->post->$type))
+			if (!empty($this->_req->post->{$type}) && is_array($this->_req->post->{$type}))
 			{
-				$recipientList[$recipientType] = array_map('intval', $this->_req->post->$type);
+				$recipientList[$recipientType] = array_map('intval', $this->_req->post->{$type});
 			}
 
 			// Are there also literal names set?
-			if (!empty($this->_req->post->$recipientType))
+			if (!empty($this->_req->post->{$recipientType}))
 			{
 				// We're going to take out the "s anyway ;).
-				$recipientString = strtr($this->_req->post->$recipientType, array('\\"' => '"'));
+				$recipientString = strtr($this->_req->post->{$recipientType}, array('\\"' => '"'));
 
 				preg_match_all('~"([^"]+)"~', $recipientString, $matches);
 				$namedRecipientList[$recipientType] = array_unique(array_merge($matches[1], explode(',', preg_replace('~"[^"]+"~', '', $recipientString))));

--- a/sources/controllers/Register.controller.php
+++ b/sources/controllers/Register.controller.php
@@ -296,7 +296,7 @@ class Register_Controller extends Action_Controller
 		{
 			if (!is_array($value))
 			{
-				$this->_req->post->$key = htmltrim__recursive(str_replace(array("\n", "\r"), '', $value));
+				$this->_req->post->{$key} = htmltrim__recursive(str_replace(array("\n", "\r"), '', $value));
 			}
 		}
 
@@ -582,20 +582,20 @@ class Register_Controller extends Action_Controller
 
 		// Include the additional options that might have been filled in.
 		foreach ($possible_strings as $var)
-			if (isset($this->_req->post->$var))
-				$extra_register_vars[$var] = Util::htmlspecialchars($this->_req->post->$var, ENT_QUOTES);
+			if (isset($this->_req->post->{$var}))
+				$extra_register_vars[$var] = Util::htmlspecialchars($this->_req->post->{$var}, ENT_QUOTES);
 
 		foreach ($possible_ints as $var)
-			if (isset($this->_req->post->$var))
-				$extra_register_vars[$var] = (int) $this->_req->post->$var;
+			if (isset($this->_req->post->{$var}))
+				$extra_register_vars[$var] = (int) $this->_req->post->{$var};
 
 		foreach ($possible_floats as $var)
-			if (isset($this->_req->post->$var))
-				$extra_register_vars[$var] = (float) $this->_req->post->$var;
+			if (isset($this->_req->post->{$var}))
+				$extra_register_vars[$var] = (float) $this->_req->post->{$var};
 
 		foreach ($possible_bools as $var)
-			if (isset($this->_req->post->$var))
-				$extra_register_vars[$var] = empty($this->_req->post->$var) ? 0 : 1;
+			if (isset($this->_req->post->{$var}))
+				$extra_register_vars[$var] = empty($this->_req->post->{$var}) ? 0 : 1;
 
 		return $extra_register_vars;
 	}
@@ -705,9 +705,9 @@ class Register_Controller extends Action_Controller
 			// We might have had some submissions on this front - go check.
 			foreach ($reg_fields as $field)
 			{
-				if (isset($this->_req->post->$field))
+				if (isset($this->_req->post->{$field}))
 				{
-					$cur_profile[$field] = Util::htmlspecialchars($this->_req->post->$field);
+					$cur_profile[$field] = Util::htmlspecialchars($this->_req->post->{$field});
 				}
 			}
 

--- a/sources/controllers/Suggest.controller.php
+++ b/sources/controllers/Suggest.controller.php
@@ -86,7 +86,7 @@ class Suggest_Controller extends Action_Controller
 				$suggest = new $currentSearch['class']($this->_req->post->search, $context['search_param']);
 
 				// Okay, let's at least assume the method exists... *rolleyes*
-				$context['xml_data'] = $suggest->$currentSearch['function']();
+				$context['xml_data'] = $suggest->{$currentSearch['function']}();
 			}
 			// Let's maintain the "namespace" action_suggest_
 			elseif (function_exists('action_suggest_' . $currentSearch['function']))

--- a/sources/controllers/Xml.controller.php
+++ b/sources/controllers/Xml.controller.php
@@ -164,7 +164,7 @@ class Xml_Controller extends Action_Controller
 					$feature = $context['features'][$id];
 					$feature_id = 'feature_' . $id;
 					$returns[] = array(
-						'value' => (!empty($this->_req->post->$feature_id) && $feature['url'] ? '<a href="' . $feature['url'] . '">' . $feature['title'] . '</a>' : $feature['title']),
+						'value' => (!empty($this->_req->post->{$feature_id}) && $feature['url'] ? '<a href="' . $feature['url'] . '">' . $feature['title'] . '</a>' : $feature['title']),
 					);
 
 					createToken('admin-core', 'post');

--- a/sources/ext/markdown/markdown.php
+++ b/sources/ext/markdown/markdown.php
@@ -340,7 +340,7 @@ class Markdown_Parser {
 
 		# Run document gamut methods.
 		foreach ($this->document_gamut as $method => $priority) {
-			$text = $this->$method($text);
+			$text = $this->{$method}($text);
 		}
 
 		$this->teardown();
@@ -610,7 +610,7 @@ class Markdown_Parser {
 	# whole-document pass.
 	#
 		foreach ($this->block_gamut as $method => $priority) {
-			$text = $this->$method($text);
+			$text = $this->{$method}($text);
 		}
 
 		# Finally form paragraph and restore hashed blocks.
@@ -667,7 +667,7 @@ class Markdown_Parser {
 	# Run span gamut tranformations.
 	#
 		foreach ($this->span_gamut as $method => $priority) {
-			$text = $this->$method($text);
+			$text = $this->{$method}($text);
 		}
 
 		return $text;
@@ -1407,7 +1407,7 @@ class Markdown_Parser {
 //
 //					# Run document gamut methods on the content.
 //					foreach ($this->document_gamut as $method => $priority) {
-//						$div_content = $this->$method($div_content);
+//						$div_content = $this->{$method}($div_content);
 //					}
 //
 //					$div_open = preg_replace(
@@ -2328,7 +2328,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 
 					# End preceding block with this tag.
 					$block_text .= $tag;
-					$parsed .= $this->$hash_method($block_text);
+					$parsed .= $this->{$hash_method}($block_text);
 
 					# Get enclosing tag name for the ParseMarkdown function.
 					# (This pattern makes $tag_name_re safe without quoting.)
@@ -2361,7 +2361,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 		#
 		# Hash last block text that wasn't processed inside the loop.
 		#
-		$parsed .= $this->$hash_method($block_text);
+		$parsed .= $this->{$hash_method}($block_text);
 
 		return array($parsed, $text);
 	}

--- a/sources/ext/simple_html_dom.php
+++ b/sources/ext/simple_html_dom.php
@@ -160,7 +160,7 @@ class simple_html_dom_node
 		{
 			echo '(';
 			foreach ($this->attr as $k=>$v)
-				echo "[$k]=>\"".$this->$k.'", ';
+				echo "[$k]=>\"".$this->{$k}.'", ';
 			echo ')';
 		}
 		echo "\n";
@@ -185,7 +185,7 @@ class simple_html_dom_node
 			$string .= '(';
 			foreach ($this->attr as $k=>$v)
 			{
-				$string .= "[$k]=>\"".$this->$k.'", ';
+				$string .= "[$k]=>\"".$this->{$k}.'", ';
 			}
 			$string .= ')';
 		}

--- a/sources/subs/DataValidator.class.php
+++ b/sources/subs/DataValidator.class.php
@@ -318,7 +318,7 @@ class Data_Validator
 
 					// Defined method to use?
 					if (is_callable(array($this, $validation_method)))
-						$result = $this->$validation_method($field, $input, $validation_parameters);
+						$result = $this->{$validation_method}($field, $input, $validation_parameters);
 					// Maybe even a custom function set up like a defined one, addons can do this.
 					elseif (is_callable($validation_function) && strpos($validation_function, 'validate_') === 0 && isset($input[$field]))
 						$result = call_user_func_array($validation_function, array_merge((array) $field, (array) $input[$field], $validation_parameters_function));
@@ -450,7 +450,7 @@ class Data_Validator
 
 					// Defined method to use?
 					if (is_callable(array($this, $sanitation_method)))
-						$input[$field] = $this->$sanitation_method($input[$field], $sanitation_parameters);
+						$input[$field] = $this->{$sanitation_method}($input[$field], $sanitation_parameters);
 					// One of our static methods or even a built in php function like strtoupper, intval, etc?
 					elseif (is_callable($sanitation_function))
 						$input[$field] = call_user_func_array($sanitation_function, array_merge((array) $input[$field], $sanitation_parameters_function));

--- a/sources/subs/HttpReq.class.php
+++ b/sources/subs/HttpReq.class.php
@@ -173,10 +173,10 @@ class HttpReq
 		{
 			case isset($this->_param[$key]):
 				return $this->_param[$key];
-			case isset($this->query->$key):
-				return $this->query->$key;
-			case isset($this->post->$key):
-				return $this->post->$key;
+			case isset($this->query->{$key}):
+				return $this->query->{$key};
+			case isset($this->post->{$key}):
+				return $this->post->{$key};
 			default:
 				return null;
 		}
@@ -220,9 +220,9 @@ class HttpReq
 		{
 			case isset($this->_param[$key]):
 				return true;
-			case isset($this->query->$key):
+			case isset($this->query->{$key}):
 				return true;
-			case isset($this->post->$key):
+			case isset($this->post->{$key}):
 				return true;
 			default:
 				return false;
@@ -244,7 +244,7 @@ class HttpReq
 	 *
 	 * - Uses any sanitize rule(s) that can be passed to the Data_Validator class
 	 * - Returned value will be the sanitized value or null of the key is not in $_GET
-	 * - If you just want a value back access it directly as $req->query->$name
+	 * - If you just want a value back access it directly as $req->query->{$name}
 	 *
 	 * @param string $name The key name of the value to return
 	 * @param string|null $sanitize a comma separated list of sanitation rules to apply
@@ -254,9 +254,9 @@ class HttpReq
 	{
 		$this->_param[$name] = $default;
 
-		if (isset($this->query->$name))
+		if (isset($this->query->{$name}))
 		{
-			$this->_param[$name] = $this->query->$name;
+			$this->_param[$name] = $this->query->{$name};
 			$this->_param[$name] = $this->cleanValue($name, $sanitize);
 		}
 
@@ -268,7 +268,7 @@ class HttpReq
 	 *
 	 * - Uses any sanitize rule(s) that can be passed to the Data_Validator class
 	 * - Returned value will be the sanitized value or null of the key is not in $_POST
-	 * - If you just want a value back access it directly as $req->post->$name
+	 * - If you just want a value back access it directly as $req->post->{$name}
 	 *
 	 * @param string $name The key name of the value to return
 	 * @param string|null $sanitize a comma separated list of sanitation rules to apply
@@ -278,9 +278,9 @@ class HttpReq
 	{
 		$this->_param[$name] = $default;
 
-		if (isset($this->post->$name))
+		if (isset($this->post->{$name}))
 		{
-			$this->_param[$name] = $this->post->$name;
+			$this->_param[$name] = $this->post->{$name};
 			$this->_param[$name] = $this->cleanValue($name, $sanitize);
 		}
 
@@ -297,8 +297,8 @@ class HttpReq
 	 */
 	public function getCookie($name = '', $default = null)
 	{
-		if (isset($this->cookie->$name))
-			return $this->cookie->$name;
+		if (isset($this->cookie->{$name}))
+			return $this->cookie->{$name};
 		elseif ($default !== null)
 			return $default;
 		else
@@ -315,8 +315,8 @@ class HttpReq
 	 */
 	public function getSession($name = '', $default = null)
 	{
-		if (isset($this->session->$name))
-			return $this->session->$name;
+		if (isset($this->session->{$name}))
+			return $this->session->{$name};
 		elseif ($default !== null)
 			return $default;
 		else


### PR DESCRIPTION
This hopefully fixes all cases of potential ambiguity with "variable variables", where a variable is used to reference a member of another structure or class. A lot of cases were probably clear, with using plain variables. Others, where the key was referenced from an array, would break on PHP 7 if not referenced:

$class->{$array['key']}