### PR TITLE
Several fatal errors when setting language defaults

### DIFF
--- a/sources/Load.php
+++ b/sources/Load.php
@@ -2017,6 +2017,7 @@ function loadAssetFile($filenames, $params = array(), $id = '')
 
 	// Whoa ... we've done this before yes?
 	$cache_name = 'load_' . $params['extension'] . '_' . hash('md5', $settings['theme_dir'] . implode('_', $filenames));
+	$temp = array();
 	if ($cache->getVar($temp, $cache_name, 600))
 	{
 		if (empty($context[$params['index_name']]))

--- a/sources/admin/ManageLanguages.controller.php
+++ b/sources/admin/ManageLanguages.controller.php
@@ -173,11 +173,13 @@ class ManageLanguages_Controller extends Action_Controller
 			{
 				$language = $this->_req->post->def_language;
 				$this->updateLanguage($language);
+				redirectexit('action=admin;area=languages;sa=edit');
 			}
 		}
 
 		// Create another one time token here.
 		createToken('admin-lang');
+		createToken('admin-ssc');
 
 		$listOptions = array(
 			'id' => 'language_list',
@@ -251,7 +253,8 @@ class ManageLanguages_Controller extends Action_Controller
 					'position' => 'bottom_of_list',
 					'value' => '
 						<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '" />
-						<input type="submit" name="set_default" value="' . $txt['save'] . '"' . (is_writable(BOARDDIR . '/Settings.php') ? '' : ' disabled="disabled"') . ' />',
+						<input type="submit" name="set_default" value="' . $txt['save'] . '"' . (is_writable(BOARDDIR . '/Settings.php') ? '' : ' disabled="disabled"') . ' />
+						<input type="hidden" name="' . $context['admin-ssc_token_var'] . '" value="' . $context['admin-ssc_token'] . '" />',
 				),
 			),
 			// For highlighting the default.
@@ -1015,7 +1018,7 @@ class ManageLanguages_Controller extends Action_Controller
 		global $scripturl, $context, $txt;
 
 		// Initialize the form
-		$settingsForm = new Settings_Form(Settings_Form::DB_ADAPTER);
+		$settingsForm = new Settings_Form(Settings_Form::FILE_ADAPTER);
 
 		// Initialize it with our settings
 		$settingsForm->setConfigVars($this->_settings());
@@ -1076,7 +1079,7 @@ class ManageLanguages_Controller extends Action_Controller
 		// Get our languages. No cache.
 		$languages = getLanguages(false);
 		foreach ($languages as $lang)
-			$config_vars['language'][4][$lang['filename']] = array($lang['filename'], strtr($lang['name'], array('-utf8' => ' (UTF-8)')));
+			$config_vars['language'][4][] = array($lang['filename'], strtr($lang['name'], array('-utf8' => ' (UTF-8)')));
 
 		return $config_vars;
 	}
@@ -1097,7 +1100,7 @@ class ManageLanguages_Controller extends Action_Controller
 	private function updateLanguage($language)
 	{
 		$configVars = array(
-			array('language')
+			array('language', '', 'file')
 		);
 		$configValues = array(
 			'language' => $language

--- a/themes/default/ManageLanguages.template.php
+++ b/themes/default/ManageLanguages.template.php
@@ -245,7 +245,7 @@ function template_modify_language_entries()
 		</form>
 
 		<form id="entry_form" action="', $scripturl, '?action=admin;area=languages;sa=editlang;lid=', $context['lang_id'], ';entries#entry_form" method="post" accept-charset="UTF-8">
-			<div class="category_header well">
+			<div class="category_header">
 				<h3 class="floatleft">
 					', $txt['edit_language_entries'], '
 				</h3>


### PR DESCRIPTION
- Wrong adapter was being used from the settings page, its a file with a db option.
- Missing token now that we use parent:save for both areas, it expects admin-ssc now, so add it as a hidden var.  I think you could just add it to the form and drop admin-lang as well.
- Redefine array so it can be parsed properly by file adapter.  IT was not being parsed as associative as it should, due to adapter changes
- Need to define config[2] even when taking a shortcut or fatal error