### PR TITLE
More dynamic group exclusion rules for inline permissions

### DIFF
--- a/sources/subs/SettingsForm.class.php
+++ b/sources/subs/SettingsForm.class.php
@@ -225,7 +225,7 @@ class Settings_Form
 
 				// Special case for inline permissions
 				if ($config_var[0] == 'permissions' && allowedTo('manage_permissions'))
-					$inlinePermissions[] = $config_var[1];
+					$inlinePermissions[] = $config_var;
 				elseif ($config_var[0] == 'permissions')
 					continue;
 


### PR DESCRIPTION
    /**
     * Configuration variables and values, for this settings form.
     *
     * @var array
     */
    $config_vars = [
        ['permissions', 'my_var', 'excluded_groups' => [-1]],
    ];