### PR TITLE
Use Bootstrap in index.php

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -12,7 +12,7 @@
  * copyright:    2011 Simple Machines (http://www.simplemachines.org)
  * license:        BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1
+ * @version 1.1.1
  *
  */
 
@@ -55,9 +55,21 @@ $ssi_on_error_method = false;
 // $ssi_guest_access = false;
 
 // We are in Elk, but from the side-entrance.
-const ELK = 'SSI';
+if (!defined('ELKBOOT'))
+{
+	define('ELK', 'SSI');
 
-require_once(dirname(__FILE__) . '/bootstrap.php');
+	require_once(dirname(__FILE__) . '/bootstrap.php');
+	$bootstrap = new Bootstrap();
+	$bootstrap->ssi_main();
+}
+
+global $time_start, $maintenance, $msubject, $mmessage, $mbname, $language;
+global $boardurl, $webmaster_email, $cookiename;
+global $db_type, $db_server, $db_name, $db_user, $db_prefix, $db_persist, $db_error_send;
+global $modSettings, $context, $sc, $user_info, $topic, $board, $txt;
+global $ssi_db_user, $scripturl, $ssi_db_passwd, $db_passwd;
+global $boarddir, $sourcedir, $db_show_debug, $ssi_error_reporting;
 
 // Have the ability to easily add functions to SSI.
 call_integration_hook('integrate_SSI');

--- a/SSI.php
+++ b/SSI.php
@@ -61,9 +61,9 @@ if (!defined('ELKBOOT'))
 
 	require_once(dirname(__FILE__) . '/bootstrap.php');
 	$bootstrap = new Bootstrap();
-	$bootstrap->ssi_main();
 }
 
+// The globals that were created during the bootstrap process
 global $time_start, $maintenance, $msubject, $mmessage, $mbname, $language;
 global $boardurl, $webmaster_email, $cookiename;
 global $db_type, $db_server, $db_name, $db_user, $db_prefix, $db_persist, $db_error_send;

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -15,323 +15,388 @@
  *
  */
 
