### PR TITLE
Markdown support fix for Patch 1 0 10

### DIFF
--- a/themes/default/Admin.template.php
+++ b/themes/default/Admin.template.php
@@ -1013,13 +1013,13 @@ function template_show_settings()
 					echo '
 							<fieldset id="', $config_var['name'], '">
 								<legend>', $txt['bbcTagsToUse_select'], '</legend>
-								<ul>';
+								<ul class="list_bbc">';
 
 					foreach ($context['bbc_columns'] as $bbcColumn)
 					{
 						foreach ($bbcColumn as $bbcTag)
 							echo '
-									<li class="list_bbc floatleft">
+									<li>
 										<input type="checkbox" name="', $config_var['name'], '_enabledTags[]" id="tag_', $config_var['name'], '_', $bbcTag['tag'], '" value="', $bbcTag['tag'], '"', !in_array($bbcTag['tag'], $context['bbc_sections'][$config_var['name']]['disabled']) ? ' checked="checked"' : '', ' class="input_check" /> <label for="tag_', $config_var['name'], '_', $bbcTag['tag'], '">', $bbcTag['tag'], '</label>', $bbcTag['show_help'] ? ' (<a href="' . $scripturl . '?action=quickhelp;help=tag_' . $bbcTag['tag'] . '" onclick="return reqOverlayDiv(this.href);">?</a>)' : '', '
 									</li>';
 					}


### PR DESCRIPTION
As discussed on the site, there are combo's of *nix distros and their associated lib-xml versions that were not properly working with multi byte words.  This should fix that and work with various other issues that can occur. 

I'd recommend just replacing the current  Html2Md.class.php with this one vs patching it in 1.0.10