### PR TITLE
[fix] rtl_besocial.css: get rid of outdated -webkit-transform property

### DIFF
--- a/themes/default/css/_besocial/rtl_besocial.css
+++ b/themes/default/css/_besocial/rtl_besocial.css
@@ -254,7 +254,6 @@ legend {
 /* ------------------------------------------------------- */
 .linktree:not(:last-child):after {
 	transform: scale(1) rotate(-135deg);
-	-webkit-transform: scale(1) rotate(-135deg);
 }
 
 /*	$BOARDICONS	*/


### PR DESCRIPTION
It's no longer relevant. But if and when it is, unprefixed should always go last.