-// Bootstrap only once.
-if (defined('ELKBOOT'))
+class Bootstrap
 {
-	return true;
-}
-
-$time_start = microtime(true);
-
-const ELKBOOT = 1;
-
-// Shortcut for the browser cache stale
-const CACHE_STALE = '?R110';
-
-// We're going to want a few globals... these are all set later.
-global $time_start, $maintenance, $msubject, $mmessage, $mbname, $language;
-global $boardurl, $webmaster_email, $cookiename;
-global $db_type, $db_server, $db_name, $db_user, $db_prefix, $db_persist, $db_error_send;
-global $modSettings, $context, $sc, $user_info, $topic, $board, $txt;
-global $ssi_db_user, $scripturl, $ssi_db_passwd, $db_passwd;
-global $boarddir, $sourcedir;
-
-// Report errors but not depreciated ones
-$ssi_error_reporting = error_reporting(E_ALL | E_STRICT & ~8192);
-
-// Directional only script time usage for display
-// getrusage is missing in php < 7 on Windows
-if (function_exists('getrusage'))
-{
-	$rusage_start = getrusage();
-}
-else
-{
-	$rusage_start = array();
-}
-
-$db_show_debug = false;
-
-// We don't need no globals. (a bug in "old" versions of PHP)
-foreach (array('db_character_set', 'cachedir') as $variable)
-{
-	if (isset($GLOBALS[$variable]))
+	public function __construct()
 	{
-		unset($GLOBALS[$variable], $GLOBALS[$variable]);
-	}
-}
-
-// Where the Settings.php file is located
-$settings_loc = __DIR__ . '/Settings.php';
-
-// First thing: if the install dir exists, just send anybody there
-// The ignore_install_dir var is for developers only. Do not add it on production sites
-if (file_exists('install'))
-{
-	if (file_exists($settings_loc))
-	{
-		require_once($settings_loc);
-	}
-
-	if (empty($ignore_install_dir))
-	{
-		if (file_exists($settings_loc) && empty($_SESSION['installing']))
+		// Bootstrap only once.
+		if (defined('ELKBOOT'))
 		{
-			$redirec_file = 'upgrade.php';
+			return true;
+		}
+
+		// We're going to want a few globals... these are all set later.
+		global $time_start, $ssi_error_reporting, $db_show_debug;
+
+		// Your on the clock
+		$time_start = microtime(true);
+
+		// Unless settings tells us otherwise
+		$db_show_debug = false;
+
+		// Report errors but not depreciated ones
+		$ssi_error_reporting = error_reporting(E_ALL | E_STRICT & ~8192);
+
+		$this->bringUpBasics();
+	}
+
+	public function bringUpBasics()
+	{
+		$this->setConstants();
+		$this->setRusage();
+		$this->clearGloballs();
+		$this->loadSettingsFile();
+		$this->validatePaths();
+		$this->loadDependants();
+		$this->loadAutoloader();
+		$this->checkMaintance();
+		$this->setDebug();
+		$this->bringUp();
+	}
+
+	private function setConstants()
+	{
+		// First things first, but not necessarily in that order.
+		define(ELK, '1');
+		define(ELKBOOT, '1');
+
+		// The software version
+		define(FORUM_VERSION, 'ElkArte 1.1');
+
+		// Shortcut for the browser cache stale
+		define(CACHE_STALE, '?R110');
+	}
+
+	private function setRusage()
+	{
+		global $rusage_start;
+
+		// Directional only script time usage for display
+		// getrusage is missing in php < 7 on Windows
+		if (function_exists('getrusage'))
+		{
+			$rusage_start = getrusage();
 		}
 		else
 		{
-			$redirec_file = 'install.php';
+			$rusage_start = array();
+		}
+	}
+
+	private function clearGloballs()
+	{
+		// We don't need no globals. (a bug in "old" versions of PHP)
+		foreach (array('db_character_set', 'cachedir') as $variable)
+		{
+			if (isset($GLOBALS[$variable]))
+			{
+				unset($GLOBALS[$variable], $GLOBALS[$variable]);
+			}
+		}
+	}
+
+	private function loadSettingsFile()
+	{
+		// All those wonderful things found in settings
+		global $maintenance, $mtitle, $msubject, $mmessage, $mbname, $language, $boardurl, $webmaster_email;
+		global $cookiename, $db_type, $db_server, $db_port, $db_name, $db_user, $db_passwd;
+		global $ssi_db_user, $ssi_db_passwd, $db_prefix, $db_persist, $db_error_send, $cache_accelerator;
+		global $cache_uid, $cache_password, $cache_enable, $cache_memcached, $db_show_debug;
+		global $cachedir, $boarddir, $sourcedir, $extdir, $languagedir;
+
+		// Where the Settings.php file is located
+		$settings_loc = __DIR__ . '/Settings.php';
+
+		// First thing: if the install dir exists, just send anybody there
+		// The ignore_install_dir var is for developers only. Do not add it on production sites
+		if (file_exists('install'))
+		{
+			if (file_exists($settings_loc))
+			{
+				require_once($settings_loc);
+			}
+
+			if (empty($ignore_install_dir))
+			{
+				if (file_exists($settings_loc) && empty($_SESSION['installing']))
+				{
+					$redirec_file = 'upgrade.php';
+				}
+				else
+				{
+					$redirec_file = 'install.php';
+				}
+
+				header('Location: http' . (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) === 'on' ? 's' : '') . '://' . (empty($_SERVER['HTTP_HOST']) ? $_SERVER['SERVER_NAME'] . (empty($_SERVER['SERVER_PORT']) || $_SERVER['SERVER_PORT'] === '80' ? '' : ':' . $_SERVER['SERVER_PORT']) : $_SERVER['HTTP_HOST']) . (strtr(dirname($_SERVER['PHP_SELF']), '\\', '/') == '/' ? '' : strtr(dirname($_SERVER['PHP_SELF']), '\\', '/')) . '/install/' . $redirec_file);
+				die();
+			}
+		}
+		else
+		{
+			require_once($settings_loc);
+		}
+	}
+
+	private function validatePaths()
+	{
+		global $boarddir, $sourcedir, $cachedir, $extdir, $languagedir;
+
+		// Make sure the paths are correct... at least try to fix them.
+		if (!file_exists($boarddir) && file_exists(__DIR__ . '/agreement.txt'))
+		{
+			$boarddir = __DIR__;
+		}
+		if (!file_exists($sourcedir . '/SiteDispatcher.class.php') && file_exists($boarddir . '/sources'))
+		{
+			$sourcedir = $boarddir . '/sources';
 		}
 
-		header('Location: http' . (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) === 'on' ? 's' : '') . '://' . (empty($_SERVER['HTTP_HOST']) ? $_SERVER['SERVER_NAME'] . (empty($_SERVER['SERVER_PORT']) || $_SERVER['SERVER_PORT'] === '80' ? '' : ':' . $_SERVER['SERVER_PORT']) : $_SERVER['HTTP_HOST']) . (strtr(dirname($_SERVER['PHP_SELF']), '\\', '/') == '/' ? '' : strtr(dirname($_SERVER['PHP_SELF']), '\\', '/')) . '/install/' . $redirec_file);
-		die();
+		// Check that directories which didn't exist in past releases are initialized.
+		if ((empty($cachedir) || !file_exists($cachedir)) && file_exists($boarddir . '/cache'))
+		{
+			$cachedir = $boarddir . '/cache';
+		}
+
+		if ((empty($extdir) || !file_exists($extdir)) && file_exists($sourcedir . '/ext'))
+		{
+			$extdir = $sourcedir . '/ext';
+		}
+
+		if ((empty($languagedir) || !file_exists($languagedir)) && file_exists($boarddir . '/themes/default/languages'))
+		{
+			$languagedir = $boarddir . '/themes/default/languages';
+		}
+
+		// Time to forget about variables and go with constants!
+		// Shortcut for the browser cache stale
+		DEFINE('BOARDDIR', $boarddir);
+		DEFINE('CACHEDIR', $cachedir);
+		DEFINE('EXTDIR', $extdir);
+		DEFINE('LANGUAGEDIR', $languagedir);
+		DEFINE('SOURCEDIR', $sourcedir);
+		DEFINE('ADMINDIR', $sourcedir . '/admin');
+		DEFINE('CONTROLLERDIR', $sourcedir . '/controllers');
+		DEFINE('SUBSDIR', $sourcedir . '/subs');
+		DEFINE('ADDONSDIR', $boarddir . '/addons');
+		unset($boarddir, $cachedir, $sourcedir, $languagedir, $extdir);
 	}
