### PR TITLE
Auto-embed: don't match any random string of characters

### DIFF
--- a/themes/default/scripts/elk_jquery_embed.js
+++ b/themes/default/scripts/elk_jquery_embed.js
@@ -141,7 +141,7 @@
 			embed_html = '<div class="elk_video"><iframe width="640px" height="385px" style="max-width: 98%; max-height: auto;" src="{src}" frameborder="0" allowfullscreen></iframe></div>',
 			handlers = {};
 		handlers['youtube.com'] = function(path, a, embed) {
-			var videoID = path.match(/\bv[=/]([^&#?$]+)/i) || path.match(/#p\/(?:a\/)?[uf]\/\d+\/([^?$]+)/i) || path.match(/([\w-]{11})/i);
+			var videoID = path.match(/\bv[=/]([^&#?$]+)/i) || path.match(/#p\/(?:a\/)?[uf]\/\d+\/([^?$]+)/i) || path.match(/(?:\/)([\w-]{11})/i);
 			if (!videoID || !(videoID = videoID[1]))
 				return;
 


### PR DESCRIPTION
I assume the last regex is really only meant for links like these:

```
http://youtu.be/lLOE3fBZcUU?t=1m37s
http://youtu.be/lLOE3fBZcUU?t=97
```

However, it'll incorrectly also match (currently unsupported) playlists:
```
https://www.youtube.com/playlist?list=PL-72lYkqnSfXj7LaTlGfsLhYoNO2xjKkc
```

See http://www.elkarte.net/community/index.php?topic=4435