### PR TITLE
Fix installer: globals, require, and closure

### DIFF
--- a/install/CommonCode.php
+++ b/install/CommonCode.php
@@ -553,7 +553,7 @@ function db_version_check()
 {
 	global $db_type, $databases, $db_connection;
 
-	$current_version = $databases[$db_type]['version_check']{($db_connection)};
+	$current_version = call_user_func($databases[$db_type]['version_check'], $db_connection);
 	$current_version = preg_replace('~\-.+?$~', '', $current_version);
 
 	return version_compare($databases[$db_type]['version'], $current_version, '<=');
@@ -602,6 +602,9 @@ function action_deleteInstaller()
  */
 function saveFileSettings($config_vars, $settingsArray)
 {
+	definePaths();
+	require_once(SOURCEDIR . '/Subs.php');
+
 	if (count($settingsArray) == 1)
 		$settingsArray = preg_split('~[\r\n]~', $settingsArray[0]);
 

--- a/install/Db-check-MySQL.php
+++ b/install/Db-check-MySQL.php
@@ -9,7 +9,7 @@
  *
  */
 
-$databases['mysql'] = array(
+$GLOBALS['databases']['mysql'] = array(
 	'name' => 'MySQL',
 	'extension' => 'MySQL Improved (MySQLi)',
 	'version' => '5.0.52',

--- a/install/Db-check-PostgreSQL.php
+++ b/install/Db-check-PostgreSQL.php
@@ -9,7 +9,7 @@
  *
  */
 
-$databases['postgresql'] = array(
+$GLOBALS['databases']['postgresql'] = array(
 	'name' => 'PostgreSQL',
 	'extension' => 'PostgreSQL (PgSQL)',
 	'version' => '8.3',


### PR DESCRIPTION
Fixes #2849

* lack of globals for Db-check-*.php
* added missing require for un_htmlspecialchars()
* fixed function is closure rather than what the function returns with call_user_func