### PR TITLE
Couple of more 

### DIFF
--- a/sources/Load.php
+++ b/sources/Load.php
@@ -2029,7 +2029,7 @@ function loadAssetFile($filenames, $params = array(), $id = '')
 		{
 			foreach ($temp as $temp_params)
 			{
-				$context['debug'][$params['debug_index']][] = $temp_params['options']['basename'] . '(' . (!empty($temp_params['options']['local']) ? (!empty($temp_params['options']['url']) ? basename($temp_params['options']['url']) : basename($temp_params['options']['dir'])) : '') . ')';
+				Debug::get()->add($params['debug_index'], $temp_params['options']['basename'] . '(' . (!empty($temp_params['options']['local']) ? (!empty($temp_params['options']['url']) ? basename($temp_params['options']['url']) : basename($temp_params['options']['dir'])) : '') . ')');
 			}
 		}
 	}

--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -2002,7 +2002,14 @@ function dieGif($expired = false)
 	$linenum = '';
 	if (headers_sent($filename, $linenum))
 	{
-		Errors::instance()->log_error('Headers already sent in ' . $filename . ' at line ' . $linenum);
+		if (empty($filename))
+		{
+			ob_clean();
+		}
+		else
+		{
+			Errors::instance()->log_error('Headers already sent in ' . $filename . ' at line ' . $linenum);
+		}
 	}
 
 	if ($expired === true)

--- a/sources/admin/Packages.controller.php
+++ b/sources/admin/Packages.controller.php
@@ -242,7 +242,7 @@ class Packages_Controller extends Action_Controller
 
 		// No actions found, return so we can display an error
 		if (empty($actions))
-			return;
+			redirectexit('action=admin;area=packages');
 
 		// Now prepare things for the template using the package actions class
 		$pka = new Package_Actions();


### PR DESCRIPTION
- the return in package manager returned to obexit with no template info ... so changed that to a redirect pending us redoing that code in 2.0

- error log is getting a no_session_data, Type of error: General, Headers already sent in at line 0  
Seems since the output buffer is enabled before dieGif() that headers_sent is true, even though nothing has been sent.  So if the function returns sent but no file, lets just clear the buffer and send the gif.

- debug class was not called in one area of assets