### PR TITLE
Fixes for read-only source files

### DIFF
--- a/sources/admin/ManageThemes.controller.php
+++ b/sources/admin/ManageThemes.controller.php
@@ -1157,7 +1157,7 @@ class ManageThemes_Controller extends Action_Controller
 		// How are we going to install this theme, from a dir, zip, copy of default?
 		if ((!empty($_FILES['theme_gz']) && (!isset($_FILES['theme_gz']['error']) || $_FILES['theme_gz']['error'] != 4)) || !empty($this->_req->query->theme_gz))
 			$method = 'upload';
-		elseif (isset($this->_req->query->theme_dir) && rtrim(realpath($this->_req->query->theme_dir), '/\\') != realpath(BOARDDIR . '/themes') && file_exists($this->_req->query->theme_dir))
+		elseif (isset($this->_req->post->theme_dir) && rtrim(realpath($this->_req->post->theme_dir), '/\\') != realpath(BOARDDIR . '/themes') && file_exists($this->_req->post->theme_dir))
 			$method = 'path';
 		else
 			$method = 'copy';

--- a/sources/subs/Admin.subs.php
+++ b/sources/subs/Admin.subs.php
@@ -241,7 +241,8 @@ function getFileVersions(&$versionOptions)
 		'file_versions_subs' => SUBSDIR,
 		'file_versions_modules' => SOURCEDIR . '/modules',
 	);
-	readFileVersions($tmp_version_info, $directories, '.php', true);
+	$tmp_version_info = array_combine(array_keys($directories),array_fill(0,count($directories),array()));
+	readFileVersions($tmp_version_info, $directories, '.php', false);
 
 	foreach ($tmp_version_info['file_versions_subs'] as $key => $val)
 	{

--- a/sources/subs/Admin.subs.php
+++ b/sources/subs/Admin.subs.php
@@ -242,7 +242,7 @@ function getFileVersions(&$versionOptions)
 		'file_versions_modules' => SOURCEDIR . '/modules',
 	);
 	$tmp_version_info = array_combine(array_keys($directories),array_fill(0,count($directories),array()));
-	readFileVersions($tmp_version_info, $directories, '.php', false);
+	readFileVersions($tmp_version_info, $directories, '.php', true);
 
 	foreach ($tmp_version_info['file_versions_subs'] as $key => $val)
 	{


### PR DESCRIPTION
When the forum files are read-only:

1. The `index.php?action=admin;area=maintain;sa=routine;activity=version` command crashes because the `$tmp_version_info` variable is not set in the `getFileVersions` function in Admin.subs.

2. A custom theme folder cannot be installed because the ManageThemes controller incorrectly looks for `query` parameters when identifying the `$method = 'path'` mechanism. The submission is actually in a `post` request.

This request solves these two problems.