### PR TITLE
! fix #2895

### DIFF
--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -2372,8 +2372,8 @@ div.core_posts {
 .attachment_block, .attachment {
 	display: inline-block;
 	max-width: 99%;
-	min-width: 17em;
-	margin: 0 .25em 1em .25em;
+	min-width: 19em;
+	margin: 0 .5em 1em 0;
 	vertical-align: bottom;
 	text-align: center;
 	overflow: hidden;
@@ -2383,10 +2383,20 @@ div.core_posts {
 }
 .attachment_name, .attachment_details {
 	display: block;
+	width: 18em;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	padding: 0 .25em;
 }
-/* Just eye candy. */
 .attachment_name {
-	margin: .5em 0 0 0;
+	 margin: .5em 0 0 0;
+}
+.attachment_name_exp, .attachment_details_exp {
+	width: auto;
+}
+.attachment_name_exp {
+	margin: -.5em 0 0;
 }
 /* Important stuff. */
 .attachment_name:before {

--- a/themes/default/scripts/topic.js
+++ b/themes/default/scripts/topic.js
@@ -876,7 +876,17 @@ InTopicModeration.prototype.handleSubmit = function (sSubmitType)
 function expandThumb(thumbID)
 {
 	var img = document.getElementById('thumb_' + thumbID),
-		link = document.getElementById('link_' + thumbID);
+		link = document.getElementById('link_' + thumbID),
+		name = link.nextSibling;
+
+	// Some browsers will add empty text so loop to the next element node
+	while (name && name.nodeType !== 1) {
+		name = name.nextSibling;
+	}
+	var details = name.nextSibling;
+	while (details && details.nodeType !== 1) {
+		details = details.nextSibling;
+	}
 
 	// Save the currently displayed image attributes
 	var tmp_src = img.src,
@@ -887,6 +897,10 @@ function expandThumb(thumbID)
 	img.src = link.href;
 	img.style.width = link.style.width;
 	img.style.height = link.style.height;
+
+	// Swap the class name on the title/desc
+	name.className = name.className.includes('_exp') ? 'attachment_name' : 'attachment_name attachment_name_exp';
+	details.className = details.className.includes('_exp') ? 'attachment_details' : 'attachment_details attachment_details_exp';
 
 	// Now place the image attributes back
 	link.href = tmp_src;


### PR DESCRIPTION
I'm not sure this is what we want to do ... its easy enough to set up some css to clip that
```
	width: 18em;
	white-space: nowrap;
	overflow: hidden;
	text-overflow: ellipsis;
	padding: 0 .25em;
```
But then when you expand it the "under tab" box containing the name and details will not expand with the image, it will stay at 18em;  

Not sure thats a problem just pointing it out.  In order to have the same behavior I also updated the JS to add a second class name to the name and detail spans so on click they expand out with the image.  Could have done this with a bit less JS, however that would require changing the template and then it would not work with existing themes.

So .... what to do what to do