-}
-else
-{
-	require_once($settings_loc);
-}
 
-// Make sure the paths are correct... at least try to fix them.
-if (!file_exists($boarddir) && file_exists(__DIR__ . '/agreement.txt'))
-{
-	$boarddir = __DIR__;
-}
-if (!file_exists($sourcedir . '/SiteDispatcher.class.php') && file_exists($boarddir . '/sources'))
-{
-	$sourcedir = $boarddir . '/sources';
-}
-
-// Check that directories which didn't exist in past releases are initialized.
-if ((empty($cachedir) || !file_exists($cachedir)) && file_exists($boarddir . '/cache'))
-{
-	$cachedir = $boarddir . '/cache';
-}
-
-if ((empty($extdir) || !file_exists($extdir)) && file_exists($sourcedir . '/ext'))
-{
-	$extdir = $sourcedir . '/ext';
-}
-
-if ((empty($languagedir) || !file_exists($languagedir)) && file_exists($boarddir . '/themes/default/languages'))
-{
-	$languagedir = $boarddir . '/themes/default/languages';
-}
-
-// Time to forget about variables and go with constants!
-DEFINE('BOARDDIR', $boarddir);
-DEFINE('CACHEDIR', $cachedir);
-DEFINE('EXTDIR', $extdir);
-DEFINE('LANGUAGEDIR', $languagedir);
-DEFINE('SOURCEDIR', $sourcedir);
-DEFINE('ADMINDIR', $sourcedir . '/admin');
-DEFINE('CONTROLLERDIR', $sourcedir . '/controllers');
-DEFINE('SUBSDIR', $sourcedir . '/subs');
-DEFINE('ADDONSDIR', $boarddir . '/addons');
-unset($boarddir, $cachedir, $sourcedir, $languagedir, $extdir);
-
-// Files we cannot live without.
-require_once(SOURCEDIR . '/QueryString.php');
-require_once(SOURCEDIR . '/Session.php');
-require_once(SOURCEDIR . '/Subs.php');
-require_once(SOURCEDIR . '/Logging.php');
-require_once(SOURCEDIR . '/Load.php');
-require_once(SOURCEDIR . '/Security.php');
-require_once(SUBSDIR . '/Cache.subs.php');
-
-// Initialize the class Autoloader
-require(SOURCEDIR . '/Autoloader.class.php');
-$autoloder = Elk_Autoloader::instance();
-$autoloder->setupAutoloader(array(SOURCEDIR, SUBSDIR, CONTROLLERDIR, ADMINDIR, ADDONSDIR));
-$autoloder->register(SOURCEDIR, '\\ElkArte');
-$autoloder->register(SOURCEDIR . '/subs/BBC', '\\BBC');
-
-/**
- * Set this to one of three values depending on what you want to happen in the case of a fatal error.
- *
- *  - false: Default, will just load the error sub template and die - not putting any theme layers around it.
- *  - true: Will load the error sub template AND put the template layers around it (Not useful if on total custom
- * pages).
- *  - string: Name of a callback function to call in the event of an error to allow you to define your own methods.
- * Will die after function returns.
- */
-$ssi_on_error_method = false;
-
-// Don't do john didley if the forum's been shut down completely.
-if ($maintenance == 2 && (!isset($ssi_maintenance_off) || $ssi_maintenance_off !== true))
-{
-	die($mmessage);
-}
-
-if ($db_show_debug === true)
-{
-	Debug::instance()->rusage('start', $rusage_start);
-}
-
-// Forum in extended maintenance mode? Our trip ends here with a bland message.
-if (!empty($maintenance) && $maintenance == 2)
-{
-	Errors::instance()->display_maintenance_message();
-}
-
-// Clean the request.
-cleanRequest();
-
-// Initiate the database connection and define some database functions to use.
-loadDatabase();
-
-// It's time for settings loaded from the database.
-reloadSettings();
-
-// Our good ole' contextual array, which will hold everything
-if (!isset($context))
-{
-	$context = array();
-}
-
-// Seed the random generator.
-elk_seed_generator();
-
-// Check on any hacking attempts.
-if (isset($_REQUEST['GLOBALS']) || isset($_COOKIE['GLOBALS']))
-{
-	die('No access...');
-}
-elseif (isset($_REQUEST['ssi_theme']) && (int) $_REQUEST['ssi_theme'] == (int) $ssi_theme)
-{
-	die('No access...');
-}
-elseif (isset($_COOKIE['ssi_theme']) && (int) $_COOKIE['ssi_theme'] == (int) $ssi_theme)
-{
-	die('No access...');
-}
-elseif (isset($_REQUEST['ssi_layers'], $ssi_layers) && (@get_magic_quotes_gpc() ? stripslashes($_REQUEST['ssi_layers']) : $_REQUEST['ssi_layers']) == $ssi_layers)
-{
-	die('No access...');
-}
-
-if (isset($_REQUEST['context']))
-{
-	die('No access...');
-}
-
-// Gzip output? (because it must be boolean and true, this can't be hacked.)
-if (isset($ssi_gzip) && $ssi_gzip === true && detectServer()->outPutCompressionEnabled())
-{
-	ob_start('ob_gzhandler');
-}
-else
-{
-	$modSettings['enableCompressedOutput'] = '0';
-}
-
-// Primarily, this is to fix the URLs...
-ob_start('ob_sessrewrite');
-
-// Start the session... known to scramble SSI includes in cases...
-if (!headers_sent())
-{
-	loadSession();
-}
-else
-{
-	if (isset($_COOKIE[session_name()]) || isset($_REQUEST[session_name()]))
+	private function loadDependants()
 	{
-		// Make a stab at it, but ignore the E_WARNINGs generated because we can't send headers.
-		$temp = error_reporting(error_reporting() & !E_WARNING);
-		loadSession();
-		error_reporting($temp);
+		// Files we cannot live without.
+		require_once(SOURCEDIR . '/QueryString.php');
+		require_once(SOURCEDIR . '/Session.php');
+		require_once(SOURCEDIR . '/Subs.php');
+		require_once(SOURCEDIR . '/Logging.php');
+		require_once(SOURCEDIR . '/Load.php');
+		require_once(SOURCEDIR . '/Security.php');
+		require_once(SUBSDIR . '/Cache.subs.php');
 	}
 
-	if (!isset($_SESSION['session_value']))
+	private function loadAutoloader()
 	{
-		$tokenizer = new Token_Hash();
-		$_SESSION['session_value'] = $tokenizer->generate_hash(32, session_id());
-		$_SESSION['session_var'] = substr(preg_replace('~^\d+~', '', $tokenizer->generate_hash(16, session_id())), 0, rand(7, 12));
+		// Initialize the class Autoloader
+		require_once(SOURCEDIR . '/Autoloader.class.php');
+		$autoloder = Elk_Autoloader::instance();
+		$autoloder->setupAutoloader(array(SOURCEDIR, SUBSDIR, CONTROLLERDIR, ADMINDIR, ADDONSDIR));
+		$autoloder->register(SOURCEDIR, '\\ElkArte');
+		$autoloder->register(SOURCEDIR . '/subs/BBC', '\\BBC');
 	}
 
-	$sc = $_SESSION['session_value'];
-	// This is here only to avoid session errors in PHP7
-	// microtime effectively forces the replacing of the session in the db each
-	// time the page is loaded
-	$_SESSION['mictrotime'] = microtime();
-}
-
-// Get rid of $board and $topic... do stuff loadBoard would do.
-unset($board, $topic);
-$user_info['is_mod'] = false;
-$context['user']['is_mod'] = &$user_info['is_mod'];
-$context['linktree'] = array();
-
-// Load the user and their cookie, as well as their settings.
-loadUserSettings();
-
-// Load the current user's permissions....
-loadPermissions();
-
-// Load the current or SSI theme. (just use $ssi_theme = id_theme;)
-loadTheme(isset($ssi_theme) ? (int) $ssi_theme : 0);
-
-// Load BadBehavior functions
-loadBadBehavior();
-
-// @todo: probably not the best place, but somewhere it should be set...
-if (!headers_sent())
-{
-	header('Content-Type: text/html; charset=UTF-8');
-}
-
-// Take care of any banning that needs to be done.
-if (isset($_REQUEST['ssi_ban']) || (isset($ssi_ban) && $ssi_ban === true))
-{
-	is_not_banned();
-}
-
-// Do we allow guests in here?
-if (empty($ssi_guest_access) && empty($modSettings['allow_guestAccess']) && $user_info['is_guest'] && basename($_SERVER['PHP_SELF']) != 'SSI.php')
-{
-	$controller = new Auth_Controller();
-	$controller->action_kickguest();
-	obExit(null, true);
-}
-
-if (!empty($modSettings['front_page']) && is_callable(array($modSettings['front_page'], 'frontPageHook')))
-{
-	$modSettings['default_forum_action'] = '?action=forum;';
-}
-else
-{
-	$modSettings['default_forum_action'] = '';
-}
-
-// Load the stuff like the menu bar, etc.
-if (isset($ssi_layers))
-{
-	$template_layers = Template_Layers::instance();
-	$template_layers->removeAll();
-	foreach ($ssi_layers as $layer)
+	private function checkMaintance()
 	{
-		$template_layers->addBegin($layer);
+		global $maintenance, $ssi_maintenance_off;
+
+		// Don't do john didley if the forum's been shut down completely.
+		if (!empty($maintenance) && $maintenance == 2 && (!isset($ssi_maintenance_off) || $ssi_maintenance_off !== true))
+		{
+			Errors::instance()->display_maintenance_message();
+		}
 	}
-	template_header();
-}
-else
-{
-	setupThemeContext();
-}
 
