### PR TITLE
Revert "file_exists(): open_basedir error fix"

### DIFF
--- a/sources/subs/PackagesFilterIterator.class.php
+++ b/sources/subs/PackagesFilterIterator.class.php
@@ -41,7 +41,7 @@ class PackagesFilterIterator extends \FilterIterator
 		}
 
 		// Anything that, once extracted, doesn't contain a package-info.xml.
-		if (!($current->isDir() && file_exists($current->getPathname() . '/package-info.xml')))
+		if (!($current->isDir()) && file_exists($current->getPathname() . '/package-info.xml'))
 		{
 			return false;
 		}


### PR DESCRIPTION
Reverts elkarte/Elkarte#2855

I don't believe this change in logic relates to the open_basedir error, but more importantly, it makes it so that add-ons don't show.

See http://www.elkarte.net/community/index.php?topic=4274.msg30708#msg30708