### PR TITLE
Markdown, headers, misc for 1.0.10

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -14,7 +14,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.9
+ * @version 1.0.10
  *
  */
 

--- a/sources/Load.php
+++ b/sources/Load.php
@@ -13,7 +13,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.8
+ * @version 1.0.10
  *
  */
 

--- a/sources/Request.php
+++ b/sources/Request.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.0
+ * @version 1.0.10
  *
  */
 

--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -13,7 +13,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.8
+ * @version 1.0.10
  *
  */
 

--- a/sources/admin/ManageAttachments.controller.php
+++ b/sources/admin/ManageAttachments.controller.php
@@ -13,7 +13,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.8
+ * @version 1.0.10
  *
  */
 

--- a/sources/admin/PackageServers.controller.php
+++ b/sources/admin/PackageServers.controller.php
@@ -14,7 +14,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.7
+ * @version 1.0.10
  *
  */
 
@@ -410,7 +410,7 @@ class PackageServers_Controller extends Action_Controller
 			$listing = json_decode(fetch_web_data($url));
 
 			// Find the requested package by section and number, make sure it matches
-			$section = $listing->$_GET['section'];
+			$section = $listing->{$_GET['section']};
 
 			// This is what they requested, yes?
 			if (basename($section[$_GET['num']]->server[0]->download) === $_GET['package'])

--- a/sources/controllers/Auth.controller.php
+++ b/sources/controllers/Auth.controller.php
@@ -14,7 +14,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.7
+ * @version 1.0.10
  *
  */
 

--- a/sources/controllers/Register.controller.php
+++ b/sources/controllers/Register.controller.php
@@ -15,7 +15,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.7
+ * @version 1.0.10
  *
  */
 

--- a/sources/controllers/Reminder.controller.php
+++ b/sources/controllers/Reminder.controller.php
@@ -13,7 +13,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0
+ * @version 1.0.10
  *
  */
 

--- a/sources/database/DbTable-mysql.php
+++ b/sources/database/DbTable-mysql.php
@@ -12,7 +12,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0
+ * @version 1.0.10
  *
  */
 

--- a/sources/subs/Attachments.subs.php
+++ b/sources/subs/Attachments.subs.php
@@ -16,7 +16,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.8
+ * @version 1.0.10
  *
  */
 

--- a/sources/subs/Html2Md.class.php
+++ b/sources/subs/Html2Md.class.php
@@ -85,10 +85,10 @@ class Html_2_Md
 
 		// The XML parser will not deal gracefully with these
 		$this->html = strtr($this->html, array(
-			'?<' => "|?|&lt",
-			'?>' => "|?|&gt",
-			'>?' => "&gt|?|",
-			'<?' => "&lt|?|"
+			'?<' => '|?|&lt',
+			'?>' => '|?|&gt',
+			'>?' => '&gt|?|',
+			'<?' => '&lt|?|'
 		));
 
 		// Set the dom parser to use and load the HTML to the parser
@@ -260,8 +260,8 @@ class Html_2_Md
 		$this->markdown = strtr($this->markdown, array(
 			'|?|&gt' => '?>',
 			'|?|&lt' => '?<',
-			"&lt|?|" => '<?',
-			"&gt|?|" => '>?'
+			'&lt|?|' => '<?',
+			'&gt|?|' => '>?'
 		));
 
 		// Strip the chaff and any excess blank lines we may have produced

--- a/sources/subs/Html2Md.class.php
+++ b/sources/subs/Html2Md.class.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.0.7
+ * @version 1.0.10
  *
  */
 

--- a/sources/subs/Package.subs.php
+++ b/sources/subs/Package.subs.php
@@ -13,7 +13,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.8
+ * @version 1.0.10
  *
  */
 

--- a/sources/subs/Util.class.php
+++ b/sources/subs/Util.class.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.0.8
+ * @version 1.0.10
  *
  */
 

--- a/themes/default/Admin.template.php
+++ b/themes/default/Admin.template.php
@@ -1013,13 +1013,13 @@ function template_show_settings()
 					echo '
 							<fieldset id="', $config_var['name'], '">
 								<legend>', $txt['bbcTagsToUse_select'], '</legend>
-								<ul>';
+								<ul class="list_bbc">';
 
 					foreach ($context['bbc_columns'] as $bbcColumn)
 					{
 						foreach ($bbcColumn as $bbcTag)
 							echo '
-									<li class="list_bbc floatleft">
+									<li>
 										<input type="checkbox" name="', $config_var['name'], '_enabledTags[]" id="tag_', $config_var['name'], '_', $bbcTag['tag'], '" value="', $bbcTag['tag'], '"', !in_array($bbcTag['tag'], $context['bbc_sections'][$config_var['name']]['disabled']) ? ' checked="checked"' : '', ' class="input_check" /> <label for="tag_', $config_var['name'], '_', $bbcTag['tag'], '">', $bbcTag['tag'], '</label>', $bbcTag['show_help'] ? ' (<a href="' . $scripturl . '?action=quickhelp;help=tag_' . $bbcTag['tag'] . '" onclick="return reqOverlayDiv(this.href);">?</a>)' : '', '
 									</li>';
 					}

