### PR TITLE
Updates for very long board names breaking layout

### DIFF
--- a/themes/default/MessageIndex.template.php
+++ b/themes/default/MessageIndex.template.php
@@ -323,7 +323,7 @@ function template_topic_listing_below()
 
 	echo '
 	<div id="topic_icons" class="description">
-		<div class="floatright" id="message_index_jump_to">&nbsp;</div>';
+		<div class="qaction_row" id="message_index_jump_to">&nbsp;</div>';
 
 	if (!$context['no_topic_listing'])
 		template_basicicons_legend();

--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -183,6 +183,10 @@ input, .input_text, button, select {
 }
 select {
 	padding: 0 0 0 2px;
+	max-width: 95%;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .input_text {
 	font-size: .876em;
@@ -1657,7 +1661,7 @@ dl.settings label {
 	float: left;
 }
 .board_name {
-	padding: 0 0 1px 0;
+	padding: 0 0 1px 56px;
 	font-size: 1.143em;
 }
 .board_info .board_description, .board_info .moderators {
@@ -4241,7 +4245,7 @@ dl.no_members {
 		min-width: 20em;
 	}
 	.board_name {
-		margin: 12px 0 0 56px;
+		margin: 12px 0 0;
 	}
 	.board_lastposter {
 		display: block;
@@ -4550,7 +4554,8 @@ dl.no_members {
 		word-wrap: break-word;
 	}
 	.board_name {
-		margin: 0 0 0 35px;
+		margin: 0;
+		padding: 0 0 1px 35px;
 	}
 	.board_info:after {
 		display: block;

--- a/themes/default/css/rtl.css
+++ b/themes/default/css/rtl.css
@@ -500,6 +500,9 @@ dl.settings img {
 .board_info .board_description, .board_info .moderators {
 	margin: 0 56px 0 0;
 }
+.board_name {
+	padding: 0 56px 1px 0;
+}
 .board_stats {
 	text-align: left;
 	padding: 1px 6px 1px 0;
@@ -1171,9 +1174,6 @@ div.labels {
 		margin-right: 0;
 		margin-left: 5px;
 	}
-	.board_name {
-		margin: 0 56px 0 0;
-	}
 	.board_description, .moderators, .childboards {
 		margin: 0 8px 0 0;
 	}
@@ -1247,7 +1247,8 @@ div.labels {
 		margin: 0 5px;
 	}
 	.board_name {
-		margin: 0 35px 0 0;
+		margin: 0;
+		padding: 0 35px 0 0;
 	}
 	#basicinfo, #detailedinfo {
 		float: none;


### PR DESCRIPTION
Discussed on the site .. http://www.elkarte.net/community/index.php?topic=3358

Not sure we want to fix this for 1.0.7 but here it is anyway

Board name with no natural break points, losses alignment on board index and overflowed the select drop down.  This will partially fix the issue should it ever arise in the real world (the select pull down can still misbehave) 