### PR TITLE
Address more of #3225

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -167,7 +167,13 @@ class Bootstrap
 					$redirec_file = 'install.php';
 				}
 
-				header('Location: http' . (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) === 'on' ? 's' : '') . '://' . (empty($_SERVER['HTTP_HOST']) ? $_SERVER['SERVER_NAME'] . (empty($_SERVER['SERVER_PORT']) || $_SERVER['SERVER_PORT'] === '80' ? '' : ':' . $_SERVER['SERVER_PORT']) : $_SERVER['HTTP_HOST']) . (strtr(dirname($_SERVER['PHP_SELF']), '\\', '/') == '/' ? '' : strtr(dirname($_SERVER['PHP_SELF']), '\\', '/')) . '/install/' . $redirec_file);
+				$version_running = str_replace('ElkArte ', '', FORUM_VERSION);
+				$proto = 'http' . (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) === 'on' ? 's' : '');
+				$port = empty($_SERVER['SERVER_PORT']) || $_SERVER['SERVER_PORT'] === '80' ? '' : ':' . $_SERVER['SERVER_PORT'];
+				$host = empty($_SERVER['HTTP_HOST']) ? $_SERVER['SERVER_NAME'] . $port : $_SERVER['HTTP_HOST'];
+				$path = strtr(dirname($_SERVER['PHP_SELF']), '\\', '/') == '/' ? '' : strtr(dirname($_SERVER['PHP_SELF']), '\\', '/');
+
+				header('Location:' . $proto . '://' . $host . $path . '/install/' . $redirec_file . '?v=' . $version_running);
 				die();
 			}
 		}

--- a/install/TemplateUpgrade.php
+++ b/install/TemplateUpgrade.php
@@ -9,7 +9,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1
+ * @version 1.1.7
  *
  */
 
