### PR TITLE
Php 7

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -35,6 +35,7 @@ global $boarddir, $sourcedir;
 $ssi_error_reporting = error_reporting(E_ALL | E_STRICT);
 
 // Directional only script time usage for display
+// getrusage is missing in php < 7 on Windows
 if (function_exists('getrusage'))
 	$rusage_start = getrusage();
 else

--- a/index.php
+++ b/index.php
@@ -32,6 +32,7 @@ const CACHE_STALE = '?R11';
 error_reporting(E_ALL | E_STRICT & ~8192);
 
 // Directional only script time usage for display
+// getrusage is missing in php < 7 on Windows
 if (function_exists('getrusage'))
 	$rusage_start = getrusage();
 else

--- a/sources/Debug.class.php
+++ b/sources/Debug.class.php
@@ -181,7 +181,7 @@ class Debug
 
 	/**
 	 * Adds a new getrusage value (by default two are added: one at the beginning
-	 * of the script execution and one at the end
+	 * of the script execution and one at the end)
 	 *
 	 * @param string $point can be end or start depending on when the function
 	 *               is called
@@ -189,6 +189,7 @@ class Debug
 	 */
 	public function rusage($point, $rusage = null)
 	{
+		// getrusage is missing in php < 7 on Windows
 		if (!function_exists('getrusage') || !$this->_track)
 			return;
 

--- a/sources/Debug.class.php
+++ b/sources/Debug.class.php
@@ -190,8 +190,10 @@ class Debug
 	public function rusage($point, $rusage = null)
 	{
 		// getrusage is missing in php < 7 on Windows
-		if (!function_exists('getrusage') || !$this->_track)
+		if ($this->_track === false || function_exists('getrusage') === false)
+		{
 			return;
+		}
 
 		if ($rusage === null)
 			$this->_rusage[$point] = getrusage();

--- a/sources/Errors.class.php
+++ b/sources/Errors.class.php
@@ -316,11 +316,12 @@ class Errors
 	 *
 	 * - It dies with fatal_error() if the error_level matches with error_reporting.
 	 *
-	 * @param Exception $e
+	 * @param Exception|Throwable $e The error. Since the code shall work with php 5 and 7
+	 *                               we cannot type-hint the function parameter.
 	 * @param string|null $err_file
 	 * @param int|null $err_line
 	 */
-	public function exception_handler(Exception $e, $err_file = null, $err_line = null)
+	public function exception_handler($e, $err_file = null, $err_line = null)
 	{
 		$this->error_text = '';
 

--- a/sources/SiteDispatcher.class.php
+++ b/sources/SiteDispatcher.class.php
@@ -254,7 +254,7 @@ class Site_Dispatcher
 			// Call integrate_action_XYZ_before -> XYZ_controller -> integrate_action_XYZ_after
 			call_integration_hook('integrate_action_' . $hook . '_before', array($this->_function_name));
 
-			$result = $controller->$method();
+			$result = $controller->{$method}();
 
 			call_integration_hook('integrate_action_' . $hook . '_after', array($this->_function_name));
 

--- a/sources/admin/PackageServers.controller.php
+++ b/sources/admin/PackageServers.controller.php
@@ -405,7 +405,7 @@ class PackageServers_Controller extends Action_Controller
 		// Download from a package server?
 		if (isset($this->_req->query->server))
 		{
-			list(, $url, $server) = $this->_package_server();
+			list($dummy, $url, $server) = $this->_package_server();
 
 			// Fetch the package listing from the package server
 			$listing = json_decode(fetch_web_data($url));

--- a/sources/controllers/Auth.controller.php
+++ b/sources/controllers/Auth.controller.php
@@ -350,6 +350,7 @@ class Auth_Controller extends Action_Controller
 		// Correct password, but they've got no salt; fix it!
 		if ($user_settings['password_salt'] === '')
 		{
+			require_once(SUBSDIR . '/Members.subs.php');
 			$tokenizer = new Token_Hash();
 			$user_settings['password_salt'] = $tokenizer->generate_hash(4);
 			updateMemberData($user_settings['id_member'], array('password_salt' => $user_settings['password_salt']));

--- a/sources/subs/SettingsForm.class.php
+++ b/sources/subs/SettingsForm.class.php
@@ -118,7 +118,7 @@ class Settings_Form
 			else
 			{
 				$varname = $config_var[0];
-				global $$varname;
+				global ${$varname};
 
 				// Set the subtext in case it's part of the label.
 				// @todo Temporary. Preventing divs inside label tags.

--- a/themes/default/ProfileOptions.template.php
+++ b/themes/default/ProfileOptions.template.php
@@ -347,7 +347,15 @@ function template_edit_options()
 				{
 					// Is this some code to generate the options?
 					if (!is_array($field['options']))
-						$field['options'] = eval($field['options']);
+					{
+						try
+						{
+							$field['options'] = eval($field['options']);
+						}
+						catch (ParseError $e)
+						{
+							$field['options'] = '';
+						}
 
 					// Assuming we now have some!
 					if (is_array($field['options']))

--- a/themes/default/Register.template.php
+++ b/themes/default/Register.template.php
@@ -314,6 +314,7 @@ function template_registration_form()
 							{
 								$field['options'] = '';
 							}
+						}
 
 						// Assuming we now have some!
 						if (is_array($field['options']))

--- a/themes/default/Register.template.php
+++ b/themes/default/Register.template.php
@@ -305,13 +305,25 @@ function template_registration_form()
 					{
 						// Is this some code to generate the options?
 						if (!is_array($field['options']))
-							$field['options'] = eval($field['options']);
+						{
+							try
+							{
+								$field['options'] = eval($field['options']);
+							}
+							catch (ParseError $e)
+							{
+								$field['options'] = '';
+							}
 
 						// Assuming we now have some!
 						if (is_array($field['options']))
+						{
 							foreach ($field['options'] as $value => $name)
+							{
 								echo '
 							<option value="', $value, '" ', $value == $field['value'] ? 'selected="selected"' : '', '>', $name, '</option>';
+							}
+						}
 					}
 
 					echo '


### PR DESCRIPTION
A set of changes to make Elk a bit more php-7-ready.

I have just few doubts:
  1. substr() now returns an empty string, if string is equal to start characters long. 
  2. the eval in Cache.class.php (I suspect it should be extracted from the if and put in a try/catch)
  3. the list comment <blockquote>In general, it is recommended not to rely on the order in which list() assignments occur, as this is an implementation detail that may change again in the future. </blockquote>
  4. #2599 
  5. the changes to foreach may create some subtle bug http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.foreach but review all the foreach is basically impossible, so let's hope to find them during beta (yeah, I like betting! :stuck_out_tongue_winking_eye:  )

and that's all.