### PR TITLE
Some fixes for the smiley parser

### DIFF
--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -704,7 +704,7 @@ function parsesmileys(&$message)
 
 	$wrapper = \BBC\ParserWrapper::getInstance();
 	$parser = $wrapper->getSmileyParser();
-	$parser->parseBlock($message);
+	$message = $parser->parseBlock($message);
 }
 
 /**

--- a/sources/controllers/Emailpost.controller.php
+++ b/sources/controllers/Emailpost.controller.php
@@ -398,7 +398,7 @@ function pbe_create_post($pbe, $email_message, $topic_info)
 
 	// Validate they have permission to reply
 	$becomesApproved = true;
-	if (!in_array('postby_email', $pbe['user_info']['permissions']) && !$pbe['user_info']['admin'])
+	if (!in_array('postby_email', $pbe['user_info']['permissions']) && !$pbe['user_info']['is_admin'])
 		return pbe_emailError('error_permission', $email_message);
 	elseif ($topic_info['locked'] && !$pbe['user_info']['is_admin'] && !in_array('moderate_forum', $pbe['user_info']['permissions']))
 		return pbe_emailError('error_locked', $email_message);

--- a/sources/subs/BBC/Autolink.class.php
+++ b/sources/subs/BBC/Autolink.class.php
@@ -102,19 +102,21 @@ class Autolink
 	 *
 	 * @param string $data
 	 */
-	public function parse(&$data)
+	public function parse($data)
 	{
 		if ($this->hasLinks($data))
 		{
-			$this->parseLinks($data);
+			$data = $this->parseLinks($data);
 		}
 
 		if ($this->hasEmails($data))
 		{
-			$this->parseEmails($data);
+			$data = $this->parseEmails($data);
 		}
 
 		call_integration_hook('integrate_autolink_area', array(&$data, $this->bbc));
+
+		return $data;
 	}
 
 	/**
@@ -146,7 +148,7 @@ class Autolink
 	 *
 	 * @param $data
 	 */
-	public function parseLinks(&$data)
+	public function parseLinks($data)
 	{
 		// Switch out quotes really quick because they can cause problems.
 		$data = strtr($data, array('&#039;' => '\'', '&nbsp;' => "\xC2\xA0", '&quot;' => '>">', '"' => '<"<', '&lt;' => '<lt<'));
@@ -160,7 +162,7 @@ class Autolink
 		}
 
 		// Switch those quotes back
-		$data = strtr($data, array('\'' => '&#039;', "\xC2\xA0" => '&nbsp;', '>">' => '&quot;', '<"<' => '"', '<lt<' => '&lt;'));
+		return strtr($data, array('\'' => '&#039;', "\xC2\xA0" => '&nbsp;', '>">' => '&quot;', '<"<' => '"', '<lt<' => '&lt;'));
 	}
 
 	/**
@@ -189,10 +191,10 @@ class Autolink
 	 *
 	 * @param string $data
 	 */
-	public function parseEmails(&$data)
+	public function parseEmails($data)
 	{
 		// Next, emails...
-		$data = preg_replace($this->email_search, $this->email_replace, $data);
+		return preg_replace($this->email_search, $this->email_replace, $data);
 	}
 
 	/**

--- a/sources/subs/BBC/BBCParser.class.php
+++ b/sources/subs/BBC/BBCParser.class.php
@@ -277,7 +277,7 @@ class BBCParser
 			// Are we trimming outside this tag?
 			if (!empty($tag[Codes::ATTR_TRIM]) && $tag[Codes::ATTR_TRIM] !== Codes::TRIM_OUTSIDE)
 			{
-				$this->trimWhiteSpace($this->message, $this->pos + 1);
+				$this->message = $this->trimWhiteSpace($this->message, $this->pos + 1);
 			}
 		}
 	}
@@ -393,7 +393,7 @@ class BBCParser
 			// Trim inside whitespace
 			if (!empty($tag[Codes::ATTR_TRIM]) && $tag[Codes::ATTR_TRIM] !== Codes::TRIM_INSIDE)
 			{
-				$this->trimWhiteSpace($this->message, $this->pos + 1);
+				$this->message = $this->trimWhiteSpace($this->message, $this->pos + 1);
 			}
 		}
 
@@ -440,9 +440,9 @@ class BBCParser
 	 *
 	 * @param string $data
 	 */
