### PR TITLE
Cache

### DIFF
--- a/sources/admin/Admin.controller.php
+++ b/sources/admin/Admin.controller.php
@@ -27,6 +27,9 @@
 
 class Admin_Controller extends Action_Controller
 {
+	private $_checkFor = array('gd', 'imagick', 'db_server', 'php', 'server',
+							  'zend', 'apc', 'memcache', 'memcached', 'xcache', 'opcache');
+
 	/**
 	 * Pre Dispatch, called before other methods.  Loads integration hooks
 	 * and HttpReq instance.
@@ -640,22 +643,7 @@ class Admin_Controller extends Action_Controller
 		$context['forum_version'] = FORUM_VERSION;
 
 		// Get a list of current server versions.
-		$checkFor = array(
-			'gd',
-			'imagick',
-			'db_server',
-			'mmcache',
-			'eaccelerator',
-			'zend',
-			'apc',
-			'memcache',
-			'xcache',
-			'opcache',
-			'php',
-			'server',
-		);
-		$context['current_versions'] = getServerVersions($checkFor);
-
+		$context['current_versions'] = getServerVersions($this->_checkFor);
 		$context['can_admin'] = allowedTo('admin_forum');
 		$context['sub_template'] = 'admin';
 		$context['page_title'] = $txt['admin_center'];
@@ -712,22 +700,7 @@ class Admin_Controller extends Action_Controller
 		$context['forum_version'] = FORUM_VERSION;
 
 		// Get a list of current server versions.
-		$checkFor = array(
-			'gd',
-			'imagick',
-			'db_server',
-			'mmcache',
-			'eaccelerator',
-			'zend',
-			'apc',
-			'memcached',
-			'xcache',
-			'opcache',
-			'php',
-			'server',
-		);
-		$context['current_versions'] = getServerVersions($checkFor);
-
+		$context['current_versions'] = getServerVersions($this->_checkFor);
 		$context['can_admin'] = allowedTo('admin_forum');
 		$context['sub_template'] = 'credits';
 		$context['page_title'] = $txt['support_credits_title'];

--- a/sources/subs/Attachments.subs.php
+++ b/sources/subs/Attachments.subs.php
@@ -438,7 +438,7 @@ function processAttachments($id_msg = null)
 		// This is a generic error
 		$attach_errors->activate();
 		$attach_errors->addError('attach_no_upload');
-		$attach_errors->addError(is_array($attachment) ? array($attachment[0], $attachment[1]) : $attachment);
+		$attach_errors->addError(isset($attachment) && is_array($attachment) ? array($attachment[0], $attachment[1]) : (isset($attachment) ? $attachment : ''));
 
 		// And delete the files 'cos they ain't going nowhere.
 		foreach ($_FILES['attachment']['tmp_name'] as $n => $dummy)

--- a/sources/subs/Cache.class.php
+++ b/sources/subs/Cache.class.php
@@ -175,7 +175,9 @@ class Cache
 	 * - It supports:
 	 *   - Xcache: http://xcache.lighttpd.net/wiki/XcacheApi
 	 *   - memcache: http://www.php.net/memcache
+	 *   - memcached: http://www.php.net/memcached
 	 *   - APC: http://www.php.net/apc
+	 *   - APCu: http://us3.php.net/manual/en/book.apcu.php
 	 *   - Zend: http://files.zend.com/help/Zend-Platform/output_cache_functions.htm
 	 *   - Zend: http://files.zend.com/help/Zend-Platform/zend_cache_functions.htm
 	 *
@@ -458,7 +460,7 @@ class Cache
 					'cache_password' => $cache_password,
 				);
 			}
-			elseif ($cache_accelerator === 'memcached')
+			elseif (substr($cache_accelerator, 0, 8) === 'memcache')
 			{
 				$options = array(
 					'servers' => explode(',', $cache_memcached),

--- a/sources/subs/Cache.subs.php
+++ b/sources/subs/Cache.subs.php
@@ -55,6 +55,7 @@ function cache_put_data($key, $value, $ttl = 120)
 
 /**
  * Gets the value from the cache specified by key, so long as it is not older than ttl seconds.
+ *
  * - It may often "miss", so shouldn't be depended on.
  * - It supports the same as Cache::instance()->put().
  *
@@ -94,6 +95,7 @@ function clean_cache($type = '')
  *             an array with 'title' and 'version' is returned.
  *             If false, for each engine available an array with 'title' (string)
  *             and 'supported' (bool) is returned.
+ *
  * @return mixed[]
  */
 function loadCacheEngines($supported_only = true)
@@ -116,7 +118,9 @@ function loadCacheEngines($supported_only = true)
 			if ($obj instanceof ElkArte\sources\subs\CacheMethod\Cache_Method_Abstract)
 			{
 				if ($supported_only && $obj->isAvailable())
+				{
 					$engines[strtolower($engine_name)] = $obj->details();
+				}
 				elseif ($supported_only === false)
 				{
 					$engines[strtolower($engine_name)] = $obj;

--- a/sources/subs/CacheMethod/CacheMethodAbstract.php
+++ b/sources/subs/CacheMethod/CacheMethodAbstract.php
@@ -21,10 +21,16 @@ abstract class Cache_Method_Abstract implements Cache_Method_Interface
 {
 	/**
 	 * The settings of the caching engine
+	 *
 	 * @var array
 	 */
 	public $_options = null;
 
+	/**
+	 * Cache hit or not
+	 *
+	 * @var bool
+	 */
 	protected $is_miss = true;
 
 	/**
@@ -59,8 +65,7 @@ abstract class Cache_Method_Abstract implements Cache_Method_Interface
 	}
 
 	/**
-	 * Obtain the variables necessary to
-	 * help build the final key for storage.
+	 * Obtain the variables necessary to help build the final key for storage.
 	 *
 	 * @param string $key
 	 * @return string
@@ -89,7 +94,7 @@ abstract class Cache_Method_Abstract implements Cache_Method_Interface
 	/**
 	 * {@inheritdoc}
 	 */
-	public function settings(&$confing_vars)
+	public function settings(&$config_vars)
 	{
 	}
 

--- a/sources/subs/CacheMethod/CacheMethodInterface.php
+++ b/sources/subs/CacheMethod/CacheMethodInterface.php
@@ -72,7 +72,7 @@ interface Cache_Method_Interface
 	public function clean($type = '');
 
 	/**
-	 * Certain caching engines (e.g. filesyste) may require fixes to the cache key
+	 * Certain caching engines (e.g. filesystem) may require fixes to the cache key
 	 * this method is here to allow fixing the key appropriately.
 	 *
 	 * @param string $key

--- a/sources/subs/CacheMethod/Filebased.php
+++ b/sources/subs/CacheMethod/Filebased.php
@@ -50,6 +50,7 @@ class Filebased extends Cache_Method_Abstract
 	 * to help the tests stay running smoothly.
 	 *
 	 * @param string $key
+	 *
 	 * @return string
 	 */
 	public function getFileName($key)
@@ -85,7 +86,9 @@ class Filebased extends Cache_Method_Abstract
 			// Write out the cache file, check that the cache write was successful; all the data must be written
 			// If it fails due to low diskspace, or other, remove the cache file
 			if (@file_put_contents(CACHEDIR . '/' . $fName, $cache_data, LOCK_EX) !== strlen($cache_data))
+			{
 				@unlink(CACHEDIR . '/' . $fName);
+			}
 		}
 	}
 
@@ -102,6 +105,7 @@ class Filebased extends Cache_Method_Abstract
 			if (filesize(CACHEDIR . '/' . $fName) > 10)
 			{
 				$value = json_decode(file_get_contents(CACHEDIR . '/' . $fName));
+
 				if ($value->expiration < time())
 				{
 					@unlink(CACHEDIR . '/' . $fName);
@@ -111,12 +115,14 @@ class Filebased extends Cache_Method_Abstract
 				{
 					$return = $value->data;
 				}
+
 				unset($value);
 				$this->is_miss = $return === null;
 
 				return $return;
 			}
 		}
+
 		$this->is_miss = true;
 
 		return $return;
@@ -127,16 +133,16 @@ class Filebased extends Cache_Method_Abstract
 	 */
 	public function clean($type = '')
 	{
-		// To be complete, we also clear out the cache dir so we get any js/css hive files
-		// Remove the cache files in our disk cache directory
 		try
 		{
 			$files = new FilesystemIterator(CACHEDIR, FilesystemIterator::SKIP_DOTS);
 
 			foreach ($files as $file)
 			{
-				if ($file->getFileName() !== 'index.php' && $file->getFileName() !== '.htaccess' && (!$type || $file->getExtension() == $type))
+				if ($file->getFileName() !== 'index.php' && $file->getFileName() !== '.htaccess' && $file->getExtension() === 'json')
+				{
 					@unlink($file->getPathname());
+				}
 			}
 		}
 		catch (UnexpectedValueException $e)

--- a/sources/subs/CacheMethod/Memcache.php
+++ b/sources/subs/CacheMethod/Memcache.php
@@ -81,7 +81,7 @@ class Memcache extends Cache_Method_Abstract
 			$this->obj->delete($key);
 		}
 
-		$this->obj->set($key, $value, 0, $ttl);
+		$this->obj->set($key, $value, MEMCACHE_COMPRESSED, $ttl);
 	}
 
 	/**
@@ -180,13 +180,11 @@ class Memcache extends Cache_Method_Abstract
 	 */
 	public function details()
 	{
-		global $txt;
-
 		$version = @$this->obj->getVersion();
 
 		return array(
 			'title' => $this->title(),
-			'version' => !empty($version) ? $version : $txt['not_applicable']
+			'version' => !empty($version) ? $version : '0.0.0'
 		);
 	}
 
@@ -202,8 +200,8 @@ class Memcache extends Cache_Method_Abstract
 		global $txt;
 
 		$var = array(
-			'cache_memcached', $txt['cache_memcached'], 'file', 'text', $txt['cache_memcached'], 'cache_memcached',
-			'force_div_id' => 'memcached_cache_memcached',
+			'cache_memcached', $txt['cache_memcache'], 'file', 'text', 30, 'cache_memcached',
+			'force_div_id' => 'memcache_cache_memcache',
 		);
 
 		$serversmList = $this->getServers();

--- a/sources/subs/CacheMethod/Memcache.php
+++ b/sources/subs/CacheMethod/Memcache.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * This file contains functions that deal with getting and setting cache values.
+ *
+ * @name      ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause
+ *
+ * @version 1.1 beta 4
+ *
+ */
+
+namespace ElkArte\sources\subs\CacheMethod;
+
+/**
+ * Memcached and Memcache.
+ */
+class Memcache extends Cache_Method_Abstract
+{
+	/**
+	 * {@inheritdoc}
+	 */
+	protected $title = 'Memcache';
+
+	/**
+	 * Creates a Memcache instance representing the connection to the memcache servers.
+	 *
+	 * @var \Memcache
+	 */
+	protected $obj;
+
+	/**
+	 * If the daemon has valid servers in it pool
+	 *
+	 * @var bool
+	 */
+	protected $_is_running;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function __construct($options)
+	{
+		if (empty($options['servers']))
+		{
+			$options['servers'] = array('');
+		}
+
+		parent::__construct($options);
+
+		if ($this->isAvailable())
+		{
+			$this->obj = new \Memcache;
+			$this->_is_running = $this->addServers();
+		}
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function exists($key)
+	{
+		$this->get($key);
+
+		return !$this->is_miss;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function put($key, $value, $ttl = 120)
+	{
+		if (!$this->_is_running)
+		{
+			return false;
+		}
+
+		if ($value === null)
+		{
+			$this->obj->delete($key);
+		}
+
+		$this->obj->set($key, $value, 0, $ttl);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get($key, $ttl = 120)
+	{
+		if (!$this->_is_running)
+		{
+			return false;
+		}
+
+		$result = $this->obj->get($key);
+		$this->is_miss = $result === null || $result === false;
+
+		return $result;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function clean($type = '')
+	{
+		if (!$this->_is_running)
+		{
+			return false;
+		}
+
+		// Clear it out, really invalidate whats there
+		$this->obj->flush();
+	}
+
+	/**
+	 * Add memcache servers.
+	 *
+	 * Don't add servers if they already exist. Ideal for persistent connections.
+	 *
+	 * @return bool True if there are servers in the daemon, false if not.
+	 */
+	protected function addServers()
+	{
+		$serversmList = $this->getServers();
+		$retVal = !empty($serversmList);
+
+		foreach ($this->_options['servers'] as $server)
+		{
+			$server = explode(':', trim($server));
+			$server[0] = !empty($server[0]) ? $server[0] : 'localhost';
+			$server[1] = !empty($server[1]) ? $server[1] : 11211;
+
+			if (!in_array(implode(':', $server), $serversmList, true))
+			{
+				$retVal |= $this->obj->addServer($server[0], $server[1], $this->is_persit());
+				$this->setOptions($server[0], $server[1]);
+			}
+		}
+
+		return $retVal;
+	}
+
+	/**
+	 * Get memcache servers.
+	 *
+	 * @return array A list of servers in the daemon.
+	 */
+	protected function getServers()
+	{
+		$servers = @$this->obj->getExtendedStats();
+
+		return !empty($servers) ? array_keys((array) $servers) : array();
+	}
+
+	/**
+	 * Set a few server specific options.  Could be done as part of setServer
+	 * but left here for convenience
+	 *
+	 * @param string $server
+	 * @param int    $port
+	 */
+	protected function setOptions($server, $port)
+	{
+		// host, port, timeout, retry_interval, status
+		$this->obj->setServerParams($server, $port, 1, 5, true);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isAvailable()
+	{
+		return class_exists('\\Memcache');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function details()
+	{
+		global $txt;
+
+		$version = @$this->obj->getVersion();
+
+		return array(
+			'title' => $this->title(),
+			'version' => !empty($version) ? $version : $txt['not_applicable']
+		);
+	}
+
+	/**
+	 * Adds the settings to the settings page.
+	 *
+	 * Used by integrate_modify_cache_settings added in the title method
+	 *
+	 * @param array $config_vars
+	 */
+	public function settings(&$config_vars)
+	{
+		global $txt;
+
+		$var = array(
+			'cache_memcached', $txt['cache_memcached'], 'file', 'text', $txt['cache_memcached'], 'cache_memcached',
+			'force_div_id' => 'memcached_cache_memcached',
+		);
+
+		$serversmList = $this->getServers();
+
+		if (!empty($serversmList))
+		{
+			$var['postinput'] = $txt['cache_memcached_servers'] . implode('</li><li>', $serversmList) . '</li></ul>';
+		}
+
+		$config_vars[] = $var;
+	}
+
+	/**
+	 * If this should be done as a persistent connection
+	 *
+	 * @return string
+	 */
+	private function is_persit()
+	{
+		global $db_persist;
+
+		return !empty($db_persist);
+	}
+}

--- a/sources/subs/CacheMethod/Memcache.php
+++ b/sources/subs/CacheMethod/Memcache.php
@@ -134,7 +134,7 @@ class Memcache extends Cache_Method_Abstract
 
 			if (!in_array(implode(':', $server), $serversmList, true))
 			{
-				$retVal |= $this->obj->addServer($server[0], $server[1], $this->is_persit());
+				$retVal |= $this->obj->addServer($server[0], $server[1], $this->_is_persist());
 				$this->setOptions($server[0], $server[1]);
 			}
 		}
@@ -219,7 +219,7 @@ class Memcache extends Cache_Method_Abstract
 	 *
 	 * @return string
 	 */
-	private function is_persit()
+	private function _is_persist()
 	{
 		global $db_persist;
 

--- a/sources/subs/CacheMethod/Memcached.php
+++ b/sources/subs/CacheMethod/Memcached.php
@@ -44,7 +44,7 @@ class Memcached extends Cache_Method_Abstract
 
 		if ($this->isAvailable())
 		{
-			$this->obj = new \Memcached($this->is_persit());
+			$this->obj = new \Memcached($this->_is_persist());
 			$this->setOptions();
 			$this->addServers();
 		}
@@ -216,7 +216,7 @@ class Memcached extends Cache_Method_Abstract
 	 *
 	 * @return string|null
 	 */
-	private function is_persit()
+	private function _is_persist()
 	{
 		global $db_persist;
 

--- a/sources/subs/CacheMethod/Xcache.php
+++ b/sources/subs/CacheMethod/Xcache.php
@@ -58,9 +58,13 @@ class Xcache extends Cache_Method_Abstract
 	public function put($key, $value, $ttl = 120)
 	{
 		if ($value === null)
+		{
 			xcache_unset($key);
+		}
 		else
+		{
 			xcache_set($key, $value, $ttl);
+		}
 	}
 
 	/**
@@ -87,13 +91,17 @@ class Xcache extends Cache_Method_Abstract
 		if ($type === '' || $type === 'user')
 		{
 			for ($i = 0; $i < $vcnt; $i++)
+			{
 				xcache_clear_cache(XC_TYPE_VAR, $i);
+			}
 		}
 
 		if ($type === '' || $type === 'data')
 		{
 			for ($i = 0; $i < $pcnt; $i++)
+			{
 				xcache_clear_cache(XC_TYPE_PHP, $i);
+			}
 		}
 	}
 

--- a/sources/subs/CacheMethod/Zend.php
+++ b/sources/subs/CacheMethod/Zend.php
@@ -29,6 +29,7 @@ class Zend extends Cache_Method_Abstract
 	public function exists($key)
 	{
 		$this->get($this->getprefixedKey($key));
+
 		return !$this->is_miss;
 	}
 

--- a/sources/subs/SettingsFormAdapter/File.php
+++ b/sources/subs/SettingsFormAdapter/File.php
@@ -75,31 +75,33 @@ class File extends Db
 			'mmessage',
 			'mbname',
 		);
+
 		foreach ($this->configVars as $identifier => $configVar)
 		{
 			$new_setting = $configVar;
+
 			if (is_array($configVar) && isset($configVar[1]))
 			{
 				$varname = $configVar[0];
 				global ${$varname};
 
 				// Rewrite the definition a bit.
-				$new_setting = array(
-					$configVar[3],
-					$configVar[0],
-					'text_label' => $configVar[1],
-				);
+				$new_setting[0] = $configVar[3];
+				$new_setting[1] = $configVar[0];
+				$new_setting['text_label'] = $configVar[1];
+
 				if (isset($configVar[4]))
 				{
 					$new_setting[2] = $configVar[4];
 				}
+
 				if (isset($configVar[5]))
 				{
 					$new_setting['helptext'] = $configVar[5];
 				}
 
 				// Special value needed from the settings file?
-				if ($configVar[2] == 'file')
+				if ($configVar[2] === 'file')
 				{
 					$value = in_array($varname, $defines) ? constant(strtoupper($varname)) : $$varname;
 					if (in_array($varname, $safe_strings))
@@ -172,13 +174,13 @@ class File extends Db
 			function ($configVar)
 			{
 				// We just saved the file-based settings, so skip their definitions.
-				if (!is_array($configVar) || $configVar[2] == 'file')
+				if (!is_array($configVar) || $configVar[2] === 'file')
 				{
 					return '';
 				}
 
 				// Rewrite the definition a bit.
-				if (is_array($configVar) && $configVar[2] == 'db')
+				if (is_array($configVar) && $configVar[2] === 'db')
 				{
 					return array($configVar[3], $configVar[0]);
 				}
@@ -214,11 +216,11 @@ class File extends Db
 		// Fix the forum's URL if necessary.
 		if (isset($this->configValues['boardurl']))
 		{
-			if (substr($this->configValues['boardurl'], -10) == '/index.php')
+			if (substr($this->configValues['boardurl'], -10) === '/index.php')
 			{
 				$this->configValues['boardurl'] = substr($this->configValues['boardurl'], 0, -10);
 			}
-			elseif (substr($this->configValues['boardurl'], -1) == '/')
+			elseif (substr($this->configValues['boardurl'], -1) === '/')
 			{
 				$this->configValues['boardurl'] = substr($this->configValues['boardurl'], 0, -1);
 			}
@@ -363,7 +365,7 @@ class File extends Db
 		for ($i = 0, $n = count($this->settingsArray); $i < $n; $i++)
 		{
 			// Don't trim or bother with it if it's not a variable.
-			if (substr($this->settingsArray[$i], 0, 1) != '$')
+			if (substr($this->settingsArray[$i], 0, 1) !== '$')
 			{
 				continue;
 			}
@@ -384,7 +386,7 @@ class File extends Db
 			}
 
 			// End of the file ... maybe
-			if (substr(trim($this->settingsArray[$i]), 0, 2) == '?' . '>')
+			if (substr(trim($this->settingsArray[$i]), 0, 2) === '?' . '>')
 			{
 				$end = $i;
 			}
@@ -399,7 +401,7 @@ class File extends Db
 		// Still more variables to go?  Then lets add them at the end.
 		if (!empty($this->new_settings))
 		{
-			if (trim($this->settingsArray[$end]) == '?' . '>')
+			if (trim($this->settingsArray[$end]) === '?' . '>')
 			{
 				$this->settingsArray[$end++] = '';
 			}

--- a/sources/subs/SettingsFormAdapter/File.php
+++ b/sources/subs/SettingsFormAdapter/File.php
@@ -137,7 +137,7 @@ class File extends Db
 	 */
 	public function save()
 	{
-		$this->cleanSettings();
+		$this->_cleanSettings();
 
 		// When was Settings.php last changed?
 		$this->last_settings_change = filemtime(BOARDDIR . '/Settings.php');
@@ -199,7 +199,7 @@ class File extends Db
 	/**
 	 * Fix the cookie name by removing invalid characters
 	 */
-	private function fixCookieName()
+	private function _fixCookieName()
 	{
 		// Fix the darn stupid cookiename! (more may not be allowed, but these for sure!)
 		if (isset($this->configValues['cookiename']))
@@ -209,11 +209,10 @@ class File extends Db
 	}
 
 	/**
-	 *
+	 * Fix the forum's URL if necessary so that it is a valid root url
 	 */
-	private function fixBoardUrl()
+	private function _fixBoardUrl()
 	{
-		// Fix the forum's URL if necessary.
 		if (isset($this->configValues['boardurl']))
 		{
 			if (substr($this->configValues['boardurl'], -10) === '/index.php')
@@ -230,12 +229,12 @@ class File extends Db
 	}
 
 	/**
-	 *
+	 * For all known configuration values, ensures they are properly cast / escaped
 	 */
-	private function cleanSettings()
+	private function _cleanSettings()
 	{
-		$this->fixCookieName();
-		$this->fixBoardUrl();
+		$this->_fixCookieName();
+		$this->_fixBoardUrl();
 
 		// Any passwords?
 		$config_passwords = array(
@@ -290,6 +289,7 @@ class File extends Db
 			}
 		}
 
+		// Escape and update Setting strings
 		foreach ($config_strs as $configVar)
 		{
 			if (isset($this->configValues[$configVar]))
@@ -305,6 +305,7 @@ class File extends Db
 			}
 		}
 
+		// Ints are saved as integers
 		foreach ($config_ints as $configVar)
 		{
 			if (isset($this->configValues[$configVar]))
@@ -313,6 +314,7 @@ class File extends Db
 			}
 		}
 
+		// Convert checkbox selections to 0 / 1
 		foreach ($config_bools as $key)
 		{
 			// Check boxes need to be part of this settings form
@@ -345,7 +347,11 @@ class File extends Db
 	}
 
 	/**
+	 * Updates / Validates the Settings array for later output.
 	 *
+	 * - Updates any values that have been changed.
+	 * - Key/value pairs that did not exists are added at the end of the array.
+	 * - Ensures the completed array is valid for later output
 	 */
 	private function _prepareSettings()
 	{
@@ -424,6 +430,7 @@ class File extends Db
 
 	/**
 	 * Write out the contents of Settings.php file.
+	 *
 	 * This function will add the variables passed to it in $this->new_settings,
 	 * to the Settings.php file.
 	 */

--- a/themes/default/languages/english/ManageSettings.english.php
+++ b/themes/default/languages/english/ManageSettings.english.php
@@ -132,6 +132,7 @@ $txt['cache_level1'] = 'Level 1 Caching (Recommended)';
 $txt['cache_level2'] = 'Level 2 Caching';
 $txt['cache_level3'] = 'Level 3 Caching (Not Recommended)';
 $txt['cache_memcached'] = 'Memcached settings';
+$txt['cache_memcache'] = 'Memcache settings';
 $txt['cache_memcached_servers'] = '<br>Added servers:<ul class="bbc_list"><li>';
 $txt['cache_accelerator'] = 'Caching Accelerator';
 $txt['cache_uid'] = 'Cache Accelerator Userid';

--- a/themes/default/languages/english/ManageSettings.english.php
+++ b/themes/default/languages/english/ManageSettings.english.php
@@ -132,7 +132,7 @@ $txt['cache_level1'] = 'Level 1 Caching (Recommended)';
 $txt['cache_level2'] = 'Level 2 Caching';
 $txt['cache_level3'] = 'Level 3 Caching (Not Recommended)';
 $txt['cache_memcached'] = 'Memcached settings';
-$txt['cache_memcached_servers'] = '<br><br>Added servers:<br><br>';
+$txt['cache_memcached_servers'] = '<br>Added servers:<ul class="bbc_list"><li>';
 $txt['cache_accelerator'] = 'Caching Accelerator';
 $txt['cache_uid'] = 'Cache Accelerator Userid';
 $txt['cache_password'] = 'Cache Accelerator Password';

--- a/themes/default/scripts/admin.js
+++ b/themes/default/scripts/admin.js
@@ -1048,7 +1048,7 @@ function toggleCache ()
 		cacheconfirm = $('#cache_password_confirm').parent();
 
 	// Show the memcache server box only if memcache has been selected
-	if (cache_type.value !== "memcached")
+	if (cache_type.value.substr(0, 8) !== "memcache")
 	{
 		memcache.slideUp();
 		memcache.prev().slideUp(100);


### PR DESCRIPTION
This should fix #2811 

Broke memcache and memcacheD in to their own cache methods.  Although they are both API's to the memcached daemon there are enough differences, such as params to same named methods, and return values from same named methods,  that it became cleaner to break them up.    There are also some ancillary changes for small bugs I found while making these updates.