### PR TITLE
Maillist IMAP heading to info box

### DIFF
--- a/sources/admin/ManageMaillist.controller.php
+++ b/sources/admin/ManageMaillist.controller.php
@@ -1628,7 +1628,7 @@ class ManageMaillist_Controller extends Action_Controller
 			$config_vars = array_merge($config_vars,
 				array(
 					array('title', 'maillist_imap'),
-					array('title', 'maillist_imap_reason'),
+					array('desc', 'maillist_imap_reason'),
 						array('text', 'maillist_imap_host', 45, 'subtext' => $txt['maillist_imap_host_desc'], 'disabled' => !function_exists('imap_open')),
 						array('text', 'maillist_imap_mailbox', 20, 'postinput' => $txt['maillist_imap_mailbox_desc'], 'disabled' => !function_exists('imap_open')),
 						array('text', 'maillist_imap_uid', 20, 'postinput' => $txt['maillist_imap_uid_desc'], 'disabled' => !function_exists('imap_open')),


### PR DESCRIPTION
This corrects the double heading display of the IMAP server. Final result is one heading followed by an information box. 
Relevant post at http://www.elkarte.net/community/index.php?topic=3324.0