@@ -372,13 +372,23 @@ function template_xml_below()
  */
 function template_error_message()
 {
-	global $upcontext;
+	global $upcontext, $txt;
 
 	echo '
 	<div class="errorbox">
-		', $upcontext['error_msg'], '
-		<br />
-		<a href="', $_SERVER['PHP_SELF'], '">Click here to try again.</a>
+		', $upcontext['error_msg'];
+
+	if (empty($upcontext['fatal']))
+	{
+		// To early to have even loaded language?
+		$txt['try_again'] = isset($txt['try_again']) ? $txt['try_again'] : 'Click here to try again.';
+
+		echo '
+		<br /><br />
+		<a href="', $_SERVER['PHP_SELF'], '">', $txt['try_again'] . '</a>';
+	}
+
+	echo '
 	</div>';
 }
 

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -607,7 +607,7 @@ function initialize_inputs()
  */
 function action_welcomeLogin()
 {
-	global $modSettings, $upgradeurl, $upcontext, $db_type, $databases, $db_character_set, $txt;
+	global $modSettings, $upgradeurl, $upcontext, $db_type, $databases, $db_character_set, $txt, $boardurl;
 
 	$db = load_database();
 
@@ -618,6 +618,29 @@ function action_welcomeLogin()
 		&& @file_exists(SOURCEDIR . '/QueryString.php')
 		&& @file_exists(SOURCEDIR . '/database/Db-' . $db_type . '.class.php')
 		&& @file_exists(__DIR__ . '/upgrade_' . DB_SCRIPT_VERSION . '.php');
+
+	// This needs to exist!
+	if (!file_exists($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/Install.' . $upcontext['language'] . '.php'))
+	{
+		return throw_error('The upgrade script could not find the &quot;Install&quot; language file for the forum default language, ' . $upcontext['language'] . '.<br /><br />Please make certain you uploaded all the files included in the package, even the theme and language files for the default theme.<br />&nbsp;&nbsp;&nbsp;[<a href="' . $upgradeurl . '?lang=english">Try English</a>]');
+	}
+	else
+	{
+		require_once($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/Install.' . $upcontext['language'] . '.php');
+	}
+
+	// Do not try to upgrade to the same version you are already running
+	if (isset($_GET['v']) && defined('CURRENT_VERSION'))
+	{
+		if ($_GET['v'] === CURRENT_VERSION)
+		{
+			$upcontext['current_step'] = 4;
+			$upcontext['overall_percent'] = 100;
+			unset($_GET['v']);
+
+			return throw_error(sprintf($txt['upgrade_warning_already_done'], CURRENT_VERSION, $boardurl), true);
+		}
+	}
 
 	// If the db is not UTF
 	if (!isset($modSettings['elkVersion']) && ($db_type == 'mysql' || $db_type == 'mysqli') && (!isset($db_character_set) || $db_character_set !== 'utf8' || empty($modSettings['global_character_set']) || $modSettings['global_character_set'] !== 'UTF-8'))
@@ -690,16 +713,6 @@ function action_welcomeLogin()
 		{
 			return throw_error('The upgrader found some old or outdated language files, for the forum default language, ' . $upcontext['language'] . '.<br /><br />Please make certain you uploaded the new versions of all the files included in the package, even the theme and language files for the default theme.<br />&nbsp;&nbsp;&nbsp;[<a href="' . $upgradeurl . '?skiplang">SKIP</a>] [<a href="' . $upgradeurl . '?lang=english">Try English</a>]');
 		}
-	}
-
-	// This needs to exist!
-	if (!file_exists($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/Install.' . $upcontext['language'] . '.php'))
-	{
-		return throw_error('The upgrader could not find the &quot;Install&quot; language file for the forum default language, ' . $upcontext['language'] . '.<br /><br />Please make certain you uploaded all the files included in the package, even the theme and language files for the default theme.<br />&nbsp;&nbsp;&nbsp;[<a href="' . $upgradeurl . '?lang=english">Try English</a>]');
-	}
-	else
-	{
-		require_once($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/Install.' . $upcontext['language'] . '.php');
 	}
 
 	if (!makeFilesWritable($writable_files))
@@ -2022,11 +2035,13 @@ function print_error($message, $fatal = false)
  * Displays and error using the error template
  *
  * @param string $message
+ * @param bool $fatal
  */
-function throw_error($message)
+function throw_error($message, $fatal = false)
 {
 	global $upcontext;
 
+	$upcontext['fatal'] = $fatal;
 	$upcontext['error_msg'] = $message;
 	$upcontext['sub_template'] = 'error_message';
 

--- a/themes/default/css/install.css
+++ b/themes/default/css/install.css
@@ -132,6 +132,9 @@ img#logo {
 	padding: 1em 0 0 0;
 	overflow: auto;
 }
+.panel .errorbox {
+	font-size: 1.15em;
+}
 /* [WIP] Warning: this next bit may cause trouble. .. confirmed, it does :P */
 /* It's just to hide an empty div when the submits are not shown.
 .panel .clear:nth-child(4) {

--- a/themes/default/languages/english/Install.english.php
+++ b/themes/default/languages/english/Install.english.php
@@ -24,6 +24,7 @@ $txt['delete_installer'] = 'Click here to try to delete the install directory no
 $txt['delete_installer_maybe'] = '<em>(doesn\'t work on all servers.)</em>';
 $txt['go_to_your_forum'] = 'Now you can see <a href="%1$s">your newly installed forum</a> and begin to use it.  You should first make sure you are logged in, after which you will be able to access the administration center.';
 $txt['good_luck'] = 'Thanks for installing ElkArte!';
+$txt['try_again'] = 'Click here to try again.';
 
 $txt['install_welcome'] = 'Welcome';
 $txt['install_welcome_desc'] = 'Welcome to ElkArte. This script will guide you through the process for installing %1$s. We\'ll gather a few details about your forum over the next few steps, and after a couple of minutes your forum will be ready for use.';
@@ -225,3 +226,4 @@ $txt['upgrade_error_script_js'] = 'The upgrade script cannot find script.js or i
 
 $txt['upgrade_warning_lots_data'] = 'This upgrade script has detected that your forum contains a lot of data which needs upgrading. This process may take quite some time depending on your server and forum size, and for very large forums (~300,000 messages) may take several hours to complete.';
 $txt['upgrade_warning_out_of_date'] = 'This upgrade script is out of date! The current version of ElkArte is <em id="elkVersion">??</em> but this upgrade script is for <em id="installedVersion">%1$s</em>.<br /><br />It is recommended that you visit the <a href="https://www.elkarte.net/" target="_blank" class="new_win">ElkArte Community</a> website to ensure you are upgrading to the latest version.';
+$txt['upgrade_warning_already_done'] = 'You are already running <em>ElkArte %1$s</em> no upgrade is available!  You must <strong>delete</strong> the install directory and then proceed to <a href="%2$s">your forum</a>';


### PR DESCRIPTION
Just a bit more work on this ... 

Now after install, if you don't delete the install directory as part of the installer, or it fails, you will still be redirected to upgrade.  But it now passes the installed forum version so upgrade knows its can't upgrade to what it already is.  

Instead it jumps to the end of upgrade and informs that you must delete the install directory.  I could have provided the checkbox to attempt this but decided not to for several reasons.  

This is better than what is there now, pic attached of where to get sent to as well.

![fail](https://user-images.githubusercontent.com/1181042/102268601-27217580-3ee1-11eb-80ea-095bdb91d571.png)