-	protected function parseHTML(&$data)
+	protected function parseHTML($data)
 	{
-		$this->html_parser->parse($data);
+		return $this->html_parser->parse($data);
 	}
 
 	/**
@@ -1058,7 +1058,7 @@ class BBCParser
 		// For parsed content, we must recurse to avoid security problems.
 		if ($tag[Codes::ATTR_TYPE] === Codes::TYPE_PARSED_EQUALS)
 		{
-			$this->recursiveParser($data, $tag);
+			$data = $this->recursiveParser($data, $tag);
 		}
 
 		$tag[Codes::ATTR_AFTER] = strtr($tag[Codes::ATTR_AFTER], array('$1' => $data));
@@ -1140,7 +1140,7 @@ class BBCParser
 		if ($this->possible_html && strpos($data, '&lt;') !== false)
 		{
 			// @todo new \Parser\BBC\HTML;
-			$this->parseHTML($data);
+			$data = $this->parseHTML($data);
 		}
 
 		if (!empty($GLOBALS['modSettings']['autoLinkUrls']))
@@ -1287,7 +1287,7 @@ class BBCParser
 	 * @param string $data
 	 * @param array $tag
 	 */
-	protected function recursiveParser(&$data, array $tag)
+	protected function recursiveParser($data, array $tag)
 	{
 		// @todo if parsed tags allowed is empty, return?
 		$bbc = clone $this->bbc;
@@ -1303,7 +1303,7 @@ class BBCParser
 		call_integration_hook('integrate_recursive_bbc_parser', array(&$autolinker, &$html));
 
 		$parser = new \BBC\BBCParser($bbc, $autolinker, $html);
-		$data = $parser->enableSmileys(empty($tag[Codes::ATTR_PARSED_TAGS_ALLOWED]))->parse($data);
+		return $parser->enableSmileys(empty($tag[Codes::ATTR_PARSED_TAGS_ALLOWED]))->parse($data);
 	}
 
 	/**
@@ -1406,12 +1406,14 @@ class BBCParser
 	 * @param string &$message
 	 * @param null|int $offset = null
 	 */
-	protected function trimWhiteSpace(&$message, $offset = null)
+	protected function trimWhiteSpace($message, $offset = null)
 	{
-		if (preg_match('~(<br />|&nbsp;|\s)*~', $this->message, $matches, null, $offset) !== 0 && isset($matches[0]) && $matches[0] !== '')
+		if (preg_match('~(<br />|&nbsp;|\s)*~', $message, $matches, null, $offset) !== 0 && isset($matches[0]) && $matches[0] !== '')
 		{
-			$this->message = substr_replace($this->message, '', $this->pos, strlen($matches[0]));
+			return substr_replace($message, '', $this->pos, strlen($matches[0]));
 		}
+
+		return $message;
 	}
 
 	/**
@@ -1535,7 +1537,7 @@ class BBCParser
 
 			if (isset($tag[Codes::ATTR_TRIM]) && $tag[Codes::ATTR_TRIM] !== Codes::TRIM_INSIDE)
 			{
-				$this->trimWhiteSpace($this->message, $this->pos);
+				$this->message = $this->trimWhiteSpace($this->message, $this->pos);
 			}
 
 			$this->closeOpenedTag();

--- a/sources/subs/BBC/BBCParser.class.php
+++ b/sources/subs/BBC/BBCParser.class.php
@@ -1186,6 +1186,8 @@ class BBCParser
 		// If we have footnotes, add them in at the end of the message
 		if (!empty($fn_num))
 		{
+			$this->message = rtrim($this->message, "\r");
+
 			$this->message .= '<div class="bbc_footnotes">' . implode('', $this->fn_content) . '</div>';
 		}
 	}

--- a/sources/subs/BBC/BBCParser.class.php
+++ b/sources/subs/BBC/BBCParser.class.php
@@ -277,7 +277,7 @@ class BBCParser
 			// Are we trimming outside this tag?
 			if (!empty($tag[Codes::ATTR_TRIM]) && $tag[Codes::ATTR_TRIM] !== Codes::TRIM_OUTSIDE)
 			{
-				$this->message = $this->trimWhiteSpace($this->message, $this->pos + 1);
+				$this->trimWhiteSpace($this->pos + 1);
 			}
 		}
 	}
@@ -393,7 +393,7 @@ class BBCParser
 			// Trim inside whitespace
 			if (!empty($tag[Codes::ATTR_TRIM]) && $tag[Codes::ATTR_TRIM] !== Codes::TRIM_INSIDE)
 			{
-				$this->message = $this->trimWhiteSpace($this->message, $this->pos + 1);
+				$this->trimWhiteSpace($this->pos + 1);
 			}
 		}
 
@@ -1403,17 +1403,14 @@ class BBCParser
 	/**
 	 * Does what it says, removes whitespace
 	 *
-	 * @param string &$message
 	 * @param null|int $offset = null
 	 */
