### PR TITLE
Unsubscribe improvements

### DIFF
--- a/sources/SiteDispatcher.class.php
+++ b/sources/SiteDispatcher.class.php
@@ -102,7 +102,6 @@ class Site_Dispatcher
 		'moderate' => array('ModerationCenter_Controller', 'action_index'),
 		'movetopic' => array('MoveTopic_Controller', 'action_movetopic'),
 		'movetopic2' => array('MoveTopic_Controller', 'action_movetopic2'),
-		'notify' => array('Notify_Controller', 'action_notify'),
 		'notifyboard' => array('Notify_Controller', 'action_notifyboard'),
 		'openidreturn' => array('OpenID_Controller', 'action_openidreturn'),
 		'xrds' => array('OpenID_Controller', 'action_xrds'),

--- a/sources/admin/ManageFeatures.controller.php
+++ b/sources/admin/ManageFeatures.controller.php
@@ -11,7 +11,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1.4
+ * @version 1.1.7
  *
  */
 
@@ -1413,22 +1413,30 @@ class ManageFeatures_Controller extends Action_Controller
 		);
 
 		$notification_methods = Notifications::instance()->getNotifiers();
-		$notification_types = getNotificationTypes();
+		list($notification_types, $frequency) = getNotificationTypes();
 		$current_settings = unserialize($modSettings['notification_methods']);
 
 		foreach ($notification_types as $title)
 		{
 			$config_vars[] = array('title', 'setting_' . $title);
 
-			foreach ($notification_methods as $method)
+			foreach ($notification_methods as $key => $method)
 			{
-				if ($method === 'notification')
-					$text_label = $txt['setting_notify_enable_this'];
-				else
-					$text_label = $txt['notify_' . $method];
+				// If the method is available in this area, show the option
+				if (in_array($method, $frequency[$title]))
+				{
+					if ($method === 'notification')
+					{
+						$text_label = $txt['setting_notify_enable_this'];
+					}
+					else
+					{
+						$text_label = $txt['notify_' . $method];
+					}
 
-				$config_vars[] = array('check', 'notifications[' . $title . '][' . $method . ']', 'text_label' => $text_label);
-				$modSettings['notifications[' . $title . '][' . $method . ']'] = !empty($current_settings[$title][$method]);
+					$config_vars[] = array('check', 'notifications[' . $title . '][' . $method . ']', 'text_label' => $text_label);
+					$modSettings['notifications[' . $title . '][' . $method . ']'] = !empty($current_settings[$title][$method]);
+				}
 			}
 		}
 

--- a/sources/controllers/Likes.controller.php
+++ b/sources/controllers/Likes.controller.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -156,7 +156,7 @@ class Likes_Controller extends Action_Controller
 							$type,
 							$this->_id_liked,
 							$user_info['id'],
-							array('id_members' => array($liked_message['id_member']), 'rlike_notif' => empty($modSettings['mentions_dont_notify_rlike']))
+							array('id_members' => array($liked_message['id_member']), 'rlike_notif' => empty($modSettings['mentions_dont_notify_rlike']), 'subject' => $liked_message['subject'])
 						));
 					}
 				}

--- a/sources/controllers/Members.controller.php
+++ b/sources/controllers/Members.controller.php
@@ -11,7 +11,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1.6
+ * @version 1.1.7
  *
  */
 
@@ -71,7 +71,7 @@ class Members_Controller extends Action_Controller
 			$user_info['buddies'][] = $user;
 
 			// Do we want a mention for our newly added buddy?
