### PR TITLE
Potential fix for #3225 checks to make sure either install.php or upgrade.php exists before redirecting

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -149,7 +149,7 @@ class Bootstrap
 
 		// First thing: if the install dir exists, just send anybody there
 		// The ignore_install_dir var is for developers only. Do not add it on production sites
-		if (file_exists('install') && (file_exists('install/install.php') || file_exists('install/upgrade.php'))
+		if (file_exists('install') && (file_exists('install/install.php') || file_exists('install/upgrade.php')))
 		{
 			if (file_exists($settings_loc))
 			{

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -149,7 +149,7 @@ class Bootstrap
 
 		// First thing: if the install dir exists, just send anybody there
 		// The ignore_install_dir var is for developers only. Do not add it on production sites
-		if (file_exists('install'))
+		if (file_exists('install') && (file_exists('install/install.php') || file_exists('install/upgrade.php'))
 		{
 			if (file_exists($settings_loc))
 			{


### PR DESCRIPTION
Added a additional check to ensure that install.php or upgrade.php exist in the install directory before redirecting the user to there. 