-	protected function trimWhiteSpace($message, $offset = null)
+	protected function trimWhiteSpace($offset = null)
 	{
-		if (preg_match('~(<br />|&nbsp;|\s)*~', $message, $matches, null, $offset) !== 0 && isset($matches[0]) && $matches[0] !== '')
+		if (preg_match('~(<br />|&nbsp;|\s)*~', $this->message, $matches, null, $offset) !== 0 && isset($matches[0]) && $matches[0] !== '')
 		{
-			return substr_replace($message, '', $this->pos, strlen($matches[0]));
+			substr_replace($this->message, '', $this->pos, strlen($matches[0]));
 		}
-
-		return $message;
 	}
 
 	/**
@@ -1537,7 +1534,7 @@ class BBCParser
 
 			if (isset($tag[Codes::ATTR_TRIM]) && $tag[Codes::ATTR_TRIM] !== Codes::TRIM_INSIDE)
 			{
-				$this->message = $this->trimWhiteSpace($this->message, $this->pos);
+				$this->trimWhiteSpace($this->pos);
 			}
 
 			$this->closeOpenedTag();

--- a/sources/subs/BBC/BBCParser.class.php
+++ b/sources/subs/BBC/BBCParser.class.php
@@ -50,6 +50,7 @@ class BBCParser
 	protected $num_footnotes = 0;
 	protected $smiley_marker = "\r";
 	protected $lastAutoPos = 0;
+	protected $fn_content = array();
 
 	/**
 	 * BBCParser constructor.
@@ -1168,14 +1169,14 @@ class BBCParser
 	 */
 	protected function handleFootnotes()
 	{
-		global $fn_num, $fn_content, $fn_count;
+		global $fn_num, $fn_count;
 		static $fn_total;
 
 		// @todo temporary until we have nesting
 		$this->message = str_replace(array('[footnote]', '[/footnote]'), '', $this->message);
 
 		$fn_num = 0;
-		$fn_content = array();
+		$this->fn_content = array();
 		$fn_count = isset($fn_total) ? $fn_total : 0;
 
 		// Replace our footnote text with a [1] link, save the text for use at the end of the message
@@ -1185,7 +1186,7 @@ class BBCParser
 		// If we have footnotes, add them in at the end of the message
 		if (!empty($fn_num))
 		{
-			$this->message .= '<div class="bbc_footnotes">' . implode('', $fn_content) . '</div>';
+			$this->message .= '<div class="bbc_footnotes">' . implode('', $this->fn_content) . '</div>';
 		}
 	}
 
@@ -1198,10 +1199,10 @@ class BBCParser
 	 */
 	protected function footnoteCallback(array $matches)
 	{
-		global $fn_num, $fn_content, $fn_count;
+		global $fn_num, $fn_count;
 
 		$fn_num++;
-		$fn_content[] = '<div class="target" id="fn' . $fn_num . '_' . $fn_count . '"><sup>' . $fn_num . '&nbsp;</sup>' . $matches[2] . '<a class="footnote_return" href="#ref' . $fn_num . '_' . $fn_count . '">&crarr;</a></div>';
+		$this->fn_content[] = '<div class="target" id="fn' . $fn_num . '_' . $fn_count . '"><sup>' . $fn_num . '&nbsp;</sup>' . $matches[2] . '<a class="footnote_return" href="#ref' . $fn_num . '_' . $fn_count . '">&crarr;</a></div>';
 
 		return '<a class="target" href="#fn' . $fn_num . '_' . $fn_count . '" id="ref' . $fn_num . '_' . $fn_count . '">[' . $fn_num . ']</a>';
 	}

--- a/sources/subs/BBC/BBCParser.class.php
+++ b/sources/subs/BBC/BBCParser.class.php
@@ -450,11 +450,11 @@ class BBCParser
 	 *
 	 * @param string $data
 	 */