-			if (!empty($modSettings['mentions_enabled']) && !empty($modSettings['mentions_buddy']))
+			if (!empty($modSettings['mentions_enabled']))
 			{
 				$notifier = Notifications::instance();
 				$notifier->add(new Notifications_Task(

--- a/sources/controllers/Notify.controller.php
+++ b/sources/controllers/Notify.controller.php
@@ -427,6 +427,7 @@ class Notify_Controller extends Action_Controller
 				case 'topic':
 					$topic = $extra;
 					$this->_toggle_topic_notification();
+					break;
 				case 'board':
 					$board = $extra;
 					$this->_toggle_board_notification();

--- a/sources/controllers/Notify.controller.php
+++ b/sources/controllers/Notify.controller.php
@@ -75,7 +75,8 @@ class Notify_Controller extends Action_Controller
 		// Api ajax call?
 		if (isset($this->_req->query->api))
 		{
-			return $this->action_notify_api();
+			$this->action_notify_api();
+			return true;
 		}
 
 		// Make sure they aren't a guest or something - guests can't really receive notifications!
@@ -423,36 +424,54 @@ class Notify_Controller extends Action_Controller
 		$valid = $this->_validateUnsubscribeToken($member, $area, $extra);
 		if ($valid)
 		{
-			global $user_info, $board, $topic;
+			$this->_unsubscribeToggle($member, $area, $extra);
+			$this->_prepareTemplateMessage( $area, $extra, $member['email_address']);
 
-			// Look away while we stuff the old ballet box, power to the people!
-			$user_info['id'] = $member['id_member'];
-			$this->_req->query->sa = 'off';
-
-			switch ($area)
-			{
-				case 'topic':
-					$topic = $extra;
-					$this->_toggle_topic_notification();
-					break;
-				case 'board':
-					$board = $extra;
-					$this->_toggle_board_notification();
-					break;
-				case 'buddy':
-				case 'likemsg':
-				case 'mentionmem':
-				case 'quotedmem':
-				case 'rlikemsg':
-					$this->_setUserNotificationArea($member['id_member'], $area, 1);
-					break;
-			}
+			return true;
 		}
 
-		$this->_prepareTemplateMessage($valid ? $area : 'default', $extra, isset($member['email_address']) ? $member['email_address'] : '');
+		// A default msg that we did something and maybe take a chill?
+		$this->_prepareTemplateMessage('default', '', '');
 
-		// Maybe take a chill? Not the proper message it should not happen either
-		return $valid ? true : spamProtection('remind');
+		// Not the proper message it should not happen either
+		spamProtection('remind');
+
+		return true;
+	}
+
+	/**
+	 * Does the actual area unsubscribe toggle
+	 *
+	 * @param mixed[] $member Member info from getBasicMemberData
+	 * @param string $area area they want to be removed from
+	 * @param string $extra parameters needed for some areas
+	 */
+	private function _unsubscribeToggle($member, $area, $extra)
+	{
+		global $user_info, $board, $topic;
+
+		// Look away while we stuff the old ballet box, power to the people!
+		$user_info['id'] = (int) $member['id_member'];
+		$this->_req->query->sa = 'off';
+
+		switch ($area)
+		{
+			case 'topic':
+				$topic = $extra;
+				$this->_toggle_topic_notification();
+				break;
+			case 'board':
+				$board = $extra;
+				$this->_toggle_board_notification();
+				break;
+			case 'buddy':
+			case 'likemsg':
+			case 'mentionmem':
+			case 'quotedmem':
+			case 'rlikemsg':
+				$this->_setUserNotificationArea($member['id_member'], $area, 1);
+				break;
+		}
 	}
 
 	/**
@@ -574,12 +593,12 @@ class Notify_Controller extends Action_Controller
 		{
 			case 'topic':
 				require_once(SUBSDIR . '/Topic.subs.php');
-				$subject = getSubject($extra);
+				$subject = getSubject((int) $extra);
 				$context['unsubscribe_message'] = sprintf($txt['notify_topic_unsubscribed'], $subject, $email);
 				break;
 			case 'board':
 				require_once(SUBSDIR . '/Boards.subs.php');
-				$name = boardInfo($extra);
+				$name = boardInfo((int) $extra);
 				$context['unsubscribe_message'] = sprintf($txt['notify_board_unsubscribed'], $name['name'], $email);
 				break;
 			case 'buddy':

--- a/sources/subs/ManageFeatures.subs.php
+++ b/sources/subs/ManageFeatures.subs.php
@@ -12,7 +12,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1.1
+ * @version 1.1.7
  *
  */
 
@@ -748,12 +748,13 @@ function loadAllCustomFields()
 }
 
 /**
- * Load all the available mention types
+ * Load all the available mention types and timings
  *
  * What it does:
  *
  * - Scans teh subs\MentionType directory for files
  * - Calls its getType method
+ * - Calls its getSupportedFrequency method
  *
  * @return array
  */
@@ -763,15 +764,17 @@ function getNotificationTypes()
 
 	$glob = new GlobIterator(SUBSDIR . '/MentionType/*Mention.php', FilesystemIterator::SKIP_DOTS);
 	$types = array();
+	$frequency = array();
 
 	// For each file found, call its getType method
 	foreach ($glob as $file)
 	{
 		$class_name = '\\ElkArte\\sources\\subs\\MentionType\\' . preg_replace('~([^^])((?<=)[A-Z](?=[a-z]))~', '$1_$2', $file->getBasename('.php'));
 		$types[] = $class_name::getType();
+		$frequency[$class_name::getType()] = $class_name::getSupportedFrequency();
 	}
 
-	return $types;
+	return array($types, $frequency);
 }
 
 /**

--- a/sources/subs/Members.subs.php
+++ b/sources/subs/Members.subs.php
@@ -1649,7 +1649,7 @@ function maxMemberID()
  * - 'sort' (string) a column to sort the results
  * - 'moderation' (bool) includes member_ip, id_group, additional_groups, last_login
  * - 'authentication' (bool) includes secret_answer, secret_question, openid_uri,
- *    is_activated, validation_code, passwd_flood
+ *    is_activated, validation_code, passwd_flood, password_salt
  * - 'preferences' (bool) includes lngfile, mod_prefs, notify_types, signature
  * @return array
  */
