### PR TITLE
Speed up some tests

### DIFF
--- a/tests/travis-ci/setup-results.sh
+++ b/tests/travis-ci/setup-results.sh
@@ -16,7 +16,7 @@ SHORT_DB=${DB%%-*}
 SHORT_PHP=${TRAVIS_PHP_VERSION:0:3}
 
 # Scrutinizer will merge all coverage data...
-if [ "$COVERAGE" == "true" ]
+if [ "$COVERAGE" == "true" -a "${TRAVIS_PULL_REQUEST}" != "false" ]
 then
 wget https://scrutinizer-ci.com/ocular.phar
 php ocular.phar code-coverage:upload --format=php-clover /tmp/coverage.xml

--- a/tests/travis-ci/setup-script.sh
+++ b/tests/travis-ci/setup-script.sh
@@ -25,7 +25,7 @@ fi
 # Build a config string for PHPUnit
 COVER=""
 WEB=""
-if [ "$COVERAGE" != "true" ]; then COVER="--no-coverage"; fi
+if [ "$COVERAGE" != "true" -o "${TRAVIS_PULL_REQUEST}" == "false" ]; then COVER="--no-coverage"; fi
 if [ "$WEBTESTS" == "true" ]; then WEB="-with-webtest"; fi
 CONFIG="--configuration /var/www/tests/travis-ci/phpunit${WEB}-${SHORT_DB}-travis.xml ${COVER}"
 

--- a/tests/travis-ci/setup-server.sh
+++ b/tests/travis-ci/setup-server.sh
@@ -114,4 +114,4 @@ sudo a2enconf fqdn
 sudo service apache2 restart
 
 # if we are not creating code coverage reports, do not run xdebug
-if [ "$COVERAGE" != "true" ]; then phpenv config-rm xdebug.ini; fi
+if [ "$COVERAGE" != "true" -o "${TRAVIS_PULL_REQUEST}" == "false" ]; then phpenv config-rm xdebug.ini; fi


### PR DESCRIPTION
Don't create test coverage (or run xdebug) when we are not going to use the coverage results.  Only run the coverage when the PR is made.  This prevents creating the coverage reports when making commits to your own branch (should you have any travis running on that)