### PR TITLE
Return True Not False

### DIFF
--- a/sources/subs/PackagesFilterIterator.class.php
+++ b/sources/subs/PackagesFilterIterator.class.php
@@ -37,13 +37,13 @@ class PackagesFilterIterator extends \FilterIterator
 		// The temp directory that may or may not be present.
 		if ($filename === 'temp')
 		{
-			return false;
+			return true;
 		}
 
 		// Anything that, once extracted, doesn't contain a package-info.xml.
 		if (!($current->isDir() && file_exists($current->getPathname() . '/package-info.xml')))
 		{
-			return false;
+			return true;
 		}
 
 		// And finally, accept anything that has a "package-like" extension.


### PR DESCRIPTION
We have discussed this in here:
http://www.elkarte.net/community/index.php?topic=4274.0

My reasoning is based on the old code that says continue and that works
to show all the packages inside its directory.

I don't change the others i.e. regarding the extension since this is
already working fine (no error so far) so that can be considered not
broken.

I do maintain my earlier suggestion regarding the bracket position as PR earlier and as
explained in the said topic as well.

signed-off Ahmad Rasyid Ismail "ahrasis" ahrasis@gmail.com