@@ -1686,7 +1686,7 @@ function getBasicMemberData($member_ids, $options = array())
 	$request = $db->query('', '
 		SELECT id_member, member_name, real_name, email_address, hide_email, posts, id_theme' . (!empty($options['moderation']) ? ',
 		member_ip, id_group, additional_groups, last_login, id_post_group' : '') . (!empty($options['authentication']) ? ',
-		secret_answer, secret_question, openid_uri, is_activated, validation_code, passwd_flood' : '') . (!empty($options['preferences']) ? ',
+		secret_answer, secret_question, openid_uri, is_activated, validation_code, passwd_flood, password_salt' : '') . (!empty($options['preferences']) ? ',
 		lngfile, mod_prefs, notify_types, signature' : '') . '
 		FROM {db_prefix}members
 		WHERE id_member IN ({array_int:member_list})

--- a/sources/subs/MentionType/LikemsgMention.php
+++ b/sources/subs/MentionType/LikemsgMention.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -45,6 +45,7 @@ class Likemsg_Mention extends Mention_BoardAccess_Abstract
 		$notifier = $this->_task->getNotifierData();
 		$replacements = array(
 			'ACTIONNAME' => $notifier['real_name'],
+			'SUBJECT' =>  $this->_task['source_data']['subject'],
 			'MSGLINK' => replaceBasicActionUrl('{script_url}?msg=' . $this->_task->id_target),
 		);
 

--- a/sources/subs/MentionType/MailfailMention.php
+++ b/sources/subs/MentionType/MailfailMention.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1.4
+ * @version 1.1.7
  *
  */
 
@@ -26,6 +26,11 @@ class Mailfail_Mention extends Mention_BoardAccess_Abstract
 	 * {@inheritdoc }
 	 */
 	protected static $_type = 'mailfail';
+
+	/**
+	 * {@inheritdoc }
+	 */
+	protected static $_frequency = ['notification'];
 
 	/**
 	 * {@inheritdoc }

--- a/sources/subs/MentionType/MentionMessageAbstract.php
+++ b/sources/subs/MentionType/MentionMessageAbstract.php
@@ -164,9 +164,13 @@ abstract class Mention_Message_Abstract implements Mention_Type_Interface
 		$return = array();
 		if (!empty($template))
 		{
+			require_once(SUBSDIR . '/Notification.subs.php');
+
 			foreach ($members as $member)
 			{
 				$replacements['REALNAME'] = $members_data[$member]['real_name'];
+				$replacements['UNSUBSCRIBELINK'] = replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
+					getNotifierToken($member, $members_data[$member]['email_address'], $members_data[$member]['password_salt'], $task->notification_type . '_' . $task->id_target));
 				$langstrings = $this->_loadStringsByTemplate($template, $keys, $members, $members_data, $lang_files, $replacements);
 
 				$return[] = array(

--- a/sources/subs/MentionType/MentionMessageAbstract.php
+++ b/sources/subs/MentionType/MentionMessageAbstract.php
@@ -170,7 +170,7 @@ abstract class Mention_Message_Abstract implements Mention_Type_Interface
 			{
 				$replacements['REALNAME'] = $members_data[$member]['real_name'];
 				$replacements['UNSUBSCRIBELINK'] = replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
-					getNotifierToken($member, $members_data[$member]['email_address'], $members_data[$member]['password_salt'], $task->notification_type . '_' . $task->id_target));
+					getNotifierToken($member, $members_data[$member]['email_address'], $members_data[$member]['password_salt'], $task->notification_type, $task->id_target));
 				$langstrings = $this->_loadStringsByTemplate($template, $keys, $members, $members_data, $lang_files, $replacements);
 
 				$return[] = array(

--- a/sources/subs/MentionType/MentionMessageAbstract.php
+++ b/sources/subs/MentionType/MentionMessageAbstract.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1.4
+ * @version 1.1.7
  *
  */
 
@@ -26,6 +26,13 @@ abstract class Mention_Message_Abstract implements Mention_Type_Interface
 	 * @var string
 	 */
 	protected static $_type = '';
+
+	/**
+	 * Which frequencies are supported by the mention type
+	 *
+	 * @var array
+	 */
+	protected static $_frequency = ['notification', 'email', 'email_daily', 'email_weekly'];
 
 	/**
 	 * The database object
@@ -67,6 +74,14 @@ abstract class Mention_Message_Abstract implements Mention_Type_Interface
 	public static function getType()
 	{
 		return static::$_type;
+	}
+
+	/**
+	 * {@inheritdoc }
+	 */
+	public static function getSupportedFrequency()
+	{
+		return static::$_frequency;
 	}
 
 	/**

--- a/sources/subs/MentionType/MentionTypeInterface.php
+++ b/sources/subs/MentionType/MentionTypeInterface.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1.4
+ * @version 1.1.7
  *
  */
 
@@ -31,6 +31,11 @@ interface Mention_Type_Interface
 	 * Just returns the _type property.
 	 */
 	public static function getType();
+
+	/**
+	 * Returns which frequencies (notification, email, daily, weekly, etc) are supported
+	 */
+	public static function getSupportedFrequency();
 
 	/**
 	 * Returns the modules to enable when turning on the mention.

--- a/sources/subs/MentionType/MentionmemMention.php
+++ b/sources/subs/MentionType/MentionmemMention.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1.4
+ * @version 1.1.7
  *
  */
 
@@ -169,7 +169,7 @@ class Mentionmem_Mention extends Mention_BoardAccess_Abstract
 				'mentionmem',
 				$msgOptions['id'],
 				$posterOptions['id'],
-				array('id_members' => $this->_actually_mentioned, 'notifier_data' => $posterOptions, 'status' => $becomesApproved
+				array('id_members' => $this->_actually_mentioned, 'notifier_data' => $posterOptions, 'subject' => $msgOptions['subject'], 'status' => $becomesApproved
 					? 'new'
 					: 'unapproved')
 			));
@@ -202,6 +202,7 @@ class Mentionmem_Mention extends Mention_BoardAccess_Abstract
 
 		$replacements = array(
 			'ACTIONNAME' => $this->_task['source_data']['notifier_data']['name'],
+			'SUBJECT' => $this->_task['source_data']['subject'],
 			'MSGLINK' => replaceBasicActionUrl('{script_url}?msg=' . $this->_task->id_target),
 		);
 

--- a/sources/subs/MentionType/QuotedmemMention.php
+++ b/sources/subs/MentionType/QuotedmemMention.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1.4
+ * @version 1.1.7
  *
  */
 
@@ -70,20 +70,19 @@ class Quotedmem_Mention extends Mention_BoardAccess_Abstract
 	public function post_after_save_post($msgOptions, $becomesApproved, $posterOptions)
 	{
 		$status = $becomesApproved ? 'new' : 'unapproved';
-		$this->_sendNotification($msgOptions['body'], $msgOptions['id'], $status, $posterOptions);
+		$this->_sendNotification($msgOptions, $status, $posterOptions);
 	}
 
 	/**
 	 * Checks if a message has been quoted and if so notifies the owner
 	 *
-	 * @param string $text The message body
-	 * @param int $msg_id The message id of the post containing the quote
+	 * @param mixed[] $msgOptions The message options array
 	 * @param string $status
 	 * @param mixed[] $posterOptions
 	 */