-// We need to set up user agent, and make more checks on the request
-$req = request();
+	private function setDebug()
+	{
+		global $db_show_debug, $rusage_start;
 
-// Make sure they didn't muss around with the settings... but only if it's not cli.
-if (isset($_SERVER['REMOTE_ADDR']) && session_id() == '')
-{
-	trigger_error($txt['ssi_session_broken'], E_USER_NOTICE);
-}
+		// Show lots of debug information below the page, not for production sites
+		if ($db_show_debug === true)
+		{
+			Debug::instance()->rusage('start', $rusage_start);
+		}
+	}
 
-// Without visiting the forum this session variable might not be set on submit.
-if (!isset($_SESSION['USER_AGENT']) && (!isset($_GET['ssi_function']) || $_GET['ssi_function'] !== 'pollVote'))
-{
-	$_SESSION['USER_AGENT'] = $req->user_agent();
+	private function bringUp()
+	{
+		global $context;
+
+		// Clean the request.
+		cleanRequest();
+
+		// Initiate the database connection and define some database functions to use.
+		loadDatabase();
+
+		// Let's set up our shiny new hooks handler.
+		Hooks::init(database(), Debug::instance());
+
+		// It's time for settings loaded from the database.
+		reloadSettings();
+
+		// Our good ole' contextual array, which will hold everything
+		if (empty($context))
+		{
+			$context = array();
+		}
+
+		// Seed the random generator.
+		elk_seed_generator();
+	}
+
+	public function ssi_main()
+	{
+		global $ssi_layers, $ssi_theme, $ssi_gzip, $ssi_ban, $ssi_guest_access;
+		global $modSettings, $context, $sc, $board, $topic, $user_info, $txt;
+
+		// Check on any hacking attempts.
+		if (isset($_REQUEST['GLOBALS']) || isset($_COOKIE['GLOBALS']))
+		{
+			die('No access...');
+		}
+		elseif (isset($_REQUEST['ssi_theme']) && (int) $_REQUEST['ssi_theme'] == (int) $ssi_theme)
+		{
+			die('No access...');
+		}
+		elseif (isset($_COOKIE['ssi_theme']) && (int) $_COOKIE['ssi_theme'] == (int) $ssi_theme)
+		{
+			die('No access...');
+		}
+		elseif (isset($_REQUEST['ssi_layers'], $ssi_layers) && (@get_magic_quotes_gpc() ? stripslashes($_REQUEST['ssi_layers']) : $_REQUEST['ssi_layers']) == $ssi_layers)
+		{
+			die('No access...');
+		}
+
+		if (isset($_REQUEST['context']))
+		{
+			die('No access...');
+		}
+
+		// Gzip output? (because it must be boolean and true, this can't be hacked.)
+		if (isset($ssi_gzip) && $ssi_gzip === true && detectServer()->outPutCompressionEnabled())
+		{
+			ob_start('ob_gzhandler');
+		}
+		else
+		{
+			$modSettings['enableCompressedOutput'] = '0';
+		}
+
+		// Primarily, this is to fix the URLs...
+		ob_start('ob_sessrewrite');
+
+		// Start the session... known to scramble SSI includes in cases...
+		if (!headers_sent())
+		{
+			loadSession();
+		}
+		else
+		{
+			if (isset($_COOKIE[session_name()]) || isset($_REQUEST[session_name()]))
+			{
+				// Make a stab at it, but ignore the E_WARNINGs generated because we can't send headers.
+				$temp = error_reporting(error_reporting() & !E_WARNING);
+				loadSession();
+				error_reporting($temp);
+			}
+
+			if (!isset($_SESSION['session_value']))
+			{
+				$tokenizer = new Token_Hash();
+				$_SESSION['session_value'] = $tokenizer->generate_hash(32, session_id());
+				$_SESSION['session_var'] = substr(preg_replace('~^\d+~', '', $tokenizer->generate_hash(16, session_id())), 0, rand(7, 12));
+			}
+
+			$sc = $_SESSION['session_value'];
+			// This is here only to avoid session errors in PHP7
+			// microtime effectively forces the replacing of the session in the db each
+			// time the page is loaded
+			$_SESSION['mictrotime'] = microtime();
+		}
+
+		// Get rid of $board and $topic... do stuff loadBoard would do.
+		unset($board, $topic);
+		$user_info['is_mod'] = false;
+		$context['user']['is_mod'] = &$user_info['is_mod'];
+		$context['linktree'] = array();
+
+		// Load the user and their cookie, as well as their settings.
+		loadUserSettings();
+
+		// Load the current user's permissions....
+		loadPermissions();
+
+		// Load the current or SSI theme. (just use $ssi_theme = id_theme;)
+		loadTheme(isset($ssi_theme) ? (int) $ssi_theme : 0);
+
+		// Load BadBehavior functions
+		loadBadBehavior();
+
+		// @todo: probably not the best place, but somewhere it should be set...
+		if (!headers_sent())
+		{
+			header('Content-Type: text/html; charset=UTF-8');
+		}
+
+		// Take care of any banning that needs to be done.
+		if (isset($_REQUEST['ssi_ban']) || (isset($ssi_ban) && $ssi_ban === true))
+		{
+			is_not_banned();
+		}
+
+		// Do we allow guests in here?
+		if (empty($ssi_guest_access) && empty($modSettings['allow_guestAccess']) && $user_info['is_guest'] && basename($_SERVER['PHP_SELF']) !== 'SSI.php')
+		{
+			$controller = new Auth_Controller();
+			$controller->action_kickguest();
+			obExit(null, true);
+		}
+
+		if (!empty($modSettings['front_page']) && is_callable(array($modSettings['front_page'], 'frontPageHook')))
+		{
+			$modSettings['default_forum_action'] = '?action=forum;';
+		}
+		else
+		{
+			$modSettings['default_forum_action'] = '';
+		}
+
+		// Load the stuff like the menu bar, etc.
+		if (isset($ssi_layers))
+		{
+			$template_layers = Template_Layers::instance();
+			$template_layers->removeAll();
+			foreach ($ssi_layers as $layer)
+			{
+				$template_layers->addBegin($layer);
+			}
+			template_header();
+		}
+		else
+		{
+			setupThemeContext();
+		}
+
+		// We need to set up user agent, and make more checks on the request
+		$req = request();
+
+		// Make sure they didn't muss around with the settings... but only if it's not cli.
+		if (isset($_SERVER['REMOTE_ADDR']) && session_id() == '')
+		{
+			trigger_error($txt['ssi_session_broken'], E_USER_NOTICE);
+		}
+
+		// Without visiting the forum this session variable might not be set on submit.
+		if (!isset($_SESSION['USER_AGENT']) && (!isset($_GET['ssi_function']) || $_GET['ssi_function'] !== 'pollVote'))
+		{
+			$_SESSION['USER_AGENT'] = $req->user_agent();
+		}
+	}
 }

