### PR TITLE
Call the frontpage method directly

### DIFF
--- a/sources/SiteDispatcher.class.php
+++ b/sources/SiteDispatcher.class.php
@@ -83,9 +83,10 @@ class Site_Dispatcher
 			'controller' => 'BoardIndex_Controller',
 			'function' => 'action_boardindex'
 		);
-
-		// Reminder: hooks need to account for multiple addons setting this hook.
-		call_integration_hook('integrate_action_frontpage', array(&$this->_default_action));
+		if (!empty($modSettings['front_page']) && is_callable(array($modSettings['front_page'], 'frontPageHook')))
+		{
+			call_user_func_array(array($modSettings['front_page'], 'frontPageHook'), array(&$this->_default_action));
+		}
 
 		$this->_noActionActions($action, !empty($modSettings['allow_guestAccess']));
 

--- a/sources/admin/ManageFeatures.controller.php
+++ b/sources/admin/ManageFeatures.controller.php
@@ -258,19 +258,15 @@ class ManageFeatures_Controller extends Action_Controller
 		// Saving?
 		if (isset($this->_req->query->save))
 		{
-			// Remove and reset if needed
-			if (!empty($modSettings['front_page']))
-			{
-				Hooks::get()->remove('integrate_action_frontpage', $modSettings['front_page'] . '::frontPageHook');
-			}
-
 			// Setting a custom frontpage, set the hook to the FrontpageInterface of the controller
 			if (!empty($this->_req->post->front_page))
 			{
 				$front_page = (string) $this->_req->post->front_page;
-				if ($front_page::validateFrontPageOptions($this->_req->post))
-				{
-					Hooks::get()->add('integrate_action_frontpage', $front_page . '::frontPageHook');
+				if (
+					is_callable(array($modSettings['front_page'], 'validateFrontPageOptions'))
+					&& !$front_page::validateFrontPageOptions($this->_req->post)
+				) {
+					$this->_req->post->front_page = '';
 				}
 			}
 


### PR DESCRIPTION
This removes integrate_action_frontpage since I think it is overkill. This can prevent conflicts with addons that don't understand the system well enough.