-	protected function _sendNotification($text, $msg_id, $status, $posterOptions)
+	protected function _sendNotification($msgOptions, $status, $posterOptions)
 	{
-		$quoted_names = $this->_findQuotedMembers($text);
+		$quoted_names = $this->_findQuotedMembers($msgOptions['body']);
 
 		if (!empty($quoted_names))
 		{
@@ -96,9 +95,9 @@ class Quotedmem_Mention extends Mention_BoardAccess_Abstract
 			$notifier = \Notifications::instance();
 			$notifier->add(new \Notifications_Task(
 				'quotedmem',
-				$msg_id,
+				$msgOptions['id'],
 				$posterOptions['id'],
-				array('id_members' => $members_id, 'notifier_data' => $posterOptions, 'status' => $status)
+				array('id_members' => $members_id, 'notifier_data' => $posterOptions, 'status' => $status, 'subject' =>  $msgOptions['subject'],)
 			));
 		}
 	}
@@ -194,6 +193,7 @@ The following bbcode is for testing, to be moved to a test when ready.
 
 		$replacements = array(
 			'ACTIONNAME' => $this->_task['source_data']['notifier_data']['name'],
+			'SUBJECT' => $this->_task['source_data']['subject'],
 			'MSGLINK' => replaceBasicActionUrl('{script_url}?msg=' . $this->_task->id_target),
 		);
 

--- a/sources/subs/MentionType/RlikemsgMention.php
+++ b/sources/subs/MentionType/RlikemsgMention.php
@@ -48,11 +48,11 @@ class Rlikemsg_Mention extends Mention_BoardAccess_Abstract
 	}
 
 	/**
-	 * {@inheritdoc }
+	 * We don't support email notification of this action, just notification
 	 */
-	public function getNotificationBody($lang_data, $users)
+	public function getNotificationBody($lang_data, $members)
 	{
-		return array();
+		return $this->_getNotificationStrings('', array('subject' => static::$_type, 'body' => static::$_type), $members, $this->_task);
 	}
 
 	/**

--- a/sources/subs/MentionType/RlikemsgMention.php
+++ b/sources/subs/MentionType/RlikemsgMention.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1.4
+ * @version 1.1.7
  *
  */
 
@@ -26,6 +26,11 @@ class Rlikemsg_Mention extends Mention_BoardAccess_Abstract
 	 * {@inheritdoc }
 	 */
 	protected static $_type = 'rlikemsg';
