### PR TITLE
Update package server code 

### DIFF
--- a/sources/admin/PackageServers.controller.php
+++ b/sources/admin/PackageServers.controller.php
@@ -197,8 +197,8 @@ class PackageServers_Controller extends Action_Controller
 					$package['id'] = $package['is_installed'] ? array_shift($is_installed) : $package['id'][0];
 
 					// Version installed vs version available
-					$package['is_current'] = !empty($package['is_installed']) && ($installed_adds[$package['id']] == $package['version']);
-					$package['is_newer'] = !empty($package['is_installed']) && ($installed_adds[$package['id']] > $package['version']);
+					$package['is_current'] = !empty($package['is_installed']) && compareVersions($installed_adds[$package['id']], $package['version']) == 0;
+					$package['is_newer'] = !empty($package['is_installed']) && compareVersions($installed_adds[$package['id']], $package['version']) > 0;
 
 					// Set the package filename for downloading and pre-existence checking
 					$base_name = $this->_rename_master($package['server']['download']);
@@ -219,7 +219,7 @@ class PackageServers_Controller extends Action_Controller
 
 					// See if this filename already exists on the server
 					$already_exists = getPackageInfo($base_name);
-					$package['download_conflict'] = is_array($already_exists) && $already_exists['id'] == $package['id'] && $already_exists['version'] != $package['version'];
+					$package['download_conflict'] = is_array($already_exists) && $already_exists['id'] == $package['id'] && compareVersions($already_exists['version'], $package['version']) != 0;
 					$package['count'] = ++$packageNum;
 
 					// Build the download to server link
@@ -425,7 +425,6 @@ class PackageServers_Controller extends Action_Controller
 		}
 
 		// First make sure it's a package.
-
 		$packageInfo = getPackageInfo($url . $_REQUEST['package']);
 		if (!is_array($packageInfo))
 			fatal_lang_error($packageInfo);
@@ -564,7 +563,7 @@ class PackageServers_Controller extends Action_Controller
 					continue;
 
 				// If it was already uploaded under another name don't upload it again.
-				if ($packageInfo['id'] == $context['package']['id'] && $packageInfo['version'] == $context['package']['version'])
+				if ($packageInfo['id'] == $context['package']['id'] && compareVersions($packageInfo['version'], $context['package']['version']) == 0)
 				{
 					@unlink($destination);
 					loadLanguage('Errors');

--- a/sources/admin/PackageServers.controller.php
+++ b/sources/admin/PackageServers.controller.php
@@ -233,12 +233,31 @@ class PackageServers_Controller extends Action_Controller
 					$section_count++;
 				}
 
+				// Sort them naturally
+				usort($context['package_list'][$packageSection]['items'], array($this, 'package_sort'));
+
 				$context['package_list'][$packageSection]['text'] = sprintf($txt['mod_section_count'], $section_count);
 			}
 		}
 
 		// Good time to sort the categories, the packages inside each category will be by last modification date.
 		asort($context['package_list']);
+
+	}
+
+	/**
+	 * Case insensitive natural sort for packages
+	 *
+	 * - Callback for usort, can be anonymous function in 1.1
+	 *
+	 * @param array $a
+	 * @param array $b
+	 *
+	 * @return int
+	 */
+	public function package_sort($a, $b)
+	{
+		return strcasecmp($a['name'], $b['name']);
 	}
 
 	/**

--- a/themes/default/PackageServers.template.php
+++ b/themes/default/PackageServers.template.php
@@ -11,7 +11,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.4
+ * @version 1.0.7
  *
  */
 
