### PR TITLE
Some more milk with the cookies

### DIFF
--- a/install/Install_Controller.php
+++ b/install/Install_Controller.php
@@ -1067,7 +1067,7 @@ class Install_Controller
 			{
 				require_once(SUBSDIR . '/Auth.subs.php');
 
-				$incontext['member_salt'] = substr(sha1(mt_rand() . microtime()), 0, 16);
+				$incontext['member_salt'] = substr(base64_encode(sha1(mt_rand() . microtime(), true)), 0, 16);
 
 				// Format the username properly.
 				$_POST['username'] = preg_replace('~[\t\n\r\x0B\0\xA0]+~', ' ', $_POST['username']);

--- a/install/Install_Controller.php
+++ b/install/Install_Controller.php
@@ -1067,7 +1067,7 @@ class Install_Controller
 			{
 				require_once(SUBSDIR . '/Auth.subs.php');
 
-				$incontext['member_salt'] = substr(md5(mt_rand()), 0, 4);
+				$incontext['member_salt'] = substr(sha1(mt_rand() . microtime()), 0, 16);
 
 				// Format the username properly.
 				$_POST['username'] = preg_replace('~[\t\n\r\x0B\0\xA0]+~', ' ', $_POST['username']);

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -869,7 +869,7 @@ function checkLogin()
 					if ($valid_password)
 					{
 						$password = validateLoginPassword($_POST['passwrd'], '', $_POST['user'], true);
-						$password_salt = substr(sha1(mt_rand() . microtime()), 0, 16);
+						$password_salt = substr(base64_encode(sha1(mt_rand() . microtime(), true)), 0, 16);
 
 						// Update the password hash and set up the salt.
 						require_once(SUBSDIR . '/Members.subs.php');

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -869,7 +869,7 @@ function checkLogin()
 					if ($valid_password)
 					{
 						$password = validateLoginPassword($_POST['passwrd'], '', $_POST['user'], true);
-						$password_salt = substr(md5(mt_rand()), 0, 4);
+						$password_salt = substr(sha1(mt_rand() . microtime()), 0, 16);
 
 						// Update the password hash and set up the salt.
 						require_once(SUBSDIR . '/Members.subs.php');

--- a/sources/Load.php
+++ b/sources/Load.php
@@ -326,6 +326,14 @@ function loadUserSettings()
 
 		// This is a logged in user, so definitely not a spider.
 		$user_info['possibly_robot'] = false;
+
+		// Lets upgrade the salt if needed.
+		require_once(SUBSDIR . '/Members.subs.php');
+		if (updateMemberSalt($id_member))
+		{
+			require_once(SUBSDIR . '/Auth.subs.php');
+			setLoginCookie(60 * $modSettings['cookieTime'], $user_settings['id_member'], hash('sha256', ($user_settings['passwd'] . $user_settings['password_salt'])));
+		}
 	}
 	// If the user is a guest, initialize all the critical user settings.
 	else

--- a/sources/Load.php
+++ b/sources/Load.php
@@ -11,7 +11,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1.5
+ * @version 1.1.7
  *
  */
 

--- a/sources/controllers/OpenID.controller.php
+++ b/sources/controllers/OpenID.controller.php
@@ -169,10 +169,8 @@ class OpenID_Controller extends Action_Controller
 			// Generate an ElkArte hash for the db to protect this account
 			$user_settings['passwd'] = validateLoginPassword($this->_secret, '', $user_settings['member_name'], true);
 
-			$tokenizer = new Token_Hash();
-			$user_settings['password_salt'] = $tokenizer->generate_hash(4);
-
 			require_once(SUBSDIR . '/Members.subs.php');
+			updateMemberSalt($user_settings['id_member'], true);
 			updateMemberData($user_settings['id_member'], array('passwd' => $user_settings['passwd'], 'password_salt' => $user_settings['password_salt']));
 
 			// Cleanup on Aisle 5.

--- a/sources/controllers/OpenID.controller.php
+++ b/sources/controllers/OpenID.controller.php
@@ -11,7 +11,7 @@
  * copyright:	2012 Simple Machines Forum (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 

--- a/sources/controllers/ProfileOptions.controller.php
+++ b/sources/controllers/ProfileOptions.controller.php
@@ -13,7 +13,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1.6
+ * @version 1.1.7
  *
  */
 

--- a/sources/controllers/ProfileOptions.controller.php
+++ b/sources/controllers/ProfileOptions.controller.php
@@ -567,7 +567,7 @@ class ProfileOptions_Controller extends Action_Controller
 					updateMemberData($this->_memID, array('openid_uri' => '', 'passwd' => $passwd));
 					if ($context['user']['is_owner'])
 					{
-						setLoginCookie(60 * $modSettings['cookieTime'], $this->_memID, hash('sha256', $new_pass . $cur_profile['password_salt']));
+						setLoginCookie(60 * $modSettings['cookieTime'], $this->_memID, hash('sha256', $passwd . $cur_profile['password_salt']));
 						redirectexit('action=profile;area=authentication;updated');
 					}
 					else

--- a/sources/subs/Members.subs.php
+++ b/sources/subs/Members.subs.php
@@ -587,7 +587,7 @@ function registerMember(&$regOptions, $ErrorContext = 'register')
 		'member_name' => $regOptions['username'],
 		'email_address' => $regOptions['email'],
 		'passwd' => validateLoginPassword($password, '', $regOptions['username'], true),
-		'password_salt' => $tokenizer->generate_hash(4),
+		'password_salt' => $tokenizer->generate_hash(16),
 		'posts' => 0,
 		'date_registered' => !empty($regOptions['time']) ? $regOptions['time'] : time(),
 		'member_ip' => $regOptions['interface'] == 'admin' ? '127.0.0.1' : $regOptions['ip'],

--- a/sources/subs/Members.subs.php
+++ b/sources/subs/Members.subs.php
@@ -2641,3 +2641,32 @@ function registerAgreementAccepted($id_member, $ip, $agreement_version)
 		array('version', 'id_member')
 	);
 }
+
+/**
+ * Utility function to update a members salt to a new value
+ *
+ * @param int $id member to update
+ * @param bool $refresh if to always refresh to a new salt
+ * @param int $min if current salt lenght is less than this, gen a new one
+ * @return bool
+ */
+function updateMemberSalt($id, $refresh = false, $min = 9)
+{
+	global $user_settings;
+
+	if (empty($user_settings['password_salt']))
+	{
+		return false;
+	}
+
+	if ((strlen($user_settings['password_salt']) > $min) && !$refresh)
+	{
+		return false;
+	}
+
+	$tokenizer = new Token_Hash();
+	$user_settings['password_salt'] = $tokenizer->generate_hash(16);
+	updateMemberData((int) $id, array('password_salt' => $user_settings['password_salt']));
+
+	return true;
+}

--- a/sources/subs/Profile.subs.php
+++ b/sources/subs/Profile.subs.php
@@ -1927,7 +1927,11 @@ function profileReloadUser()
 	if (isset($_POST['passwrd2']) && $_POST['passwrd2'] != '')
 	{
 		require_once(SUBSDIR . '/Auth.subs.php');
-		setLoginCookie(60 * $modSettings['cookieTime'], $context['id_member'], hash('sha256', Util::strtolower($cur_profile['member_name']) . un_htmlspecialchars($_POST['passwrd2']) . $cur_profile['password_salt']));
+		$check = validateLoginPassword($_POST['passwrd2'], $_POST['passwrd1'], $cur_profile['member_name']);
+		if ($check === true)
+		{
+			setLoginCookie(60 * $modSettings['cookieTime'], $context['id_member'], hash('sha256', $_POST['passwrd1'] . $cur_profile['password_salt']));
+		}
 	}
 
 	loadUserSettings();

--- a/sources/subs/Profile.subs.php
+++ b/sources/subs/Profile.subs.php
@@ -11,7 +11,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1.4
+ * @version 1.1.7
  *
  */
 


### PR DESCRIPTION
Had to close and redo this one as a wrong commit was in this original PR (one from another PR) and in fixing that things went bad quickly!

This fixes a couple of minor bugs with setting incorrect cookies when a password is changed. Introduced probably back in 1.0 😭

This also increases the salt length from 4 ~~to 8~~ to 16 which provides a vast increase in probable values. It ~~does not~~ does force it to happen but should not cause a logout but instead update the salt and cookie on the fly.  It will use it for new members and do updates on existing members during logout and password changes.

In 2.0 all of this cookie code should be centralized in a class, for setting/getting/clearing