+
+	/**
+	 * {@inheritdoc }
+	 */
+	protected static $_frequency = ['notification'];
 
 	/**
 	 * {@inheritdoc }

--- a/sources/subs/Notification.subs.php
+++ b/sources/subs/Notification.subs.php
@@ -136,7 +136,7 @@ function sendNotifications($topics, $type, $exclude = array(), $members_only = a
 			SELECT
 				mem.id_member, mem.email_address, mem.notify_regularity, mem.notify_types, mem.notify_send_body, mem.lngfile, mem.warning,
 				ln.sent, mem.id_group, mem.additional_groups, b.member_groups, mem.id_post_group, b.name, b.id_profile,
-				ln.id_board
+				ln.id_board, mem.password_salt
 			FROM {db_prefix}log_notify AS ln
 				INNER JOIN {db_prefix}boards AS b ON (b.id_board = ln.id_board)
 				INNER JOIN {db_prefix}members AS mem ON (mem.id_member = ln.id_member)
@@ -191,9 +191,11 @@ function sendNotifications($topics, $type, $exclude = array(), $members_only = a
 					'POSTERNAME' => un_htmlspecialchars($data['name']),
 					'TOPICLINKNEW' => $scripturl . '?topic=' . $id . '.new;topicseen#new',
 					'TOPICLINK' => $scripturl . '?topic=' . $id . '.msg' . $data['last_id'] . '#msg' . $data['last_id'],
-					'UNSUBSCRIBELINK' => $scripturl . '?action=notifyboard;board=' . $data['board'] . '.0',
+					'UNSUBSCRIBELINK' => replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
+						getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'board_' . $data['board'])),
 					'SIGNATURE' => $data['signature'],
 					'BOARDNAME' => $data['board_name'],
+					'SUBSCRIPTION' => $txt['board'],
 				);
 
 				if ($type === 'remove')
@@ -251,7 +253,7 @@ function sendNotifications($topics, $type, $exclude = array(), $members_only = a
 			mem.id_member, mem.email_address, mem.notify_regularity, mem.notify_types, mem.warning,
 			mem.notify_send_body, mem.lngfile, mem.id_group, mem.additional_groups,mem.id_post_group,
 			t.id_member_started, b.member_groups, b.name, b.id_profile, b.id_board,
-			ln.id_topic, ln.sent
+			ln.id_topic, ln.sent, mem.password_salt
 		FROM {db_prefix}log_notify AS ln
 			INNER JOIN {db_prefix}members AS mem ON (mem.id_member = ln.id_member)
 			INNER JOIN {db_prefix}topics AS t ON (t.id_topic = ln.id_topic)
@@ -301,9 +303,11 @@ function sendNotifications($topics, $type, $exclude = array(), $members_only = a
 			'POSTERNAME' => un_htmlspecialchars($topicData[$row['id_topic']]['name']),
 			'TOPICLINKNEW' => $scripturl . '?topic=' . $row['id_topic'] . '.new;topicseen#new',
 			'TOPICLINK' => $scripturl . '?topic=' . $row['id_topic'] . '.msg' . $data['last_id'] . '#msg' . $data['last_id'],
-			'UNSUBSCRIBELINK' => $scripturl . '?action=notify;topic=' . $row['id_topic'] . '.0',
+			'UNSUBSCRIBELINK' => replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
+				getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'topic_' . $row['id_topic'])),
 			'SIGNATURE' => $topicData[$row['id_topic']]['signature'],
 			'BOARDNAME' => $row['name'],
+			'SUBSCRIPTION' => $txt['topic'],
 		);
 
 		if ($type == 'remove')
@@ -448,7 +452,7 @@ function sendBoardNotifications(&$topicData)
 		SELECT
 			mem.id_member, mem.email_address, mem.notify_regularity, mem.notify_send_body, mem.lngfile, mem.warning,
 			ln.sent, ln.id_board, mem.id_group, mem.additional_groups, b.member_groups, b.id_profile,
-			mem.id_post_group
+			mem.id_post_group, mem.password_salt
 		FROM {db_prefix}log_notify AS ln
 			INNER JOIN {db_prefix}boards AS b ON (b.id_board = ln.id_board)
 			INNER JOIN {db_prefix}members AS mem ON (mem.id_member = ln.id_member)
@@ -498,7 +502,8 @@ function sendBoardNotifications(&$topicData)
 				'TOPICLINK' => $scripturl . '?topic=' . $topicData[$key]['topic'] . '.new#new',
 				'TOPICLINKNEW' => $scripturl . '?topic=' . $topicData[$key]['topic'] . '.new#new',
 				'MESSAGE' => $send_body ? $topicData[$key]['body'] : '',
-				'UNSUBSCRIBELINK' => $scripturl . '?action=notifyboard;board=' . $topicData[$key]['board'] . '.0',
+				'UNSUBSCRIBELINK' => replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
+					getNotifierToken($rowmember['id_member'], $rowmember['email_address'], $rowmember['password_salt'], 'board_' . $topicData[$key]['board'])),
 				'SIGNATURE' => !empty($topicData[$key]['signature']) ? $topicData[$key]['signature'] : '',
 				'BOARDNAME' => $board_names[$topicData[$key]['board']]['name'],
 			);
@@ -599,7 +604,7 @@ function sendApprovalNotifications(&$topicData)
 		SELECT
 			mem.id_member, mem.email_address, mem.notify_regularity, mem.notify_types, mem.notify_send_body, mem.lngfile,
 			ln.sent, mem.id_group, mem.additional_groups, b.member_groups, mem.id_post_group, t.id_member_started,
-			ln.id_topic
+			ln.id_topic, mem.password_salt
 		FROM {db_prefix}log_notify AS ln
 			INNER JOIN {db_prefix}members AS mem ON (mem.id_member = ln.id_member)
 			INNER JOIN {db_prefix}topics AS t ON (t.id_topic = ln.id_topic)
@@ -639,7 +644,8 @@ function sendApprovalNotifications(&$topicData)
 		$sent_this_time = false;
 		$replacements = array(
 			'TOPICLINK' => $scripturl . '?topic=' . $row['id_topic'] . '.new;topicseen#new',
-			'UNSUBSCRIBELINK' => $scripturl . '?action=notify;topic=' . $row['id_topic'] . '.0',
+			'UNSUBSCRIBELINK' => replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
+				getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'topic_' .  $row['id_topic'])),
 		);
 
 		// Now loop through all the messages to send.
@@ -1003,4 +1009,82 @@ function getConfiguredNotificationMethods($type)
 	{
 		return array();
 	}
+}
+
+/**
+ * Creates a hash code using the notification details and our secret key
+ *
+ * - If no salt (secret key) has been set, creates a random one and saves it
+ * in modSettings for future use
+ *
+ * @param string $memID member id
+ * @param string $memEmail member email address
+ * @param string $memSalt member salt
+ * @param string $area area to unsubscribe
+ * @return string the token for the unsubscribe link
+ */
+function getNotifierToken($memID, $memEmail, $memSalt, $area)
+{
+	global $modSettings;
+
+	// Generate a 22 digit random code suitable for Blowfish crypt.
+	$tokenizer = new \Token_Hash();
+	$unsubscribe_salt = '$2a$10$' . $tokenizer->generate_hash(22);
+	$now = time();
+
+	// Ideally we would just have a larger -per user- password_salt
+	if (empty($modSettings['unsubscribe_site_salt']))
+	{
+		// extra 10 digits of salt
+		$modSettings['unsubscribe_site_salt'] = $tokenizer->generate_hash();
+		updateSettings(array('unsubscribe_site_salt' => $modSettings['unsubscribe_site_salt']));
+	}
+
+	// Add member salt + site salt to the otherwise deterministic data
+	$hash = crypt($area . $now . $memEmail . $memSalt . $modSettings['unsubscribe_site_salt'], $unsubscribe_salt);
+
+	return urlencode(implode('_',
+		array(
+			$memID,
+			substr($hash, 7),
+			$area,
+			$now
+		)
+	));
+}
+
+/**
+ * Creates a hash code using the notification details and our secret key
+ *
+ * - If no salt (secret key) has been set, creates a random one and saves it
+ * in modSettings for future use
+ *
+ * @param string $memEmail member email address
+ * @param string $memSalt member salt
+ * @param string $area area to unsubscribe
+ * @param string $hash the sent hash
+ * @return bool
+ */
+function validateNotifierToken($memEmail, $memSalt, $area, $hash)
+{
+	global $modSettings;
+
+	if (empty($modSettings['unsubscribe_site_salt']))
+	{
+		return false;
+	}
+
+	$expected = '$2a$10$' . $hash;
+	$check = crypt($area . $memEmail . $memSalt . $modSettings['unsubscribe_site_salt'], $expected);
+
+	// Basic safe compare as hash_equals is PHP 5.6+
+	if (function_exists('hash_equals'))
+	{
+		return hash_equals($expected, $check);
+	}
+
+	$ret = strlen($expected) ^ strlen($check);
+	$ret |= array_sum(unpack("C*", $expected ^ $check));
+
+	return !$ret;
 }

--- a/sources/subs/Notification.subs.php
+++ b/sources/subs/Notification.subs.php
@@ -1030,7 +1030,7 @@ function getNotifierToken($memID, $memEmail, $memSalt, $area, $extra)
 
 	// Generate a 22 digit random code suitable for Blowfish crypt.
 	$tokenizer = new \Token_Hash();
-	$unsubscribe_salt = '$2a$10$' . $tokenizer->generate_hash(22);
+	$blowfish_salt = '$2a$10$' . $tokenizer->generate_hash(22);
 	$now = time();
 
 	// Ideally we would just have a larger -per user- password_salt
