### PR TITLE
PHP 7.4 updates and "other"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,24 @@
-sudo: required
 language: php
 dist: trusty
+os: linix
 
-matrix:
+jobs:
   include:
-    - php: 5.6
-      env:
-        - DB=mysql-5.6
-        - WEBTESTS=false
-        - COVERAGE=true
     - php: 7.3
       env:
         - DB=mysql-5.6
         - WEBTESTS=false
         - COVERAGE=false
-    - php: 5.6
-      env:
-        - DB=postgres-9.4
-        - WEBTESTS=false
-        - COVERAGE=true
     - php: 7.1
       env:
         - DB=postgres-9.5
         - WEBTESTS=false
-        - COVERAGE=false
+        - COVERAGE=true
     - php: 5.6
       env:
         - DB=mariadb-10.0
         - WEBTESTS=false
-        - COVERAGE=false
+        - COVERAGE=true
       addons:
         mariadb: '10.0'
   fast_finish: true

--- a/Settings.sample.php
+++ b/Settings.sample.php
@@ -13,7 +13,7 @@ $maintenance = 0;
 /**
  * Title for the Maintenance Mode message.
  * @var string
- * @global int $mtitle
+ * @global string $mtitle
  */
 $mtitle = 'Maintenance Mode';
 

--- a/sources/BrowserDetector.class.php
+++ b/sources/BrowserDetector.class.php
@@ -246,7 +246,7 @@ class Browser_Detector
 		// Be you robot or human?
 		if (!isset($this->_browsers['possibly_robot']))
 		{
-			if ($user_info['possibly_robot']) {
+			if (isset($user_info['possibly_robot'])) {
 				// This isn't meant to be reliable, it's just meant to catch most bots to prevent PHPSESSID from showing up.
 				$this->_browsers['possibly_robot'] = !empty($user_info['possibly_robot']);
 

--- a/sources/Load.php
+++ b/sources/Load.php
@@ -291,7 +291,7 @@ function loadUserSettings()
 			$_SESSION['id_msg_last_visit'] = $user_settings['id_msg_last_visit'];
 
 			// If it was *at least* five hours ago...
-			if ($visitOpt['poster_time'] < time() - 5 * 3600)
+			if ($visitOpt === false || $visitOpt['poster_time'] < time() - 5 * 3600)
 			{
 				require_once(SUBSDIR . '/Members.subs.php');
 				updateMemberData($id_member, array('id_msg_last_visit' => (int) $modSettings['maxMsgID'], 'last_login' => time(), 'member_ip' => $req->client_ip(), 'member_ip2' => $req->ban_ip()));

--- a/sources/admin/ManageAttachments.controller.php
+++ b/sources/admin/ManageAttachments.controller.php
@@ -11,7 +11,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1.6
+ * @version 1.1.7
  *
  */
 
@@ -840,8 +840,8 @@ class ManageAttachments_Controller extends Action_Controller
 			'files_without_attachment' => 0,
 		);
 
-		$to_fix = !empty($this->_req->session->attachments_to_fix) ? $this->_req->session->attachments_to_fix : array();
-		$context['repair_errors'] = $this->_req->getSession('attachments_to_fix2', $context['repair_errors']);
+		$to_fix = !empty($_SESSION['attachments_to_fix']) ? $_SESSION['attachments_to_fix'] : array();
+		$context['repair_errors'] = isset($_SESSION['attachments_to_fix2']) ? $_SESSION['attachments_to_fix2'] : $context['repair_errors'];
 		$fix_errors = isset($this->_req->query->fixErrors) ? true : false;
 
 		// Get stranded thumbnails.

--- a/sources/admin/ManageMaillist.controller.php
+++ b/sources/admin/ManageMaillist.controller.php
@@ -8,7 +8,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -477,7 +477,7 @@ class ManageMaillist_Controller extends Action_Controller
 	{
 		global $context, $txt, $modSettings, $scripturl, $mbname;
 
-		if (!isset($this->_req->query->bounce))
+		if (isset($this->_req->query->bounce))
 		{
 			checkSession('get');
 			validateToken('admin-ml', 'get');
@@ -486,11 +486,9 @@ class ManageMaillist_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Mail.subs.php');
 
 		// We should have been sent an email ID
-		if (isset($this->_req->query->item))
+		$id = $this->_req->get('item', 'intval');
+		if (!empty($id))
 		{
-			// Needs to be an int!
-			$id = (int) $this->_req->query->item;
-
 			// Load up the email details, no funny biz yall ;)
 			$temp_email = list_maillist_unapproved($id);
 
@@ -534,7 +532,7 @@ class ManageMaillist_Controller extends Action_Controller
 			$context['settings_message'] = $txt['badid'];
 
 		// Check if they are sending the notice
-		if (isset($this->_req->query->bounce) && isset($temp_email))
+		if (isset($this->_req->post->bounce) && isset($temp_email))
 		{
 			checkSession('post');
 			validateToken('admin-ml');
@@ -553,6 +551,8 @@ class ManageMaillist_Controller extends Action_Controller
 				else
 				{
 					// Time for someone to get a we're so sorry message!
+					$mark_down = new Html_2_Md($body);
+					$body = $mark_down->get_markdown();
 					sendmail($to, $subject, $body, null, null, false, 5);
 					redirectexit('action=admin;area=maillist;bounced');
 				}

--- a/sources/admin/ManageMaillist.controller.php
+++ b/sources/admin/ManageMaillist.controller.php
@@ -345,9 +345,9 @@ class ManageMaillist_Controller extends Action_Controller
 
 		// Prep and show the template with what we found
 		$context['body'] = $parser->parseEmail($text);
-		$context['to'] = $txt['to'] . ' ' . (isset($email_to) ? $email_to : '');
-		$context['notice_subject'] = isset($temp_email[0]['subject']) ? $txt['subject'] . ': ' . $temp_email[0]['subject'] : '';
-		$context['notice_from'] = isset($temp_email[0]['from']) ? $txt['from'] . ': ' . $temp_email[0]['from'] : '';
+		$context['to'] = isset($email_to) ? $email_to : '';
+		$context['notice_subject'] = isset($temp_email[0]['subject']) ? $temp_email[0]['subject'] : '';
+		$context['notice_from'] = isset($temp_email[0]['from']) ? $temp_email[0]['from'] : '';
 		$context['page_title'] = $txt['show_notice'];
 		$context['error_code'] = isset($temp_email[0]['error_code']) && isset($txt[$temp_email[0]['error_code']]) ? $txt[$temp_email[0]['error_code']] : '';
 		$context['sub_template'] = 'show_email';

--- a/sources/controllers/Emailpost.controller.php
+++ b/sources/controllers/Emailpost.controller.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -465,6 +465,12 @@ function pbe_create_post($pbe, $email_message, $topic_info)
 	// Make the post.
 	createPost($msgOptions, $topicOptions, $posterOptions);
 
+	// Bind any attachments that may be included to this new message
+	if (!empty($attachIDs) && !empty($msgOptions['id']))
+	{
+		bindMessageAttachments($msgOptions['id'], $attachIDs);
+	}
+
 	// We need the auto_notify setting, it may be theme based so pass the theme in use
 	$theme_settings = query_get_theme($pbe['profile']['id_member'], $pbe['profile']['id_theme'], $topic_info);
 	$auto_notify = isset($theme_settings['auto_notify']) ? $theme_settings['auto_notify'] : 0;
@@ -634,6 +640,12 @@ function pbe_create_topic($pbe, $email_message, $board_info)
 
 	// Attempt to make the new topic.
 	createPost($msgOptions, $topicOptions, $posterOptions);
+
+	// Bind any attachments that may be included to this new topic
+	if (!empty($attachIDs) && !empty($msgOptions['id']))
+	{
+		bindMessageAttachments($msgOptions['id'], $attachIDs);
+	}
 
 	// The auto_notify setting
 	$theme_settings = query_get_theme($pbe['profile']['id_member'], $pbe['profile']['id_theme'], $board_info);

--- a/sources/controllers/ProfileInfo.controller.php
+++ b/sources/controllers/ProfileInfo.controller.php
@@ -12,7 +12,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -44,7 +44,7 @@ class ProfileInfo_Controller extends Action_Controller
 	 */
 	public function pre_dispatch()
 	{
-		global $context, $user_info;
+		global $memberContext, $context, $user_info;
 
 		require_once(SUBSDIR . '/Profile.subs.php');
 
@@ -54,6 +54,10 @@ class ProfileInfo_Controller extends Action_Controller
 			$context['user']['is_owner'] = (int) $this->_memID === (int) $user_info['id'];
 
 		loadLanguage('Profile');
+
+		// Attempt to load the member's profile data.
+		if (!loadMemberContext($this->_memID) || !isset($memberContext[$this->_memID]))
+			throw new Elk_Exception('not_a_user', false);
 	}
 
 	/**
@@ -93,11 +97,7 @@ class ProfileInfo_Controller extends Action_Controller
 	 */
 	public function action_summary()
 	{
-		global $context, $memberContext, $modSettings, $scripturl;
-
-		// Attempt to load the member's profile data.
-		if (!loadMemberContext($this->_memID) || !isset($memberContext[$this->_memID]))
-			throw new Elk_Exception('not_a_user', false);
+		global $context, $modSettings, $scripturl;
 
 		loadTemplate('ProfileInfo');
 

--- a/sources/controllers/Spellcheck.controller.php
+++ b/sources/controllers/Spellcheck.controller.php
@@ -11,7 +11,7 @@
  * copyright:    2011 Simple Machines (http://www.simplemachines.org)
  * license:        BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -23,7 +23,7 @@
 class Spellcheck_Controller extends Action_Controller
 {
 	/**
-	 * Known words that pspell will not now
+	 * Known words that pspell will not know
 	 *
 	 * @var array
 	 */
@@ -73,16 +73,17 @@ class Spellcheck_Controller extends Action_Controller
 		ob_start();
 		$old = error_reporting(0);
 
-		// See, first, some windows machines don't load pspell properly on the first try.  Dumb, but this is a workaround.
-		pspell_new('en');
-
 		// Next, the dictionary in question may not exist. So, we try it... but...
-		$this->pspell_link = pspell_new($txt['lang_dictionary'], $txt['lang_spelling'], '', 'utf-8', PSPELL_FAST | PSPELL_RUN_TOGETHER);
+		$this->pspell_link = pspell_new($txt['lang_locale'], $txt['lang_spelling'], null, 'utf-8', PSPELL_FAST);
+		if (!$this->pspell_link)
+		{
+			$this->pspell_link = pspell_new($txt['lang_dictionary'], $txt['lang_spelling'], null, 'utf-8', PSPELL_FAST);
+		}
 
 		// Most people don't have anything but English installed... So we use English as a last resort.
 		if (!$this->pspell_link)
 		{
-			$this->pspell_link = pspell_new('en', '', '', '', PSPELL_FAST | PSPELL_RUN_TOGETHER);
+			$this->pspell_link = pspell_new('en');
 		}
 
 		// Reset error reporting to what it was
@@ -92,7 +93,7 @@ class Spellcheck_Controller extends Action_Controller
 		// Nothing to check or nothing to check with
 		if (!isset($this->_req->post->spellstring) || !$this->pspell_link)
 		{
-			die;
+			die ('pspell initializing failure');
 		}
 
 		// Get all the words (Javascript already separated them).

--- a/sources/controllers/Xml.controller.php
+++ b/sources/controllers/Xml.controller.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -280,10 +280,10 @@ class Xml_Controller extends Action_Controller
 		// Failed validation, tough to be you
 		else
 		{
-			if (!empty($validation_session))
-				$errors[] = array('value' => $txt[$validation_session]);
+			if ($validation_session !== true)
+				$errors[] = array('value' => $txt['session_verify_fail']);
 
-			if (empty($validation_token))
+			if ($validation_token === false)
 				$errors[] = array('value' => $txt['token_verify_fail']);
 		}
 
@@ -444,10 +444,10 @@ class Xml_Controller extends Action_Controller
 		// Failed validation, extra work for you I'm afraid
 		else
 		{
-			if (!empty($validation_session))
-				$errors[] = array('value' => $txt[$validation_session]);
+			if ($validation_session !== true)
+				$errors[] = array('value' => $txt['session_verify_fail']);
 
-			if (empty($validation_token))
+			if ($validation_token === false)
 				$errors[] = array('value' => $txt['token_verify_fail']);
 		}
 
@@ -604,10 +604,10 @@ class Xml_Controller extends Action_Controller
 		// Failed validation :'(
 		else
 		{
-			if (!empty($validation_session))
-				$errors[] = array('value' => $txt[$validation_session]);
+			if ($validation_session !== true)
+				$errors[] = array('value' => $txt['session_verify_fail']);
 
-			if (empty($validation_token))
+			if ($validation_token === false)
 				$errors[] = array('value' => $txt['token_verify_fail']);
 		}
 
@@ -694,10 +694,10 @@ class Xml_Controller extends Action_Controller
 		// Failed validation, tough to be you
 		else
 		{
-			if (!empty($validation_session))
-				$errors[] = array('value' => $txt[$validation_session]);
+			if ($validation_session !== true)
+				$errors[] = array('value' => $txt['session_verify_fail']);
 
-			if (empty($validation_token))
+			if ($validation_token === false)
 				$errors[] = array('value' => $txt['token_verify_fail']);
 		}
 
@@ -788,10 +788,10 @@ class Xml_Controller extends Action_Controller
 		// Failed validation, tough to be you
 		else
 		{
-			if (!empty($validation_session))
-				$errors[] = array('value' => $txt[$validation_session]);
+			if ($validation_session !== true)
+				$errors[] = array('value' => $txt['session_verify_fail']);
 
-			if (empty($validation_token))
+			if ($validation_token === false)
 				$errors[] = array('value' => $txt['token_verify_fail']);
 		}
 

--- a/sources/subs/Attachments.subs.php
+++ b/sources/subs/Attachments.subs.php
@@ -767,7 +767,7 @@ function attachmentChecks($attachID)
 			// Success! However, successes usually come for a price:
 			// we might get a new format for our image...
 			$old_format = $size[2];
-			$size = elk_getimagesize($attachmentOptions['tmp_name']);
+			$size = elk_getimagesize($_SESSION['temp_attachments'][$attachID]['tmp_name']);
 
 			if (!(empty($size)) && ($size[2] !== $old_format))
 			{

--- a/sources/subs/BBC/BBCParser.php
+++ b/sources/subs/BBC/BBCParser.php
@@ -410,7 +410,7 @@ class BBCParser
 			$this->pos2 = $this->pos - 1;
 
 			// See the comment at the end of the big loop - just eating whitespace ;).
-			if (isset($tag[Codes::ATTR_BLOCK_LEVEL]) && isset($this->message[$this->pos]) && substr_compare($this->message, '<br />', $this->pos, 6) === 0)
+			if (!empty($tag[Codes::ATTR_BLOCK_LEVEL]) && isset($this->message[$this->pos]) && substr_compare($this->message, '<br />', $this->pos, 6) === 0)
 			{
 				$this->message = substr_replace($this->message, '', $this->pos, 6);
 			}

--- a/sources/subs/BBC/BBCParser.php
+++ b/sources/subs/BBC/BBCParser.php
@@ -10,7 +10,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -337,7 +337,7 @@ class BBCParser
 				break;
 			}
 
-			if ($tag[Codes::ATTR_BLOCK_LEVEL])
+			if (!empty($tag[Codes::ATTR_BLOCK_LEVEL]))
 			{
 				// Only find out if we need to.
 				if ($block_level === false)
@@ -368,7 +368,7 @@ class BBCParser
 			}
 
 			$to_close[] = $tag;
-		} while ($tag[Codes::ATTR_TAG] !== $look_for);
+		} while (isset($tag[Codes::ATTR_TAG]) && $tag[Codes::ATTR_TAG] !== $look_for);
 
 		// Did we just eat through everything and not find it?
 		if (!$this->hasOpenTags() && (empty($tag) || $tag[Codes::ATTR_TAG] !== $look_for))
@@ -376,7 +376,7 @@ class BBCParser
 			$this->open_tags = $to_close;
 			return;
 		}
-		elseif (!empty($to_close) && $tag[Codes::ATTR_TAG] !== $look_for)
+		elseif (!empty($to_close) && isset($tag[Codes::ATTR_TAG]) && $tag[Codes::ATTR_TAG] !== $look_for)
 		{
 			if ($block_level === null && isset($look_for[0], $this->bbc_codes[$look_for[0]]))
 			{
@@ -410,7 +410,7 @@ class BBCParser
 			$this->pos2 = $this->pos - 1;
 
 			// See the comment at the end of the big loop - just eating whitespace ;).
-			if ($tag[Codes::ATTR_BLOCK_LEVEL] && isset($this->message[$this->pos]) && substr_compare($this->message, '<br />', $this->pos, 6) === 0)
+			if (isset($tag[Codes::ATTR_BLOCK_LEVEL]) && isset($this->message[$this->pos]) && substr_compare($this->message, '<br />', $this->pos, 6) === 0)
 			{
 				$this->message = substr_replace($this->message, '', $this->pos, 6);
 			}
@@ -488,7 +488,7 @@ class BBCParser
 		{
 			foreach ($this->getOpenedTags() as $open_tag)
 			{
-				if (!$open_tag[Codes::ATTR_AUTOLINK])
+				if (empty($open_tag[Codes::ATTR_AUTOLINK]))
 				{
 					return $data;
 				}
@@ -574,7 +574,7 @@ class BBCParser
 		}
 
 		// If its a footnote, keep track of the number
-		if ($tag[Codes::ATTR_TAG] === 'footnote')
+		if (isset($tag[Codes::ATTR_TAG]) && $tag[Codes::ATTR_TAG] === 'footnote')
 		{
 			$this->num_footnotes++;
 		}
@@ -594,7 +594,7 @@ class BBCParser
 		foreach ($this->open_tags as $open_quote)
 		{
 			// Every parent quote this quote has flips the styling
-			if ($open_quote[Codes::ATTR_TAG] === 'quote')
+			if (isset($open_quote[Codes::ATTR_TAG]) && $open_quote[Codes::ATTR_TAG] === 'quote')
 			{
 				$quote_alt = !$quote_alt;
 			}
@@ -736,7 +736,7 @@ class BBCParser
 		$tag = $this->item_codes[$this->message[$this->pos + 1]];
 
 		// First let's set up the tree: it needs to be in a list, or after an li.
-		if ($this->inside_tag === null || ($this->inside_tag[Codes::ATTR_TAG] !== 'list' && $this->inside_tag[Codes::ATTR_TAG] !== 'li'))
+		if ($this->inside_tag === null || (isset($this->inside_tag[Codes::ATTR_TAG]) && $this->inside_tag[Codes::ATTR_TAG] !== 'list' && $this->inside_tag[Codes::ATTR_TAG] !== 'li'))
 		{
 			$this->addOpenTag(array(
 				Codes::ATTR_TAG => 'list',
@@ -751,7 +751,7 @@ class BBCParser
 			$code = '<ul' . ($tag === '' ? '' : ' style="list-style-type: ' . $tag . '"') . ' class="bbc_list">';
 		}
 		// We're in a list item already: another itemcode?  Close it first.
-		elseif ($this->inside_tag[Codes::ATTR_TAG] === 'li')
+		elseif (isset($this->inside_tag[Codes::ATTR_TAG]) && $this->inside_tag[Codes::ATTR_TAG] === 'li')
 		{
 			$this->closeOpenedTag();
 			$code = '</li>';
@@ -1640,7 +1640,9 @@ class BBCParser
 		// Close all the non block level tags so this tag isn't surrounded by them.
 		for ($i = count($this->open_tags) - 1; $i > $n; $i--)
 		{
-			$tmp = $this->noSmileys($this->open_tags[$i][Codes::ATTR_AFTER]);
+			$tmp = isset($this->open_tags[$i][Codes::ATTR_AFTER])
+				? $this->noSmileys($this->open_tags[$i][Codes::ATTR_AFTER])
+				: $this->noSmileys('');
 			$this->message = substr_replace($this->message, $tmp, $this->pos, 0);
 			$ot_strlen = strlen($tmp);
 			$this->pos += $ot_strlen;

--- a/sources/subs/BBC/BBCParser.php
+++ b/sources/subs/BBC/BBCParser.php
@@ -1527,7 +1527,7 @@ class BBCParser
 	{
 		if (preg_match('~(<br />|&nbsp;|\s)*~', $this->message, $matches, null, $offset) !== 0 && isset($matches[0]) && $matches[0] !== '')
 		{
-			$this->message = substr_replace($this->message, '', $this->pos, strlen($matches[0]));
+			$this->message = substr_replace($this->message, '', $offset, strlen($matches[0]));
 		}
 	}
 

--- a/sources/subs/BBC/Codes.php
+++ b/sources/subs/BBC/Codes.php
@@ -10,7 +10,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1.6
+ * @version 1.1.7
  *
  */
 
@@ -783,7 +783,7 @@ class Codes
 				self::ATTR_TYPE => self::TYPE_PARSED_CONTENT,
 				self::ATTR_BEFORE => '<div class="bbc_table_container"><table class="bbc_table">',
 				self::ATTR_AFTER => '</table></div>',
-				self::ATTR_TRIM => self::TRIM_INSIDE,
+				self::ATTR_TRIM => self::TRIM_BOTH,
 				self::ATTR_REQUIRE_CHILDREN => array(
 					'tr' => 1,
 				),

--- a/sources/subs/Drafts.subs.php
+++ b/sources/subs/Drafts.subs.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -30,6 +30,7 @@ function create_pm_draft($draft, $recipientList)
 		'subject' => 'string-255',
 		'body' => 'string-65534',
 		'to_list' => 'string-255',
+		'is_usersaved' => 'int',
 	);
 	$draft_parameters = array(
 		$draft['reply_id'],
@@ -39,6 +40,7 @@ function create_pm_draft($draft, $recipientList)
 		$draft['subject'],
 		$draft['body'],
 		serialize($recipientList),
+		$draft['is_usersaved'],
 	);
 	$db->insert('',
 		'{db_prefix}user_drafts',
@@ -71,7 +73,8 @@ function modify_pm_draft($draft, $recipientList)
 			poster_time = {int:poster_time},
 			subject = {string:subject},
 			body = {string:body},
-			to_list = {string:to_list}
+			to_list = {string:to_list},
+			is_usersaved = {int:is_usersaved}
 		WHERE id_draft = {int:id_pm_draft}
 		LIMIT 1',
 		array(
@@ -82,6 +85,7 @@ function modify_pm_draft($draft, $recipientList)
 			'body' => $draft['body'],
 			'id_pm_draft' => $draft['id_pm_draft'],
 			'to_list' => serialize($recipientList),
+			'is_usersaved' => $draft['is_usersaved'],
 		)
 	);
 }
@@ -455,7 +459,7 @@ function saveDraft($draft, $check_last_save = false)
 	if (!isset($draft['is_usersaved']))
 		$draft['is_usersaved'] = 0;
 
-	if ($draft_info['is_usersaved'] == 1)
+	if (isset($draft_info['is_usersaved']) && $draft_info['is_usersaved'] == 1)
 		$draft['is_usersaved'] = 1;
 
 	// Modifying an existing draft, like hitting the save draft button or autosave enabled?
@@ -481,8 +485,6 @@ function saveDraft($draft, $check_last_save = false)
 		else
 			$post_errors->addError('draft_not_saved');
 	}
-
-	return;
 }
 
 /**
@@ -534,7 +536,7 @@ function savePMDraft($recipientList, $draft, $check_last_save = false)
 	if (!isset($draft['is_usersaved']))
 		$draft['is_usersaved'] = 0;
 
-	if ($draft_info['is_usersaved'] == 1)
+	if (isset($draft_info['is_usersaved']) && $draft_info['is_usersaved'] == 1)
 		$draft['is_usersaved'] = 1;
 
 	// Modifying an existing PM draft?

--- a/sources/subs/EmailFormat.class.php
+++ b/sources/subs/EmailFormat.class.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1.4
+ * @version 1.1.7
  *
  */
 
@@ -363,7 +363,7 @@ class Email_Format
 		$this->_body = strtr($this->_body, array("\xe2\x80\x98" => "'", "\xe2\x80\x99" => "'", "\xe2\x80\x9c" => '"', "\xe2\x80\x9d" => '"', "\xe2\x80\x93" => '-', "\xe2\x80\x94" => '--', "\xe2\x80\xa6" => '...'));
 
 		// And its 1252 variants
-		if ($charset !== 'UTF-8')
+		if (strcasecmp($charset, 'UTF-8') !== 0)
 			$this->_body = strtr($this->_body, array(chr(145) => "'", chr(146) => "'", chr(147) => '"', chr(148) => '"', chr(150) => '-', chr(151) => '--', chr(133) => '...'));
 	}
 

--- a/sources/subs/EmailFormat.class.php
+++ b/sources/subs/EmailFormat.class.php
@@ -455,7 +455,11 @@ class Email_Format
 		// Starting a list like a) 1. 1) etc ...
 		$temp = $this->_in_plainlist;
 
-		if (preg_match('~^[a-j](\.|\)|-)\s~i', $var) || preg_match('~^[1-9](\.|\)|-)\s?~', $var) || preg_match('~' . chr(187) . '~', $var))
+		if (preg_match('~^[a-j](\.|\)|-)\s~i', $var)
+			|| preg_match('~^[1-9](\.|\)|-)\s?~', $var)
+			|| preg_match('~' . chr(187) . '~', $var)
+			|| preg_match('~^[ \t]?\* ?~', $var)
+		)
 			$this->_in_plainlist++;
 
 		return $this->_in_plainlist !== $temp;

--- a/sources/subs/EmailParse.class.php
+++ b/sources/subs/EmailParse.class.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -323,12 +323,6 @@ class Email_Parse
 	{
 		$this->_header_block = '';
 		$match = array();
-
-		// Do we even start with a header in this boundary section?
-		if (!preg_match('~^[\w-]+:[ ].*?\r?\n~i', $this->raw_message))
-		{
-			return;
-		}
 
 		// The header block ends based on condition (1) or (2)
 		if (!preg_match('~^(.*?)\r?\n(?:\r?\n|(?!(\t|[\w-]+:|[ ])))(.*)~s', $this->raw_message, $match))
@@ -748,8 +742,8 @@ class Email_Parse
 		{
 			$part = trim($part);
 
-			// Nothing?
-			if (empty($part))
+			// Nothing or epilogue section?
+			if (empty($part) || (strcmp($part, '--') == 0))
 			{
 				continue;
 			}

--- a/sources/subs/Emailpost.subs.php
+++ b/sources/subs/Emailpost.subs.php
@@ -828,7 +828,7 @@ function pbe_email_attachments($pbe, $email_message)
 
 		// Load the attachmentOptions array with the data needed to create an attachment
 		$attachmentOptions = array(
-			'post' => !empty($email_message->message_id) ? $email_message->message_id : 0,
+			'post' => 0,
 			'poster' => $pbe['profile']['id_member'],
 			'name' => $attachment['name'],
 			'tmp_name' => $attachment['tmp_name'],

--- a/sources/subs/Graphics.subs.php
+++ b/sources/subs/Graphics.subs.php
@@ -77,7 +77,7 @@ function createThumbnail($source, $max_width, $max_height)
  */
 function reencodeImage($fileName, $preferred_format = 0)
 {
-	if (!resizeImageFile($fileName, $fileName . '.tmp', null, null, $preferred_format))
+	if (!resizeImageFile($fileName, $fileName . '.tmp', null, null, $preferred_format, true))
 	{
 		if (file_exists($fileName . '.tmp'))
 			unlink($fileName . '.tmp');
@@ -235,8 +235,8 @@ function imageMemoryCheck($sizes)
  * @param int $max_width The maximum allowed width
  * @param int $max_height The maximum allowed height
  * @param int $preferred_format Used by Imagick/resizeImage
- * @param bool $force_resize Always resize the image (force scale up)
  * @param bool $strip Allow IM to remove exif data as GD always will
+ * @param bool $force_resize Always resize the image (force scale up)
  *
  * @return boolean Whether the thumbnail creation was successful.
  */

--- a/sources/subs/Html2BBC.class.php
+++ b/sources/subs/Html2BBC.class.php
@@ -190,7 +190,12 @@ class Html_2_BBC
 		for ($i = 0, $n = count($parts); $i < $n; $i++)
 		{
 			if ($i % 4 == 0)
-				$parts[$i] = strip_tags($parts[$i]);
+			{
+				// protect << symbols from being stripped
+				$working = str_replace('<<', "[\xC2\xA0]", $parts[$i]);
+				$working = strip_tags($working);
+				$parts[$i] = str_replace("[\xC2\xA0]", '<<', $working);
+			}
 		}
 		$bbc = implode('', $parts);
 

--- a/sources/subs/Html2BBC.class.php
+++ b/sources/subs/Html2BBC.class.php
@@ -187,17 +187,20 @@ class Html_2_BBC
 
 		// Remove any html tags we left behind ( outside of code tags that is )
 		$parts = preg_split('~(\[/code\]|\[code(?:=[^\]]+)?\])~i', $bbc, -1, PREG_SPLIT_DELIM_CAPTURE);
-		for ($i = 0, $n = count($parts); $i < $n; $i++)
+		if ($parts !== false)
 		{
-			if ($i % 4 == 0)
+			for ($i = 0, $n = count($parts); $i < $n; $i++)
 			{
-				// protect << symbols from being stripped
-				$working = str_replace('<<', "[\xC2\xA0]", $parts[$i]);
-				$working = strip_tags($working);
-				$parts[$i] = str_replace("[\xC2\xA0]", '<<', $working);
+				if ($i % 4 == 0)
+				{
+					// protect << symbols from being stripped
+					$working = str_replace('<<', "[\xC2\xA0]", $parts[$i]);
+					$working = strip_tags($working);
+					$parts[$i] = str_replace("[\xC2\xA0]", '<<', $working);
+				}
 			}
+			$bbc = implode('', $parts);
 		}
-		$bbc = implode('', $parts);
 
 		return $bbc;
 	}

--- a/sources/subs/Html2Md.class.php
+++ b/sources/subs/Html2Md.class.php
@@ -7,7 +7,7 @@
  * @copyright ElkArte Forum contributors
  * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
- * @version 1.1.6
+ * @version 1.1.7
  *
  */
 
@@ -563,7 +563,9 @@ class Html_2_Md
 	{
 		global $txt;
 
-		$href = htmlentities($node->getAttribute('href'), ENT_COMPAT, 'UTF-8', false);
+		$href = htmlspecialchars_decode($node->getAttribute('href'));
+		$href = strtr($href, array('(' => '%28', ')' => '%29', '[' => '%5B', ']' => '%5D', '&' => '%26a'));
+
 		$title = $node->getAttribute('title');
 		$class = $node->getAttribute('class');
 		$value = $this->_get_value($node);
@@ -585,7 +587,9 @@ class Html_2_Md
 		}
 		else
 		{
-			$markdown = '[' . $value . '](' . $href . ')';
+			// This will trigger a base64 version in our outbound email
+			$link = "\xF0\x9F\x94\x97";
+			$markdown = '[' . $value . '](' . $href . ' ' . $link . ')';
 		}
 
 		// Some links can be very long and if we wrap them they break

--- a/sources/subs/Notification.subs.php
+++ b/sources/subs/Notification.subs.php
@@ -1037,8 +1037,8 @@ function getNotifierToken($memID, $memEmail, $memSalt, $area, $extra)
 	if (empty($modSettings['unsubscribe_site_salt']))
 	{
 		// extra 10 digits of salt
-		$modSettings['unsubscribe_site_salt'] = $tokenizer->generate_hash();
-		updateSettings(array('unsubscribe_site_salt' => $modSettings['unsubscribe_site_salt']));
+		$unsubscribe_site_salt = $tokenizer->generate_hash();
+		updateSettings(array('unsubscribe_site_salt' => $unsubscribe_site_salt));
 	}
 
 	// Add member salt + site salt to the otherwise deterministic data

--- a/sources/subs/RepairBoards.subs.php
+++ b/sources/subs/RepairBoards.subs.php
@@ -353,6 +353,7 @@ function loadForumTests()
 				$memberStartedID = getMsgMemberID($row['myid_first_msg']);
 				$memberUpdatedID = getMsgMemberID($row['myid_last_msg']);
 
+				require_once(SUBSDIR . '/Topic.subs.php');
 				setTopicAttribute($row['id_topic'], array(
 					'id_first_msg' => $row['myid_first_msg'],
 					'id_member_started' => $memberStartedID,

--- a/sources/subs/Unread.class.php
+++ b/sources/subs/Unread.class.php
@@ -244,9 +244,8 @@ class Unread
 				LEFT JOIN {db_prefix}boards AS b ON (b.id_board = t.id_board)' : '
 				LEFT JOIN {db_prefix}boards AS b ON (b.id_board = ms.id_board)') . '
 				LEFT JOIN {db_prefix}members AS mems ON (mems.id_member = ms.id_member)
-				LEFT JOIN {db_prefix}members AS meml ON (meml.id_member = ml.id_member)' . ($this->_have_temp_table ? '
-				LEFT JOIN {db_prefix}log_topics_unread AS lt ON (lt.id_topic = t.id_topic)' : '
-				LEFT JOIN {db_prefix}log_topics AS lt ON (lt.id_topic = t.id_topic AND lt.id_member = {int:current_member})') . (!empty($custom_joins) ? implode("\n\t\t\t\t", $custom_joins) : '') . '
+				LEFT JOIN {db_prefix}members AS meml ON (meml.id_member = ml.id_member)
+				LEFT JOIN {db_prefix}log_topics AS lt ON (lt.id_topic = t.id_topic AND lt.id_member = {int:current_member})' . (!empty($custom_joins) ? implode("\n\t\t\t\t", $custom_joins) : '') . '
 				LEFT JOIN {db_prefix}log_mark_read AS lmr ON (lmr.id_board = t.id_board AND lmr.id_member = {int:current_member})
 			WHERE t.id_board IN ({array_int:boards})
 				AND t.id_last_msg >= {int:min_message}

--- a/sources/subs/VerificationControls.class.php
+++ b/sources/subs/VerificationControls.class.php
@@ -12,7 +12,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1.6
+ * @version 1.1.7
  *
  */
 
@@ -831,7 +831,7 @@ class Verification_Controls_Questions implements Verification_Controls
 			FROM {db_prefix}antispam_questions' . ($filter === null || !isset($available_filters[$filter['type']]) ? '' : '
 			WHERE ' . $available_filters[$filter['type']]),
 			array(
-				'current_filter' => $filter['value'],
+				'current_filter' => $filter === null ? '' : $filter['value'],
 			)
 		);
 		while ($row = $db->fetch_assoc($request))

--- a/tests/sources/subs/HTML2Md.class.Basic.php
+++ b/tests/sources/subs/HTML2Md.class.Basic.php
@@ -31,7 +31,7 @@ class TestHTML2Md extends PHPUnit_Framework_TestCase
 			array(
 				'Named links',
 				'<a href="http://www.elkarte.net/" class="bbc_link" target="_blank">ElkArte</a>',
-				'[ElkArte](http://www.elkarte.net/)',
+				'[ElkArte](http://www.elkarte.net/ 🔗)',
 			),
 			array(
 				'URL link',

--- a/tests/sources/subs/HTML2Md.class.Basic.php
+++ b/tests/sources/subs/HTML2Md.class.Basic.php
@@ -36,7 +36,7 @@ class TestHTML2Md extends PHPUnit_Framework_TestCase
 			array(
 				'URL link',
 				'<a href="http://www.elkarte.net/" class="bbc_link" target="_blank">http://www.elkarte.net/</a>',
-				'[Link](http://www.elkarte.net/)',
+				'[Link](http://www.elkarte.net/ 🔗)',
 			),
 			array(
 				'Lists',
@@ -74,7 +74,7 @@ password, you can reset it by visiting
 [Link](https://www.awesomeforum.com/?action=reminder)
 Before you can login, you first need to activate your account. To do so, please follow this
 link:
-[Reg Link](https://www.awesomeforum.com/?action=register;sa=activate;u=12345;code=S5cv#4Xh)
+[Reg Link](https://www.awesomeforum.com/?action=register;sa=activate;u=12345;code=S5cv#4Xh 🔗)
 Should you have any problems with activation, please visit
 [Link](https://www.awesomeforum.com/?action=register;sa=activate;u=12345) use the code
 "S5cv#4Xh".

--- a/tests/travis-ci/setup-server.sh
+++ b/tests/travis-ci/setup-server.sh
@@ -68,14 +68,7 @@ fi
 # Setup cache engines for elkarte cache testing
 if [ "$COVERAGE" == "true" ]
 then
-    if [ "$SHORT_PHP" == "5.3" -o "$SHORT_PHP" == "5.4" ]
-    then
-        sudo apt-get -qq --allow-downgrades install php5-xcache php5-apcu
-        printf "extension=xcache.so\nxcache.size=64M\nxcache.var_size=16M\nxcache.test=On" > xcache.ini
-        phpenv config-add xcache.ini
-        printf "extension=apc.so\napc.enabled=1" > 5.3.ini
-        phpenv config-add 5.3.ini
-    elif [ "$SHORT_PHP" == "7.0" -o "$SHORT_PHP" == "7.1" ]
+    if [ "$SHORT_PHP" == "7.0" -o "$SHORT_PHP" == "7.1" ]
     then
         printf "\n"| pecl install -f apcu
     else
@@ -83,8 +76,8 @@ then
         printf "\n"| pecl install -f channel://pecl.php.net/APCu-4.0.10
 
         # Build Xcache
-        wget http://xcache.lighttpd.net/pub/Releases/3.2.0/xcache-3.2.0.tar.gz
-        tar xf xcache-3.2.0.tar.gz
+        wget https://github.com/xuefer/xcache/archive/3.2.0.tar.gz
+        tar xf 3.2.0.tar.gz
         cd xcache-3.2.0
         phpize
         ./configure
@@ -92,7 +85,7 @@ then
         make --quiet install
         cd ../
         rm -r xcache-3.2.0
-        rm xcache-3.2.0.tar.gz
+        rm 3.2.0.tar.gz
         printf "extension=xcache.so\nxcache.size=64M\nxcache.var_size=16M\nxcache.test=On" > xcache.ini
         phpenv config-add xcache.ini
     fi

--- a/themes/default/Maillist.template.php
+++ b/themes/default/Maillist.template.php
@@ -20,10 +20,14 @@ function template_show_email()
 
 	echo '
 		<h2 class="category_header">', $txt['show_notice'], '</h2>
-		<h2 class="category_header">', $context['notice_subject'], '</h2>
-		<h2 class="category_header">', $context['notice_from'], '</h2>
-		<h2 class="category_header">', $context['to'], '</h2>
-		<div class="warningbox">', $txt['email_failure'], ': ', $context['error_code'], '</div>
+		<div class="content">
+			<ul>
+				<li><strong>' . $txt['subject'] . ': </strong>', $context['notice_subject'], '</li>
+				<li><strong>' . $txt['from'] . ': </strong>', $context['notice_from'], '</li>
+				<li><strong>' . $txt['to'] . ': </strong>', $context['to'], '</li>
+			</ul>
+			<p class="warningbox">', $txt['email_failure'], ': ', $context['error_code'], '</p>
+		</div>
 		<div class="content">
 			<dl>
 				<dt>

--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -931,6 +931,7 @@ a.bbc_link {
 #quick_edit_body_container .editor {
 	width: 100%;
 	margin-bottom: 10px;
+	padding: 2px;
 }
 #quick_edit_body_container .input_text {
 	width: 85%;


### PR DESCRIPTION
This fixes any 7.4 errors that I have encountered, could be more but this is a start.  Some of the 7.4 issues were in fact minor real errors so those were fixed as well

Noticed a bug in the re-encode image function when using imagik, it was not stripping the exif headers and that is where mischievous code could exist, so it was 100% ineffective.

Fixed a few errors reported on the site or in the issues log

Made updates to PBE based on reported errors as well as things found while giving it a good thrashing.   There were some new email content types to deal with and the plain text email link issues.  That fix was a bit eh? but it does what is needed.

Make updates to the build environment which was failing (mostly due to xcache) but also reduced the number of environments.  I'm not sure what is going on with Travis but things sit in the queue for hours and then would only run 4 concurrent jobs, so a 5 job run could take 4 hours to complete, so much for CI ... not sure if this is just the .org to .com change or due to other reasons.



