### PR TITLE
Fix adding session ID to redirects if a cookie is still set.

### DIFF
--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -2421,7 +2421,7 @@ function redirectexit($setLocation = '', $refresh = false)
 		$setLocation = $scripturl . ($setLocation != '' ? '?' . $setLocation : '');
 
 	// Put the session ID in.
-	if (defined('SID') && SID != '')
+	if (empty($_COOKIE) && defined('SID') && SID != '')
 		$setLocation = preg_replace('/^' . preg_quote($scripturl, '/') . '(?!\?' . preg_quote(SID, '/') . ')\\??/', $scripturl . '?' . SID . ';', $setLocation);
 	// Keep that debug in their for template debugging!
 	elseif (isset($_GET['debug']))


### PR DESCRIPTION
This fixes a bug which would occur with queryless URL generation, where a session code would be inserted between the page name and the /parameters added later, which no longer handles the SID parameter if a cookie is set.