@@ -1042,7 +1042,7 @@ function getNotifierToken($memID, $memEmail, $memSalt, $area, $extra)
 	}
 
 	// Add member salt + site salt to the otherwise deterministic data
-	$hash = crypt($area . $extra . $now . $memEmail . $memSalt . $modSettings['unsubscribe_site_salt'], $unsubscribe_salt);
+	$hash = crypt($area . $extra . $now . $memEmail . $memSalt . $modSettings['unsubscribe_site_salt'], $blowfish_salt);
 
 	return urlencode(implode('_',
 		array(
@@ -1058,8 +1058,7 @@ function getNotifierToken($memID, $memEmail, $memSalt, $area, $extra)
 /**
  * Creates a hash code using the notification details and our secret key
  *
- * - If no salt (secret key) has been set, creates a random one and saves it
- * in modSettings for future use
+ * - If no site salt (secret key) has been set, simply fails
  *
  * @param string $memEmail member email address
  * @param string $memSalt member salt

--- a/sources/subs/Notification.subs.php
+++ b/sources/subs/Notification.subs.php
@@ -192,7 +192,7 @@ function sendNotifications($topics, $type, $exclude = array(), $members_only = a
 					'TOPICLINKNEW' => $scripturl . '?topic=' . $id . '.new;topicseen#new',
 					'TOPICLINK' => $scripturl . '?topic=' . $id . '.msg' . $data['last_id'] . '#msg' . $data['last_id'],
 					'UNSUBSCRIBELINK' => replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
-						getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'board_' . $data['board'])),
+						getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'board', $data['board'])),
 					'SIGNATURE' => $data['signature'],
 					'BOARDNAME' => $data['board_name'],
 					'SUBSCRIPTION' => $txt['board'],
@@ -304,7 +304,7 @@ function sendNotifications($topics, $type, $exclude = array(), $members_only = a
 			'TOPICLINKNEW' => $scripturl . '?topic=' . $row['id_topic'] . '.new;topicseen#new',
 			'TOPICLINK' => $scripturl . '?topic=' . $row['id_topic'] . '.msg' . $data['last_id'] . '#msg' . $data['last_id'],
 			'UNSUBSCRIBELINK' => replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
-				getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'topic_' . $row['id_topic'])),
+				getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'topic', $row['id_topic'])),
 			'SIGNATURE' => $topicData[$row['id_topic']]['signature'],
 			'BOARDNAME' => $row['name'],
 			'SUBSCRIPTION' => $txt['topic'],
@@ -503,7 +503,7 @@ function sendBoardNotifications(&$topicData)
 				'TOPICLINKNEW' => $scripturl . '?topic=' . $topicData[$key]['topic'] . '.new#new',
 				'MESSAGE' => $send_body ? $topicData[$key]['body'] : '',
 				'UNSUBSCRIBELINK' => replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
-					getNotifierToken($rowmember['id_member'], $rowmember['email_address'], $rowmember['password_salt'], 'board_' . $topicData[$key]['board'])),
+					getNotifierToken($rowmember['id_member'], $rowmember['email_address'], $rowmember['password_salt'], 'board', $topicData[$key]['board'])),
 				'SIGNATURE' => !empty($topicData[$key]['signature']) ? $topicData[$key]['signature'] : '',
 				'BOARDNAME' => $board_names[$topicData[$key]['board']]['name'],
 			);
@@ -645,7 +645,7 @@ function sendApprovalNotifications(&$topicData)
 		$replacements = array(
 			'TOPICLINK' => $scripturl . '?topic=' . $row['id_topic'] . '.new;topicseen#new',
 			'UNSUBSCRIBELINK' => replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
-				getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'topic_' . $row['id_topic'])),
+				getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'topic', $row['id_topic'])),
 		);
 
 		// Now loop through all the messages to send.
@@ -1021,9 +1021,10 @@ function getConfiguredNotificationMethods($type)
  * @param string $memEmail member email address
  * @param string $memSalt member salt
  * @param string $area area to unsubscribe
+ * @param string $extra area specific data such as topic id or liked msg
  * @return string the token for the unsubscribe link
  */
-function getNotifierToken($memID, $memEmail, $memSalt, $area)
+function getNotifierToken($memID, $memEmail, $memSalt, $area, $extra)
 {
 	global $modSettings;
 
@@ -1041,13 +1042,14 @@ function getNotifierToken($memID, $memEmail, $memSalt, $area)
 	}
 
 	// Add member salt + site salt to the otherwise deterministic data
-	$hash = crypt($area . $now . $memEmail . $memSalt . $modSettings['unsubscribe_site_salt'], $unsubscribe_salt);
+	$hash = crypt($area . $extra . $now . $memEmail . $memSalt . $modSettings['unsubscribe_site_salt'], $unsubscribe_salt);
 
 	return urlencode(implode('_',
 		array(
 			$memID,
 			substr($hash, 7),
 			$area,
+			$extra,
 			$now
 		)
 	));

--- a/sources/subs/Notification.subs.php
+++ b/sources/subs/Notification.subs.php
@@ -645,7 +645,7 @@ function sendApprovalNotifications(&$topicData)
 		$replacements = array(
 			'TOPICLINK' => $scripturl . '?topic=' . $row['id_topic'] . '.new;topicseen#new',
 			'UNSUBSCRIBELINK' => replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
-				getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'topic_' .  $row['id_topic'])),
+				getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'topic_' . $row['id_topic'])),
 		);
 
 		// Now loop through all the messages to send.