@@ -171,64 +171,91 @@ function template_package_list()
 
 			foreach ($packageSection['items'] as $id => $package)
 			{
+				// 1. Some addon [ Download ].
 				echo '
-							<li>';
-					// 1. Some addon [ Download ].
-					echo '
-							<strong>
-								<img id="ps_img_', $i, '_pkg_', $id, '" src="', $settings['images_url'], '/selected_open.png" alt="*" style="display: none;" /> ',
-								$package['can_install'] ? '<strong>' . $package['name'] . '</strong> <a class="linkbutton" href="' . $package['download']['href'] . '">' . $txt['download'] . '</a>' : $package['name'];
+						<li>
+							<img id="ps_img_', $i, '_pkg_', $id, '" src="', $settings['images_url'], '/selected_open.png" alt="*" style="display: none;" /> ';
 
-					// Mark as installed and current?
-					if ($package['is_installed'] && !$package['is_newer'])
-						echo '<img src="', $settings['images_url'], '/icons/package_', $package['is_current'] ? 'installed' : 'old', '.png" class="centericon package_img" alt="', $package['is_current'] ? $txt['package_installed_current'] : $txt['package_installed_old'], '" />';
-
+				// Installed but newer one is available
+				if ($package['is_installed'] && $package['is_newer'])
+				{
 					echo '
-							</strong>
+							<span class="package_id">', $package['name'], '</span>&nbsp;<a class="linkbutton" href="', $package['download']['href'], '">', $txt['download'], '</a>&nbsp;',
+					sprintf($txt['package_update'], '<i class="fa fa-exclamation-circle" title="' . $txt['package_installed_old'] . '"></i>', $txt['package_installed']);
+				}
+				// Installed but nothing newer is available
+				else if ($package['is_installed'])
+				{
+					echo '
+							<span class="package_id">', $package['name'], '</span>&nbsp;',
+					sprintf($txt['package_current'], '<i class="fa fa-check" title="' . $txt['package_installed_current'] . '"></i>', $txt['package_installed']);
+				}
+				// Downloaded, but there is a more recent version available
+				else if ($package['is_downloaded'] && $package['is_newer'])
+				{
+					echo '
+							<span class="package_id">', $package['name'], '</span>&nbsp;<a class="linkbutton" href="', $package['download']['href'], '">', $txt['download'], '</a>&nbsp;',
+					sprintf($txt['package_update'], '<i class="fa fa-minus-circle" title="' . $txt['package_installed_old'] . '"></i>', $txt['package_downloaded']);
+				}
+				// Downloaded, and its current
+				else if ($package['is_downloaded'])
+				{
+					echo '
+							<span class="package_id">', $package['name'], '</span>&nbsp;',
+					sprintf($txt['package_current'], '<i class="fa fa-plus-circle" title="' . $txt['package_installed_current'] . '"></i>', $txt['package_downloaded']);
+				}
+				// Not downloaded or installed
+				else
+				{
+					echo '
+							<span class="package_id">', $package['name'], '</span>&nbsp;<a class="linkbutton" href="', $package['download']['href'], '">', $txt['download'], '</a>';
+				}
+
+				echo '
 							<ul id="package_section_', $i, '_pkg_', $id, '" class="package_section">';
 
-					// Show the addon type?
-					if ($package['type'] != '')
-						echo '
+				// Show the addon type?
+				if ($package['type'] != '')
+					echo '
 								<li class="package_section">', $txt['package_type'], ':&nbsp; ', Util::ucwords(Util::strtolower($package['type'])), '</li>';
 
-					// Show the version number?
-					if ($package['version'] != '')
-						echo '
+				// Show the version number?
+				if ($package['version'] != '')
+					echo '
 								<li class="package_section">', $txt['mod_version'], ':&nbsp; ', $package['version'], '</li>';
 
-					// Show the last date?
-					if ($package['date'] != '')
-						echo '
+				// Show the last date?
+				if ($package['date'] != '')
+					echo '
 								<li class="package_section">', $txt['mod_date'], ':&nbsp; ', $package['date'], '</li>';
 
-					// How 'bout the author?
-					if (!empty($package['author']))
-						echo '
+				// How 'bout the author?
+				if (!empty($package['author']))
+					echo '
 								<li class="package_section">', $txt['mod_author'], ':&nbsp; ', $package['author'], '</li>';
 
-					// Nothing but hooks ?
-					if ($package['hooks'] != '' && in_array($package['hooks'] , array('yes', 'true')))
-						echo '
+				// Nothing but hooks ?
+				if ($package['hooks'] != '' && in_array($package['hooks'] , array('yes', 'true')))
+					echo '
 								<li class="package_section">', $txt['mod_hooks'], ' <i class="fa fa-check-circle-o"></i></li>';
 
-					// Location of file: http://someplace/.
-					echo '
+				// Location of file: http://someplace/.
+				echo '
 								<ul style="margin-left: 5em">
 									<li class="package_section"><i class="fa fa-cloud-download"></i> ', $txt['file_location'], ':&nbsp; <a href="', $package['server']['download'], '">', $package['server']['download'], '</a></li>';
 
-					// Location of issues?
-					if (!empty($package['server']['bugs']))
-						echo '
+				// Location of issues?
+				if (!empty($package['server']['bugs']))
+					echo '
 									<li class="package_section"><i class="fa fa-bug"></i> ', $txt['bug_location'], ':&nbsp; <a href="', $package['server']['bugs'], '">', $package['server']['bugs'], '</a></li>';
 
-					// Location of support?
-					if (!empty($package['server']['support']))
-						echo '
+				// Location of support?
+				if (!empty($package['server']['support']))
+					echo '
 									<li class="package_section"><i class="fa fa-support"></i> ', $txt['support_location'], ':&nbsp; <a href="', $package['server']['support'], '">', $package['server']['support'], '</a></li>';
 
-					// Description: bleh bleh!
-					echo '
+				// Description: bleh bleh!
+				echo '
 								</ul>
 								<li class="package_section"><div class="infobox">', $txt['package_description'], ':&nbsp; ', $package['description'], '</div></li>
 							</ul>';

--- a/themes/default/css/admin.css
+++ b/themes/default/css/admin.css
@@ -132,7 +132,7 @@ h3 a.help .icon {
 }
 .settings .help .icon {
 	margin: 0 0 0 -20px;
-    position: absolute;
+	position: absolute;
 }
 .table_caption, tr.table_caption td {
 	font-weight: bold;
@@ -402,6 +402,12 @@ div.quick_tasks {
 #package_list li {
 	padding: 0.2em;
 	margin: 1px;
+}
+.package_id {
+	width: 35%;
+	min-width: 20em;
+	display: inline-block;
+	font-weight: bold;
 }
 .description, .information {
 	max-height: 16em;

--- a/themes/default/languages/english/Packages.english.php
+++ b/themes/default/languages/english/Packages.english.php
@@ -56,6 +56,12 @@ $txt['mod_hooks'] = 'No source edits';
 $txt['mod_date'] = 'Last updated';
 $txt['mod_section_count'] = 'Browse the (%1d) addons in this section';
 
+// Package Server strings
+$txt['package_current'] = '(%s <em>You have the Current version %s</em>)';
+$txt['package_update'] = '(%s <em>An update for your %s version is available</em>)';
+$txt['package_installed'] = 'installed';
+$txt['package_downloaded'] = 'downloaded';
+
 $txt['package_installed_key'] = 'Installed addons:';
 $txt['package_installed_current'] = 'current version';
 $txt['package_installed_old'] = 'older version';


### PR DESCRIPTION
This adds / fixes the detection for installed and downloaded packages.  When it comes to bringing this into 1.0.7 I feel we can just replace the PackageServers.controller.php and PackageServers.template.php since the odds of them being modified from the default are near null