--- a/themes/default/Admin.template.php
+++ b/themes/default/Admin.template.php
@@ -11,7 +11,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.5
+ * @version 1.0.10
  *
  */
 

--- a/themes/default/Display.template.php
+++ b/themes/default/Display.template.php
@@ -11,7 +11,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.6
+ * @version 1.0.10
  *
  */
 

--- a/themes/default/GenericControls.template.php
+++ b/themes/default/GenericControls.template.php
@@ -11,7 +11,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.4
+ * @version 1.0.10
  *
  */
 

--- a/themes/default/css/admin.css
+++ b/themes/default/css/admin.css
@@ -931,6 +931,7 @@ ul.moderation_notes li {
 	-moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;
 	/* The next bits should fix https://github.com/elkarte/Elkarte/issues/567 */
 	word-wrap: break-word;
+	word-break: break-all;
 	-webkit-hyphens: auto;
 	-moz-hyphens: auto;
 	-ms-hyphens: auto;

--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -656,15 +656,15 @@ div.windowbg, div.windowbg2 {
 }
 /* Extra code block styling. */
 .bbc_code {
-	overflow: auto;
-	height: 20em;
 	white-space: nowrap;
 	font-family: "DejaVu Sans Mono", Monaco, Consolas, monospace;
 	resize: vertical;
+	height: auto;
+	max-height: 20em;
 }
 .bbc_code .tab {
 	width: 4ex;
-	white-space:pre;
+	white-space: pre;
 	display: inline-block;
 }
 /* Stop em compounding when elements are nested. */

--- a/themes/default/scripts/dropAttachments.js
+++ b/themes/default/scripts/dropAttachments.js
@@ -3,7 +3,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.0
+ * @version 1.0.10
  *
  * This file contains javascript associated with the drag drop of files functionality
  * while posting

--- a/themes/default/scripts/jquery.sceditor.elkarte.js
+++ b/themes/default/scripts/jquery.sceditor.elkarte.js
@@ -9,7 +9,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.0.4
+ * @version 1.0.10
  * Extension functions to provide ElkArte compatibility with sceditor
  */
 

--- a/themes/default/scripts/jquery.sceditor.elkarte.js
+++ b/themes/default/scripts/jquery.sceditor.elkarte.js
@@ -562,7 +562,7 @@ $.sceditor.plugins.bbcode.bbcode
 
 			if (attrs.type)
 				style = 'style="list-style-type: ' + attrs.type + '"';
-			return '<' + code + ' ' + style + '>' + content + '</' + code + '>';
+			return '<' + code + ' ' + style + '>' + content.replace(/<\/li><br \/>/g, '</li>') + '</' + code + '>';
 		}
 	})
 	.set('li', {
@@ -573,11 +573,13 @@ $.sceditor.plugins.bbcode.bbcode
 			ul: null
 		},
 		breakStart: true,
-		format: function(element, content) {
-			if ($(element[0]).css('list-style-type') === 'disc')
+		format: function (element, content) {
+			var type = $(element[0]).prop('style')['list-style-type'];
+
+			if (type === 'disc' || type === '')
 				return '[list]' + content + '[/list]';
 			else
-				return '[list type=' + $(element[0]).css('list-style-type') + ']' + content + '[/list]';
+				return '[list type=' + type + ']' + content + '[/list]';
 		},
 		isInline: false,
 		skipLastLineBreak: true,

--- a/themes/default/scripts/script_elk.js
+++ b/themes/default/scripts/script_elk.js
@@ -3,22 +3,29 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.0.1
+ * @version 1.0.10
  *
  * This file contains javascript utility functions specific to ElkArte
  */
 
 /**
- * Sets an auto height so small code blocks collapse
- * Sets a height for larger code blocks and lets them resize / overflow as normal
+ * Sets code blocks such that resize vertical works as expect.  Done this way to avoid
+ * page jumps to named anchors missing the target.
  */
 function elk_codefix()
 {
 	$('.bbc_code').each(function()
 	{
-		$(this).height("auto");
-		if ($(this).height() > 200)
-			$(this).css('height', '20em');
+		var $this = $(this);
+
+		// If it has a scroll bar, allow the user to resize it vertically
+		if ($this.get(0).scrollHeight > $this.innerHeight()) {
+			$this.css('height', $this.height());
+			$this.css('max-height', 'none');
+		}
+		else {
+			$this.css('resize', 'none');
+		}
 	});
 }
 


### PR DESCRIPTION
As discussed on the site, there are combo's of *nix distros and their associated lib-xml versions that were not properly working with multi byte words. This should fix that and work with various other issues that can occur.

I'd recommend just replacing the current Html2Md.class.php with this one vs patching it in 1.0.10

Tried to catch up on the version number in the headers as well