--- a/sources/subs/NotificationsTask.class.php
+++ b/sources/subs/NotificationsTask.class.php
@@ -8,7 +8,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -96,7 +96,7 @@ class Notifications_Task extends \ElkArte\ValuesContainer
 		if ($this->_members_data === null)
 		{
 			require_once(SUBSDIR . '/Members.subs.php');
-			$this->_members_data = getBasicMemberData($this->getMembers(), array('preferences' => true));
+			$this->_members_data = getBasicMemberData($this->getMembers(), array('preferences' => true, 'authentication' => true));
 		}
 
 		return $this->_members_data;

--- a/sources/subs/ProfileOptions.subs.php
+++ b/sources/subs/ProfileOptions.subs.php
@@ -43,7 +43,7 @@ function getBuddiesID($buddies, $adding = true)
 	);
 
 	// If we are mentioning buddies, then let them know who's their buddy.
-	if ($adding && !empty($modSettings['mentions_enabled']) && !empty($modSettings['mentions_buddy']))
+	if ($adding && !empty($modSettings['mentions_enabled']))
 	{
 		$notifier = Notifications::instance();
 	}

--- a/themes/default/Notify.template.php
+++ b/themes/default/Notify.template.php
@@ -50,3 +50,19 @@ function template_notify_board()
 			</p>
 		</div>';
 }
+
+/**
+ * Something to show confirmation when they have unsubscribed from mention/topic/board/etc
+ */
+function template_notify_unsubscribe()
+{
+	global $context, $txt;
+
+	echo '
+		<h2 class="category_header hdicon cat_img_mail">
+			', $txt['unnotify'], '
+		</h2>
+		<div class="well centertext">
+			<p>', $context['unsubscribe_message'], '</p>
+		</div>';
+}

--- a/themes/default/languages/english/EmailTemplates.english.php
+++ b/themes/default/languages/english/EmailTemplates.english.php
@@ -4,7 +4,7 @@
 // Since all of these strings are being used in emails, numeric entities should be used.
 
 // Do not translate anything that is between {}, they are used as replacement variables and MUST remain exactly how they are.
-//   Additionally do not translate the @additioinal_parmas: line or the variable names in the lines that follow it.  You may
+//   Additionally do not translate the @additional_params: line or the variable names in the lines that follow it.  You may
 //   translate the description of the variable.  Do not translate @description:, however you may translate the rest of that line.
 
 // Do not use block comments in this file, they will have special meaning.
@@ -868,7 +868,7 @@ Once the attachments directory reaches it\'s maximum permitted size users will n
 $txt['admin_backup_database_subject'] = 'A database backup has been taken';
 $txt['admin_backup_database_body'] = '{REALNAME},
 
-this email is to to inform you that {BAK_REALNAME} has just downloaded a backup of the database at {FORUMNAME}.
+This email is to inform you that {BAK_REALNAME} has just downloaded a backup of the database at {FORUMNAME}.
 
 {REGARDS}';
 
@@ -1038,9 +1038,15 @@ Reply to this Personal Message (to the sender only) here: {REPLYLINK}';
 $txt['notify_new_buddy_subject'] = '{ACTIONNAME} added you as buddy';
 $txt['notify_new_buddy_body'] = '{REALNAME},
 
-this email is to to inform you that {ACTIONNAME} has just has added you as buddy at {FORUMNAME}.
+We wanted to let you know that {ACTIONNAME} has just added you as a buddy 
+at {FORUMNAME}.  
 
-{REGARDS}';
+{REGARDS}
+
+
+You can unsubscribe to further "new buddy" notifications by using this link:
+{UNSUBSCRIBELINK}
+';
 $txt['notify_new_buddy_digest'] = 'You have been added as buddy by:';
 $txt['notify_new_buddy_snippet'] = '{ACTIONNAME}';
 
@@ -1048,14 +1054,23 @@ $txt['notify_new_buddy_snippet'] = '{ACTIONNAME}';
 	@additional_params: notify_new_likemsg
 		ACTIONNAME:  The user name of the member that liked the message.
 		MSGLINK:  The url to the message liked.
+		SUBJECT: The subject of the message
 	@description: A notification email sent to the members whose message has been liked
 */
 $txt['notify_new_likemsg_subject'] = 'A message received a like';
 $txt['notify_new_likemsg_body'] = '{REALNAME},
 
-this email is to to inform you that {ACTIONNAME} has just has liked the message {MSGLINK} at {FORUMNAME}.
+We wanted to let you know that {ACTIONNAME} has just liked your message 
+in the "{SUBJECT}" topic at {FORUMNAME}.  
+You can view that message by following this link:
+{MSGLINK}
 
-{REGARDS}';
+{REGARDS}
+
+
+You can unsubscribe to further "liked by" notifications by using this link:
+{UNSUBSCRIBELINK}
+';
 $txt['notify_new_likemsg_digest'] = 'The following messages has been liked:';
 $txt['notify_new_likemsg_snippet'] = '{MSGLINK}';
 
@@ -1063,29 +1078,47 @@ $txt['notify_new_likemsg_snippet'] = '{MSGLINK}';
 	@additional_params: notify_mentionmem
 		ACTIONNAME:  The user name of the member that mentioned someone.
 		MSGLINK:  The url to the message where someone has been mentioned.
+        SUBJECT: The subject of the message
 	@description: A notification email sent to the members mentioned by someone else in a message
 */
 $txt['notify_mentionmem_subject'] = 'You have been mentioned';
 $txt['notify_mentionmem_body'] = '{REALNAME},
 
-this email is to to inform you that {ACTIONNAME} has just mentioned you in the message {MSGLINK} at {FORUMNAME}.
+We wanted to let you know that {ACTIONNAME} has just mentioned you in a message 
+in the "{SUBJECT}" topic at {FORUMNAME}.  
+You can view that message by following this link:
+{MSGLINK}
 