-	protected function autoLink(&$data)
+	protected function autoLink($data)
 	{
 		if ($data === '' || $data === $this->smiley_marker || !$this->autolinker->hasPossible())
 		{
-			return;
+			return $data;
 		}
 
 		// Are we inside tags that should be auto linked?
@@ -464,12 +464,12 @@ class BBCParser
 			{
 				if (!$open_tag[Codes::ATTR_AUTOLINK])
 				{
-					return;
+					return $data;
 				}
 			}
 		}
 
-		$this->autolinker->parse($data);
+		return $this->autolinker->parse($data);
 	}
 
 	/**
@@ -1145,7 +1145,7 @@ class BBCParser
 
 		if (!empty($GLOBALS['modSettings']['autoLinkUrls']))
 		{
-			$this->autoLink($data);
+			$data = $this->autoLink($data);
 		}
 
 		// This cannot be moved earlier. It breaks tests

--- a/sources/subs/BBC/ParserWrapper.php
+++ b/sources/subs/BBC/ParserWrapper.php
@@ -179,24 +179,21 @@ class ParserWrapper
 		}
 
 		$parsers = $this->getParsersByArea($area);
+		$smileys_enabled = $this->smileys_enabled && $GLOBALS['user_info']['smiley_set'] !== 'none';
 
 		if (!$this->isEnabled())
 		{
 			// You need to run the smiley parser to get rid of the markers
-			$parsers['smiley']
-				->setEnabled($this->smileys_enabled && $GLOBALS['user_info']['smiley_set'] !== 'none')
+			return $parsers['smiley']
+				->setEnabled($smileys_enabled)
 				->parse($message);
-
-			return $message;
 		}
 
 		$message = $parsers['bbc']->parse($message);
 
-		$parsers['smiley']
-			->setEnabled($this->smileys_enabled && $GLOBALS['user_info']['smiley_set'] !== 'none')
+		return $parsers['smiley']
+			->setEnabled($smileys_enabled)
 			->parse($message);
-
-		return $message;
 	}
 
 	/**

--- a/sources/subs/BBC/SmileyParser.class.php
+++ b/sources/subs/BBC/SmileyParser.class.php
@@ -71,19 +71,19 @@ class SmileyParser
 	 *
 	 * @param string $message
 	 */
-	public function parseBlock(&$message)
+	public function parseBlock($message)
 	{
 		// No smiley set at all?!
 		if (!$this->enabled || $message === '' || trim($message) === '')
 		{
-			return;
+			return $message;
 		}
 
 		// Replace away!
-		$message = preg_replace_callback($this->search, array($this, 'parser_callback'), $message);
+		return preg_replace_callback($this->search, array($this, 'parser_callback'), $message);
 	}
 
-	public function parse(&$message)
+	public function parse($message)
 	{
 		// Parse the smileys within the parts where it can be done safely.
 		if ($this->enabled && trim($message) !== '')
@@ -93,15 +93,15 @@ class SmileyParser
 			// first part (0) parse smileys. Then every other one after that parse smileys
 			for ($i = 0, $n = count($message_parts); $i < $n; $i += 2)
 			{
-				$this->parseBlock($message_parts[$i]);
+				$message_parts[$i] = $this->parseBlock($message_parts[$i]);
 			}
 
-			$message = implode('', $message_parts);
+			return implode('', $message_parts);
 		}
 		// No smileys, just get rid of the markers.
 		else
 		{
-			$message = str_replace($this->marker, '', $message);
+			return str_replace($this->marker, '', $message);
 		}
 	}
 

--- a/sources/subs/Profile.subs.php
+++ b/sources/subs/Profile.subs.php
@@ -1915,7 +1915,7 @@ function profileValidateSignature(&$value)
 		$wrapper = \BBC\ParserWrapper::getInstance();
 		$parser = $wrapper->getSmileyParser();
 		$parser->setEnabled($GLOBALS['user_info']['smiley_set'] !== 'none' && trim($smiley_parsed) !== '');
-		$parser->parseBlock($smiley_parsed);
+		$smiley_parsed = $parser->parseBlock($smiley_parsed);
 
 		$smiley_count = substr_count(strtolower($smiley_parsed), '<img') - substr_count(strtolower($unparsed_signature), '<img');
 		if (!empty($sig_limits[4]) && $sig_limits[4] == -1 && $smiley_count > 0)


### PR DESCRIPTION
@joshuaadickerson FYI something related to the parser ;)

Anyway, the way smiley are parsed (i.e. splitting on "\r" and parsing only every even index of the resulting array) looks quite fragile to me (I know it dates back to SMF, but in the next round of refactoring we should do something about it... of course IMO :stuck_out_tongue: ).