--- a/email_imap_cron.php
+++ b/email_imap_cron.php
@@ -18,7 +18,8 @@ error_reporting(0);
 // Being run as a cron job
 if (!defined('ELK'))
 {
-	require_once(__DIR__ . '/SSI.php');
+	require_once(__DIR__ . '/bootstrap.php');
+	new Bootstrap();
 	postbyemail_imap();
 
 	// Need to keep the cli clean on return

--- a/email_imap_cron.php
+++ b/email_imap_cron.php
@@ -8,7 +8,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1
+ * @version 1.1.1
  *
  */
 
@@ -18,7 +18,7 @@ error_reporting(0);
 // Being run as a cron job
 if (!defined('ELK'))
 {
-	require_once(__DIR__ . '/bootstrap.php');
+	require_once(__DIR__ . '/SSI.php');
 	postbyemail_imap();
 
 	// Need to keep the cli clean on return

--- a/emailpost.php
+++ b/emailpost.php
@@ -15,7 +15,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1
+ * @version 1.1.1
  *
  */
 
@@ -27,7 +27,7 @@ if (!defined('STDIN'))
 error_reporting(0);
 
 // Need SSI to do much
-require_once(__DIR__ . '/bootstrap.php');
+require_once(__DIR__ . '/SSI.php');
 
 // No need to ID the server if we fall on our face :)
 $_SERVER['SERVER_SOFTWARE'] = '';

--- a/emailpost.php
+++ b/emailpost.php
@@ -26,8 +26,9 @@ if (!defined('STDIN'))
 // Any output here is not good
 error_reporting(0);
 
-// Need SSI to do much
-require_once(__DIR__ . '/SSI.php');
+// Need to bootstrap to do much
+require_once(__DIR__ . '/bootstrap.php');
+new Bootstrap();
 
 // No need to ID the server if we fall on our face :)
 $_SERVER['SERVER_SOFTWARE'] = '';

--- a/emailtopic.php
+++ b/emailtopic.php
@@ -26,8 +26,9 @@ if (!defined('STDIN'))
 // Any output here is not good, it will be bounced as email
 error_reporting(0);
 
-// Need SSI to do much
-require_once(dirname(__FILE__) . '/SSI.php');
+// Need to bootstrap the system to do much
+require_once(dirname(__FILE__) . '/bootstrap.php');
+new Bootstrap();
 
 // No need to ID the server if we fall on our face :)
 $_SERVER['SERVER_SOFTWARE'] = '';

--- a/emailtopic.php
+++ b/emailtopic.php
@@ -15,7 +15,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1
+ * @version 1.1.1
  *
  */
 
@@ -27,7 +27,7 @@ if (!defined('STDIN'))
 error_reporting(0);
 
 // Need SSI to do much
-require_once(dirname(__FILE__) . '/bootstrap.php');
+require_once(dirname(__FILE__) . '/SSI.php');
 
 // No need to ID the server if we fall on our face :)
 $_SERVER['SERVER_SOFTWARE'] = '';

--- a/index.php
+++ b/index.php
@@ -13,169 +13,17 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1
+ * @version 1.1.1
  *
  */
 
-$time_start = microtime(true);
-
-// The software version
-const FORUM_VERSION = 'ElkArte 1.1';
-
-// First things first, but not necessarily in that order.
-const ELK = '1';
-
-// Shortcut for the browser cache stale
-const CACHE_STALE = '?R110';
-
-// Report errors but not depreciated ones
-error_reporting(E_ALL | E_STRICT & ~8192);
-
-// Directional only script time usage for display
-// getrusage is missing in php < 7 on Windows
-if (function_exists('getrusage'))
-{
-	$rusage_start = getrusage();
-}
-else
-{
-	$rusage_start = array();
-}
+// Bootstrap the system
+require_once(dirname(__FILE__) . '/bootstrap.php');
+new Bootstrap();
 
 // Turn on output buffering if it isn't already on (via php.ini for example)
 if (!ob_get_level())
 	ob_start();
-
-$db_show_debug = false;
-
-// We don't need no globals. (a bug in "old" versions of PHP)
-foreach (array('db_character_set', 'cachedir') as $variable)
-{
-	if (isset($GLOBALS[$variable]))
-	{
-		unset($GLOBALS[$variable], $GLOBALS[$variable]);
-	}
-}
-
-// Where the Settings.php file is located
-$settings_loc = __DIR__ . '/Settings.php';
-
-// First thing: if the install dir exists, just send anybody there
-// The ignore_install_dir var is for developers only. Do not add it on production sites
-if (file_exists('install'))
-{
-	if (file_exists($settings_loc))
-	{
-		require_once($settings_loc);
-	}
-
-	if (empty($ignore_install_dir))
-	{
-		// No install_time defined or finished the installing in the last 2 minutes
-		if (empty($install_time) || $install_time - time() < 120)
-		{
-			$redirec_file = 'install.php';
-		}
-		else
-		{
-			$redirec_file = 'upgrade.php';
-		}
-
-		header('Location: http' . (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) === 'on' ? 's' : '') . '://' . (empty($_SERVER['HTTP_HOST']) ? $_SERVER['SERVER_NAME'] . (empty($_SERVER['SERVER_PORT']) || $_SERVER['SERVER_PORT'] === '80' ? '' : ':' . $_SERVER['SERVER_PORT']) : $_SERVER['HTTP_HOST']) . (strtr(dirname($_SERVER['PHP_SELF']), '\\', '/') == '/' ? '' : strtr(dirname($_SERVER['PHP_SELF']), '\\', '/')) . '/install/' . $redirec_file);
-		die();
-	}
-}
-else
-{
-	require_once($settings_loc);
-}
-
-// Make sure the paths are correct... at least try to fix them.
-if (!file_exists($boarddir) && file_exists(__DIR__ . '/agreement.txt'))
-{
-	$boarddir = __DIR__;
-}
-if (!file_exists($sourcedir . '/SiteDispatcher.class.php') && file_exists($boarddir . '/sources'))
-{
-	$sourcedir = $boarddir . '/sources';
-}
-
-// Check that directories which didn't exist in past releases are initialized.
-if ((empty($cachedir) || !file_exists($cachedir)) && file_exists($boarddir . '/cache'))
-{
-	$cachedir = $boarddir . '/cache';
-}
-
-if ((empty($extdir) || !file_exists($extdir)) && file_exists($sourcedir . '/ext'))
-{
-	$extdir = $sourcedir . '/ext';
-}
-
-if ((empty($languagedir) || !file_exists($languagedir)) && file_exists($boarddir . '/themes/default/languages'))
-{
-	$languagedir = $boarddir . '/themes/default/languages';
-}
-
-// Time to forget about variables and go with constants!
-DEFINE('BOARDDIR', $boarddir);
-DEFINE('CACHEDIR', $cachedir);
-DEFINE('EXTDIR', $extdir);
-DEFINE('LANGUAGEDIR', $languagedir);
-DEFINE('SOURCEDIR', $sourcedir);
-DEFINE('ADMINDIR', $sourcedir . '/admin');
-DEFINE('CONTROLLERDIR', $sourcedir . '/controllers');
-DEFINE('SUBSDIR', $sourcedir . '/subs');
-DEFINE('ADDONSDIR', $boarddir . '/addons');
-unset($boarddir, $cachedir, $sourcedir, $languagedir, $extdir);
-
-// Files we cannot live without.
-require_once(SOURCEDIR . '/QueryString.php');
-require_once(SOURCEDIR . '/Session.php');
-require_once(SOURCEDIR . '/Subs.php');
-require_once(SOURCEDIR . '/Logging.php');
-require_once(SOURCEDIR . '/Load.php');
-require_once(SOURCEDIR . '/Security.php');
-require_once(SUBSDIR . '/Cache.subs.php');
-
-// Initialize the class Autoloader
-require(SOURCEDIR . '/Autoloader.class.php');
-$autoloder = Elk_Autoloader::instance();
-$autoloder->setupAutoloader(array(SOURCEDIR, SUBSDIR, CONTROLLERDIR, ADMINDIR, ADDONSDIR));
-$autoloder->register(SOURCEDIR, '\\ElkArte');
-$autoloder->register(SOURCEDIR . '/subs/BBC', '\\BBC');
-
-// Show lots of debug information below the page, not for production sites
-if ($db_show_debug === true)
-{
-	Debug::instance()->rusage('start', $rusage_start);
-}
-
-// Forum in extended maintenance mode? Our trip ends here with a bland message.
-if (!empty($maintenance) && $maintenance == 2)
-{
-	Errors::instance()->display_maintenance_message();
-}
-
-// Clean the request.
-cleanRequest();
-
-// Initiate the database connection and define some database functions to use.
-loadDatabase();
-
-// Let's set up our shiny new hooks handler.
-Hooks::init(database(), Debug::instance());
-
-// It's time for settings loaded from the database.
-reloadSettings();
-
-// Our good ole' contextual array, which will hold everything
-if (!isset($context))
-{
-	$context = array();
-}
-
-// Seed the random generator.
-elk_seed_generator();
 
 // Before we get carried away, are we doing a scheduled task? If so save CPU cycles by jumping out!
 if (isset($_GET['scheduled']))

--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@
 
 // Bootstrap the system
 require_once(dirname(__FILE__) . '/bootstrap.php');
-new Bootstrap();
+new Bootstrap(false);
 
 // Turn on output buffering if it isn't already on (via php.ini for example)
 if (!ob_get_level())

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -21,8 +21,12 @@ $ssi_guest_access = true;
 if (!file_exists(dirname(__FILE__) . '/bootstrap.php'))
 	die('Unable to initialize');
 
+require_once(dirname(__FILE__) . '/bootstrap.php');
+new Bootstrap();
+
+global $txt, $modSettings, $context;
+
 // Need lots of help
-require_once(dirname(__FILE__) . '/SSI.php');
 require_once(SUBSDIR . '/PaidSubscriptions.subs.php');
 require_once(SUBSDIR . '/Admin.subs.php');
 require_once(SUBSDIR . '/Members.subs.php');

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -12,17 +12,17 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1
+ * @version 1.1.1
  *
  */
 
 // Start things rolling by getting the forum alive...
 $ssi_guest_access = true;
 if (!file_exists(dirname(__FILE__) . '/bootstrap.php'))
-	die('Cannot find bootstrap.php');
+	die('Unable to initialize');
 
 // Need lots of help
-require_once(dirname(__FILE__) . '/bootstrap.php');
+require_once(dirname(__FILE__) . '/SSI.php');
 require_once(SUBSDIR . '/PaidSubscriptions.subs.php');
 require_once(SUBSDIR . '/Admin.subs.php');
 require_once(SUBSDIR . '/Members.subs.php');


### PR DESCRIPTION
There was *a lot* of duplicate code between index.php and bootstrap ... this is a *first* pass at using a single bootup class for both SSI and "normal" elk to remove the duplication.

This may be a bit much for 1,1.1 ... if so we need to still make a couple of minor changes to allow SSI to load from inside ELK ... so things like portals work 😸 

If we want to go this way i'll add in some quick docblocks, right now this was really a quick and dirty setup so things should work in 1.1.1 and we can do some proper things in 2.0.  Also if so PLEASE test this out, I have not checked the logs (site or server) for issues just yet. 

If however we feel this is to much, I need to make a commit to fix the SSI loading form inside ELK, so let me know which way we feel is the right way (for 1.1.1 that is)