-{REGARDS}';
-$txt['notify_mentionmem_digest'] = 'You have been mentioned in the followin messages:';
+{REGARDS}
+
+
+You can unsubscribe to further "mentioned" notifications by using this link:
+{UNSUBSCRIBELINK}
+';
+$txt['notify_mentionmem_digest'] = 'You have been mentioned in the following messages:';
 $txt['notify_mentionmem_snippet'] = '{MSGLINK}';
 
 /**
 	@additional_params: notify_quotedmem
 		ACTIONNAME:  The user name of the member that quoted someone's message.
 		MSGLINK:  The url to the message where someone has been quoted.
+        SUBJECT: The subject of the message
 	@description: A notification email sent to the members quoted in someone else message
 */
-$txt['notify_quotedmem_subject'] = 'A message has been quoted';
+$txt['notify_quotedmem_subject'] = 'Your message has been quoted';
 $txt['notify_quotedmem_body'] = '{REALNAME},
 
-this email is to to inform you that {ACTIONNAME} has just quoted one of your messages in {MSGLINK} at {FORUMNAME}.
+We wanted to let you know that {ACTIONNAME} at {FORUMNAME} has just quoted
+your messages in the "{SUBJECT}" topic.  You can view that message by 
+following this link:
+{MSGLINK}
 
-{REGARDS}';
+{REGARDS}
+
+
+You can unsubscribe to further "quoted message" notifications by using this link:
+{UNSUBSCRIBELINK}
+';
 $txt['notify_quotedmem_digest'] = 'Your messages have been quoted in:';
 $txt['notify_quotedmem_snippet'] = '{MSGLINK}';
 

--- a/themes/default/languages/english/MaillistTemplates.english.php
+++ b/themes/default/languages/english/MaillistTemplates.english.php
@@ -40,7 +40,7 @@ You can reply to this email and have it posted as a topic reply.
 <*> You can see this message by using this link:
     {TOPICLINK}
 
-<*> Unsubscribe to this by using this link:
+<*> Unsubscribe to this board by using this link:
     {UNSUBSCRIBELINK}
 
 {EMAILREGARDS}';
@@ -81,7 +81,7 @@ You can reply to this email and have it posted as a topic reply.
 <*> You can go to your first unread message by using this link:
     {TOPICLINKNEW}
 
-<*> Unsubscribe to this by using this link:
+<*> Unsubscribe to this board by using this link:
     {UNSUBSCRIBELINK}
 
 {EMAILREGARDS}';
@@ -122,7 +122,7 @@ You can reply to this email and have it posted as a topic reply.
 <*> You can go to your first unread message by using this link:
     {TOPICLINKNEW}
 
-<*> Unsubscribe to this by using this link:
+<*> Unsubscribe to this {SUBSCRIPTION} by using this link:
     {UNSUBSCRIBELINK}
 
 {EMAILREGARDS}';
@@ -164,7 +164,7 @@ You can reply to this email and have it posted as a reply.
 <*> You can go to your first unread message by using this link:
     {TOPICLINKNEW}
 
-<*> Unsubscribe to this by using this link:
+<*> Unsubscribe to this {SUBSCRIPTION} by using this link:
     {UNSUBSCRIBELINK}
 
 {EMAILREGARDS}';

--- a/themes/default/languages/english/index.english.php
+++ b/themes/default/languages/english/index.english.php
@@ -786,6 +786,11 @@ $txt['approve_many_members_waiting'] = 'There are <a href="%1$s">%2$d members</a
 $txt['notifyboard_turnon'] = 'Do you want a notification email when someone posts a new topic in this board?';
 $txt['notifyboard_turnoff'] = 'Are you sure you do not want to receive new topic notifications for this board?';
 
+$txt['notify_board_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and you will no longer receive notifications from the "%1$s" board.';
+$txt['notify_topic_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and you will no longer receive notifications on the "%1$s" topic.';
+$txt['notify_mention_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and you will no longer receive "%1$s" notifications.';
+$txt['notify_default_unsubscribed'] = 'Your request has been successfully processed.';
+
 $txt['find_members'] = 'Find Members';
 $txt['find_username'] = 'Name, username, or email address';
 $txt['find_buddies'] = 'Show Buddies Only?';

--- a/themes/default/languages/english/index.english.php
+++ b/themes/default/languages/english/index.english.php
@@ -786,9 +786,9 @@ $txt['approve_many_members_waiting'] = 'There are <a href="%1$s">%2$d members</a
 $txt['notifyboard_turnon'] = 'Do you want a notification email when someone posts a new topic in this board?';
 $txt['notifyboard_turnoff'] = 'Are you sure you do not want to receive new topic notifications for this board?';
 
-$txt['notify_board_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and you will no longer receive notifications from the "%1$s" board.';
-$txt['notify_topic_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and you will no longer receive notifications on the "%1$s" topic.';
-$txt['notify_mention_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and you will no longer receive "%1$s" notifications.';
+$txt['notify_board_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and will no longer be sent notifications from the "%1$s" board.';
+$txt['notify_topic_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and will no longer be sent notifications on the "%1$s" topic.';
+$txt['notify_mention_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and will no longer be sent "%1$s" notifications.';
 $txt['notify_default_unsubscribed'] = 'Your request has been successfully processed.';
 
 $txt['find_members'] = 'Find Members';


### PR DESCRIPTION
This extends  the current unsubscribe links from topics/boards to all our various mentions (quoted, liked, mentioned, etc) to allow easy unsubscribe.  It also adds additional information to those mentions, namely the subject in which the event occurred, thats a bit nicer for the email.

Adds the static frequency value to the mention controllers, currently all frequencies were shown for all methods but that was not really correct (e.g. bounced is only notify not email).  With this the method allowed frequencies is shown in the ACP.

links are all now a one button affair with some protections to avoid spamming and general mischief.  I'm not super happy with some things but in general the token is a blowfish crypt with user and extra site salt, this makes a brute force a time consuming process and all you would get is the ability to unsubscribe someone.

Adds a buh-bye thanks for no longer using our quota confirmation page with just what you have been unsubscribed from.