### PR TITLE
Update querys from MySQL unique LIMIT offset, start to more universal LIMIT start OFFSET offset

### DIFF
--- a/sources/ElkArte/Database/Mysqli/Dump.php
+++ b/sources/ElkArte/Database/Mysqli/Dump.php
@@ -325,7 +325,7 @@ class Dump extends AbstractDump
 		$result = $this->_db->query('', '
 			SELECT /*!40001 SQL_NO_CACHE */ *
 			FROM `' . $tableName . '`
-			LIMIT ' . $start . ', ' . $limit,
+			LIMIT ' . $limit . ' OFFSET ' . $start,
 			array(
 				'security_override' => true,
 			)

--- a/sources/ElkArte/Database/Postgresql/Dump.php
+++ b/sources/ElkArte/Database/Postgresql/Dump.php
@@ -217,7 +217,7 @@ class Dump extends AbstractDump
 		$result = $this->_db->query('', '
 			SELECT *
 			FROM ' . $tableName . '
-			LIMIT ' . $start . ', ' . $limit,
+			LIMIT ' . $limit . ' OFFSET ' . $start,
 			array(
 				'security_override' => true,
 			)

--- a/sources/ElkArte/Database/Postgresql/Query.php
+++ b/sources/ElkArte/Database/Postgresql/Query.php
@@ -274,7 +274,7 @@ class Query extends AbstractQuery
 			$db_string = preg_replace(array_keys($replacements[$identifier]), array_values($replacements[$identifier]), $db_string);
 		}
 
-		// Limits need to be a little different.
+		// Limits need to be a little different, left in place for non conformance addons
 		$db_string = preg_replace('~\sLIMIT\s(\d+|{int:.+}),\s*(\d+|{int:.+})(.*)~i', ' LIMIT $2 OFFSET $1 $3', $db_string);
 
 		if (trim($db_string) === '')

--- a/sources/ElkArte/Errors/Log.php
+++ b/sources/ElkArte/Errors/Log.php
@@ -111,7 +111,7 @@ class Log extends AbstractModel
 			FROM {db_prefix}log_errors' . (!empty($filter) ? '
 			WHERE ' . $filter['variable'] . ' LIKE {string:filter}' : '') . '
 			ORDER BY id_error ' . ($sort_direction === 'down' ? 'DESC' : '') . '
-			LIMIT ' . $start . ', ' . $this->_modSettings['defaultMaxMessages'],
+			LIMIT ' . $this->_modSettings['defaultMaxMessages'] . ' OFFSET ' . $start,
 			array(
 				'filter' => !empty($filter) ? $filter['value']['sql'] : '',
 			)

--- a/sources/ElkArte/Recent.php
+++ b/sources/ElkArte/Recent.php
@@ -182,7 +182,7 @@ class Recent
 					AND m.approved = {int:is_approved}
 					AND t.approved = {int:is_approved}
 				ORDER BY m.id_msg DESC
-				LIMIT {int:offset}, {int:limit}',
+				LIMIT {int:limit} OFFSET {int:offset}',
 				array_merge($this->_query_parameters, array(
 					'is_approved' => 1,
 					'offset' => $start,

--- a/sources/ElkArte/ScheduledTasks/Tasks/UserAccessMentions.php
+++ b/sources/ElkArte/ScheduledTasks/Tasks/UserAccessMentions.php
@@ -88,7 +88,7 @@ class UserAccessMentions implements ScheduledTaskInterface
 							WHERE mnt.id_member = {int:current_member}
 								AND mnt.mention_type IN ({array_string:mention_types})
 								AND {raw:user_see_board}
-							LIMIT {int:start}, {int:limit}',
+							LIMIT {int:limit} OFFSET {int:start}',
 							array(
 								'current_member' => $member,
 								'mention_types' => $mentionTypes,

--- a/sources/ElkArte/Search/API/Sphinxql.php
+++ b/sources/ElkArte/Search/API/Sphinxql.php
@@ -225,7 +225,7 @@ class Sphinxql extends AbstractAPI
 			}
 
 			$query .= ' ORDER BY ' . $sphinx_sort;
-			$query .= ' LIMIT 0,' . (int) $modSettings['sphinx_max_results'];
+			$query .= ' LIMIT ' . (int) $modSettings['sphinx_max_results'] . ' OFFSET 0';
 
 			// Set any options needed, like field weights
 			// A better ranker expression is one based off the standard Sphinx SPH04 algo but boosted for

--- a/sources/ElkArte/Search/API/Standard.php
+++ b/sources/ElkArte/Search/API/Standard.php
@@ -922,7 +922,7 @@ class Standard extends AbstractAPI
 				INNER JOIN {db_prefix}topics AS t ON (t.id_topic = lsr.id_topic)' : '') . '
 			WHERE lsr.id_search = {int:id_search}
 			ORDER BY {raw:sort} {raw:sort_dir}
-			LIMIT {int:start}, {int:limit}',
+			LIMIT {int:limit} OFFSET {int:start}',
 			array(
 				'id_search' => $id_search,
 				'sort' => $this->_searchParams->sort,

--- a/sources/ElkArte/Unread.php
+++ b/sources/ElkArte/Unread.php
@@ -320,7 +320,7 @@ class Unread
 			($this->_post_mod ? ' AND ms.approved = {int:is_approved}' : '') .
 			($this->_unwatch ? ' AND COALESCE(lt.unwatched, 0) != 1' : '') . '
 			ORDER BY {raw:order}
-			LIMIT {int:offset}, {int:limit}',
+			LIMIT {int:limit} OFFSET {int:offset}',
 			array_merge($this->_query_parameters, array(
 				'current_member' => $this->_user_id,
 				'min_message' => $this->_min_message,
@@ -360,7 +360,7 @@ class Unread
 			($this->_post_mod ? ' AND t.approved = {int:is_approved}' : '') .
 			($this->_unwatch ? ' AND COALESCE(lt.unwatched, 0) != 1' : '') . '
 			ORDER BY {raw:order}
-			LIMIT {int:offset}, {int:limit}',
+			LIMIT {int:limit} OFFSET {int:offset}',
 			array_merge($this->_query_parameters, array(
 				'current_member' => $this->_user_id,
 				'min_message' => $this->_min_message,

--- a/sources/subs/BadBehavior.subs.php
+++ b/sources/subs/BadBehavior.subs.php
@@ -122,7 +122,7 @@ function getBadBehaviorLogEntries($start, $items_per_page, $sort, $filter = '')
 		FROM {db_prefix}log_badbehavior' . (!empty($filter) ? '
 		WHERE ' . $filter['variable'] . ' LIKE {string:filter}' : '') . '
 		ORDER BY id ' . ($sort === 'down' ? 'DESC' : '') . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . ' OFFSET ' . $start,
 		array(
 			'filter' => !empty($filter) ? $filter['value']['sql'] : '',
 		)

--- a/sources/subs/Bans.subs.php
+++ b/sources/subs/Bans.subs.php
@@ -1184,7 +1184,7 @@ function list_getBanTriggers($start, $items_per_page, $sort, $trigger_type)
 			INNER JOIN {db_prefix}members AS mem ON (mem.id_member = bi.id_member)' : '
 		WHERE ' . $where[$trigger_type]) . '
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array(
 			'blank_string' => '',
 		)
@@ -1345,7 +1345,7 @@ function list_getBanLogEntries($start, $items_per_page, $sort)
 		FROM {db_prefix}log_banned AS lb
 			LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = lb.id_member)
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array(
 			'blank_string' => '',
 			'dash' => '-',
@@ -1526,7 +1526,7 @@ function list_getBans($start, $items_per_page, $sort)
 			LEFT JOIN {db_prefix}ban_items AS bi ON (bi.id_ban_group = bg.id_ban_group)
 		GROUP BY bg.id_ban_group, bg.name, bg.ban_time, bg.expire_time, bg.reason, bg.notes
 		ORDER BY {raw:sort}
-		LIMIT {int:offset}, {int:limit}',
+		LIMIT {int:limit} OFFSET {int:offset} ',
 		array(
 			'sort' => $sort,
 			'offset' => $start,

--- a/sources/subs/Calendar.subs.php
+++ b/sources/subs/Calendar.subs.php
@@ -1213,7 +1213,7 @@ function list_getHolidays($start, $items_per_page, $sort)
 			id_holiday, YEAR(event_date) AS year, MONTH(event_date) AS month, DAYOFMONTH(event_date) AS day, title
 		FROM {db_prefix}calendar_holidays
 		ORDER BY {raw:sort}
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . ' OFFSET ' . $start,
 		array(
 			'sort' => $sort,
 		)

--- a/sources/subs/Likes.subs.php
+++ b/sources/subs/Likes.subs.php
@@ -408,7 +408,7 @@ function likesPostsGiven($start, $items_per_page, $sort, $memberID)
 		WHERE l.id_member = {int:id_member}' . (!empty($modSettings['recycle_enable']) ? ('
 			AND b.id_board != ' . $modSettings['recycle_board']) : '') . '
 		ORDER BY {raw:sort}
-		LIMIT {int:start}, {int:per_page}',
+		LIMIT {int:per_page} OFFSET {int:start}',
 		array(
 			'id_member' => $memberID,
 			'sort' => $sort,
@@ -461,7 +461,7 @@ function likesPostsReceived($start, $items_per_page, $sort, $memberID)
 			AND b.id_board != ' . $modSettings['recycle_board']) : '') . '
 		GROUP BY m.subject, m.id_topic, b.name, m.id_msg
 		ORDER BY {raw:sort}
-		LIMIT {int:start}, {int:per_page}',
+		LIMIT {int:per_page} OFFSET {int:start}',
 		array(
 			'id_member' => $memberID,
 			'sort' => $sort,
@@ -518,7 +518,7 @@ function postLikers($start, $items_per_page, $sort, $messageID, $simple = true)
 			LEFT JOIN {db_prefix}attachments AS a ON (a.id_member = m.id_member)') . '
 		WHERE l.id_msg = {int:id_message}
 		ORDER BY {raw:sort}
-		LIMIT {int:start}, {int:per_page}',
+		LIMIT {int:per_page} OFFSET {int:start}',
 		array(
 			'id_message' => $messageID,
 			'sort' => $sort,

--- a/sources/subs/Maillist.subs.php
+++ b/sources/subs/Maillist.subs.php
@@ -74,7 +74,7 @@ function list_maillist_unapproved($id = 0, $start = 0, $items_per_page = 0, $sor
 			LEFT JOIN {db_prefix}boards AS b ON (b.id_board = e.id_board)
 		WHERE ' . $where_query . '
 		ORDER BY {raw:sort}
-		' . ((!empty($items_per_page)) ? 'LIMIT {int:offset}, {int:limit} ' : 'LIMIT 1'),
+		' . ((!empty($items_per_page)) ? 'LIMIT {int:limit} OFFSET {int:offset}  ' : 'LIMIT 1'),
 		array(
 			'offset' => $start,
 			'limit' => $items_per_page,
@@ -225,7 +225,7 @@ function list_get_filter_parser($start, $items_per_page, $sort = '', $id = 0, $s
 		WHERE id_filter' . (($id == 0) ? ' > {int:id}' : ' = {int:id}') . '
 			AND filter_style = {string:style}
 		ORDER BY {raw:sort}, filter_type ASC, filter_order ASC
-		' . ((!empty($items_per_page)) ? 'LIMIT {int:offset}, {int:limit} ' : ''),
+		' . ((!empty($items_per_page)) ? 'LIMIT {int:limit} OFFSET {int:offset}  ' : ''),
 		array(
 			'offset' => $start,
 			'limit' => $items_per_page,

--- a/sources/subs/ManageAttachments.subs.php
+++ b/sources/subs/ManageAttachments.subs.php
@@ -1522,7 +1522,7 @@ function list_getFiles($start, $items_per_page, $sort, $browse_type)
 				LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = a.id_member)
 			WHERE a.id_member != {int:guest_id}
 			ORDER BY {raw:sort}
-			LIMIT {int:start}, {int:per_page}',
+			LIMIT {int:per_page} OFFSET {int:start} ',
 			array(
 				'guest_id' => 0,
 				'blank_text' => '',
@@ -1546,7 +1546,7 @@ function list_getFiles($start, $items_per_page, $sort, $browse_type)
 				LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = m.id_member)
 			WHERE a.attachment_type = {int:attachment_type}
 			ORDER BY {raw:sort}
-			LIMIT {int:start}, {int:per_page}',
+			LIMIT {int:per_page} OFFSET {int:start} ',
 			array(
 				'attachment_type' => $browse_type === 'thumbs' ? '3' : '0',
 				'sort' => $sort,
@@ -1702,7 +1702,7 @@ function findAttachmentsToMove($from, $start, $limit)
 		FROM {db_prefix}attachments
 		WHERE id_folder = {int:folder}
 			AND attachment_type != {int:attachment_type}
-		LIMIT {int:start}, {int:limit}',
+		LIMIT {int:limit} OFFSET {int:start} ',
 		array(
 			'folder' => $from,
 			'attachment_type' => 1,

--- a/sources/subs/Membergroups.subs.php
+++ b/sources/subs/Membergroups.subs.php
@@ -2138,7 +2138,7 @@ function list_getGroupRequests($start, $items_per_page, $sort, $where, $where_pa
 			INNER JOIN {db_prefix}membergroups AS mg ON (mg.id_group = lgr.id_group)
 		WHERE ' . $where . '
 		ORDER BY {raw:sort}
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array_merge($where_parameters, array(
 			'sort' => $sort,
 		))

--- a/sources/subs/Members.subs.php
+++ b/sources/subs/Members.subs.php
@@ -1292,7 +1292,7 @@ function list_getMembers($start, $items_per_page, $sort, $where, $where_params =
 			LEFT JOIN {db_prefix}membergroups AS mg ON (mg.id_group = mem.id_group)
 		WHERE ' . ($where == '1' ? '1=1' : $where) . '
 		ORDER BY {raw:sort}
-		LIMIT {int:start}, {int:per_page}',
+		LIMIT {int:per_page} OFFSET {int:start}',
 		array_merge($where_params, array(
 			'sort' => $sort,
 			'start' => $start,
@@ -1611,7 +1611,7 @@ function membersBy($query, $query_params, $details = false, $only_active = true)
 			hide_email, posts, is_activated, real_name' : '') . '
 		FROM {db_prefix}members
 		WHERE ' . $query_where . (isset($query_params['start']) ? '
-		LIMIT {int:start}, {int:limit}' : '') . (!empty($query_params['order']) ? '
+		LIMIT {int:limit} OFFSET {int:start}' : '') . (!empty($query_params['order']) ? '
 		ORDER BY {raw:order}' : ''),
 		$query_params
 	)->fetch_callback(
@@ -2340,7 +2340,7 @@ function onlineMembers($conditions, $sort_method, $sort_direction, $start)
 			LEFT JOIN {db_prefix}membergroups AS mg ON (mg.id_group = CASE WHEN mem.id_group = {int:regular_member} THEN mem.id_post_group ELSE mem.id_group END)' . (!empty($conditions) ? '
 		WHERE ' . implode(' AND ', $conditions) : '') . '
 		ORDER BY {raw:sort_method} {raw:sort_direction}
-		LIMIT {int:offset}, {int:limit}',
+		LIMIT {int:limit} OFFSET {int:offset}',
 		array(
 			'regular_member' => 0,
 			'sort_method' => $sort_method,

--- a/sources/subs/Mentions.subs.php
+++ b/sources/subs/Mentions.subs.php
@@ -104,7 +104,7 @@ function getUserMentions($start, $limit, $sort, $all = false, $type = '')
 			AND mtn.mention_type IN ({array_string:current_type})' : '
 			AND mtn.mention_type = {string:current_type}')) . '
 		ORDER BY {raw:sort}
-		LIMIT {int:start}, {int:limit}',
+		LIMIT {int:limit} OFFSET {int:start} ',
 		array(
 			'current_user' => User::$info->id,
 			'current_type' => $type,

--- a/sources/subs/MessageIndex.subs.php
+++ b/sources/subs/MessageIndex.subs.php
@@ -61,7 +61,7 @@ function messageIndexTopics($id_board, $id_member, $start, $items_per_page, $sor
 		WHERE t.id_board = {int:current_board}' . (!$indexOptions['only_approved'] ? '' : '
 			AND (t.approved = {int:is_approved}' . ($id_member == 0 ? '' : ' OR t.id_member_started = {int:current_member}') . ')') . '
 		ORDER BY ' . ($indexOptions['include_sticky'] ? 'is_sticky' . ($indexOptions['fake_ascending'] ? '' : ' DESC') . ', ' : '') . $sort_column . ($indexOptions['ascending'] ? '' : ' DESC') . '
-		LIMIT {int:start}, {int:maxindex}',
+		LIMIT {int:maxindex} OFFSET {int:start}',
 		array(
 			'current_board' => $id_board,
 			'current_member' => $id_member,

--- a/sources/subs/Messages.subs.php
+++ b/sources/subs/Messages.subs.php
@@ -515,7 +515,7 @@ function messageAt($start, $id_topic, $params = array())
 			AND id_msg NOT IN ({array_int:not_in})') . (!$params['only_approved'] ? '' : '
 			AND approved = {int:is_approved}') . '
 		ORDER BY id_msg DESC' . ($params['limit'] === false ? '' : '
-		LIMIT {int:start}, {int:limit}'),
+		LIMIT {int:limit} OFFSET {int:start} '),
 		$params
 	)->fetch_callback(
 		function ($row) use (&$msg) {

--- a/sources/subs/Moderation.subs.php
+++ b/sources/subs/Moderation.subs.php
@@ -533,7 +533,7 @@ function warningTemplates($start, $items_per_page, $sort, $template_type = 'warn
 		WHERE lc.comment_type = {string:tpltype}
 			AND (id_recipient = {string:generic} OR id_recipient = {int:current_member})
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array(
 			'tpltype' => $template_type,
 			'generic' => 0,
@@ -621,7 +621,7 @@ function warnings($start, $items_per_page, $sort, $query_string = '', $query_par
 		WHERE lc.comment_type = {string:warning}' . (!empty($query_string) ? '
 			AND ' . $query_string : '') . '
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array_merge($query_params, array(
 			'warning' => 'warning',
 		))
@@ -843,7 +843,7 @@ function getModReports($status = 0, $start = 0, $limit = 10, $show_pms = false)
 				AND lr.type IN ({array_string:rep_type})
 				AND ' . (User::$info->mod_cache['bq'] == '1=1' || User::$info->mod_cache['bq'] == '0=1' ? User::$info->mod_cache['bq'] : 'lr.' . User::$info->mod_cache['bq']) . '
 			ORDER BY lr.time_updated DESC
-			LIMIT {int:start}, {int:limit}',
+			LIMIT {int:limit} OFFSET {int:start} ',
 		array(
 			'view_closed' => $status,
 			'start' => $start,
@@ -1035,7 +1035,7 @@ function watchedUsers($start, $items_per_page, $sort)
 		FROM {db_prefix}members
 		WHERE warning >= {int:warning_watch}
 		ORDER BY {raw:sort}
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array(
 			'warning_watch' => $modSettings['warning_watch'],
 			'sort' => $sort,
@@ -1192,7 +1192,7 @@ function watchedUserPosts($start, $items_per_page, $approve_query, $delete_board
 			AND b.id_board != {int:recycle}' : '') .
 		$approve_query . '
 		ORDER BY m.id_msg DESC
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array(
 			'warning_watch' => $modSettings['warning_watch'],
 			'recycle' => $modSettings['recycle_board'],
@@ -1494,7 +1494,7 @@ function moderatorNotes($offset)
 				LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = lc.id_member)
 			WHERE lc.comment_type = {string:modnote}
 			ORDER BY id_comment DESC
-			LIMIT {int:offset}, 10',
+			LIMIT 10 OFFSET {int:offset} ',
 			array(
 				'modnote' => 'modnote',
 				'offset' => $offset,
@@ -1624,7 +1624,7 @@ function getUnapprovedPosts($approve_query, $current_view, $boards_allowed, $sta
 			AND t.id_first_msg ' . ($current_view == 'topics' ? '=' : '!=') . ' m.id_msg
 			AND {query_see_board}
 			' . $approve_query . '
-		LIMIT {int:start}, {int:limit}',
+		LIMIT {int:limit} OFFSET {int:start} ',
 		array(
 			'start' => $start,
 			'limit' => $limit,

--- a/sources/subs/Modlog.subs.php
+++ b/sources/subs/Modlog.subs.php
@@ -102,7 +102,7 @@ function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '
 		. (!empty($query_string) ? '
 				AND ' . $query_string : '') . '
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array_merge($query_params, array(
 			'reg_group_id' => 0,
 			'log_type' => $log_type,

--- a/sources/subs/PaidSubscriptions.subs.php
+++ b/sources/subs/PaidSubscriptions.subs.php
@@ -83,7 +83,7 @@ function list_getSubscribedUsers($start, $items_per_page, $sort, $id_sub, $searc
 		WHERE ls.id_subscribe = {int:current_subscription} ' . $search_string . '
 			AND (ls.end_time != {int:no_end_time} OR ls.payments_pending != {int:no_payments_pending})
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array_merge($search_vars, array(
 			'current_subscription' => $id_sub,
 			'no_end_time' => 0,

--- a/sources/subs/PersonalMessage.subs.php
+++ b/sources/subs/PersonalMessage.subs.php
@@ -1050,7 +1050,7 @@ function loadPMs($pm_options, $id_member)
 					AND pm.id_pm = {int:id_pm}') . '
 				GROUP BY pm.id_pm_head
 				ORDER BY sort_param' . ($pm_options['descending'] ? ' DESC' : ' ASC') . (empty($pm_options['pmsg']) ? '
-				LIMIT ' . $pm_options['start'] . ', ' . $pm_options['limit'] : ''),
+				LIMIT ' . $pm_options['limit'] . ' OFFSET ' . $pm_options['start'] : ''),
 				array(
 					'current_member' => $id_member,
 					'not_deleted' => 0,
@@ -1077,7 +1077,7 @@ function loadPMs($pm_options, $id_member)
 					LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = {raw:id_member})') : '') . '
 				WHERE ' . (empty($sub_pms) ? '0=1' : 'pm.id_pm IN ({array_int:pm_list})') . '
 				ORDER BY ' . ($pm_options['sort_by_query'] == 'pm.id_pm' && $pm_options['folder'] != 'sent' ? 'id_pm' : '{raw:sort}') . ($pm_options['descending'] ? ' DESC' : ' ASC') . (empty($pm_options['pmsg']) ? '
-				LIMIT ' . $pm_options['start'] . ', ' . $pm_options['limit'] : ''),
+				LIMIT ' . $pm_options['limit'] . ' OFFSET ' . $pm_options['start'] : ''),
 				array(
 					'current_member' => $id_member,
 					'pm_list' => array_keys($sub_pms),
@@ -1105,7 +1105,7 @@ function loadPMs($pm_options, $id_member)
 					AND pm.id_pm = {int:pmsg}') . '
 				GROUP BY pm.id_pm_head
 				ORDER BY ' . ($pm_options['sort_by_query'] == 'pm.id_pm' && $pm_options['folder'] != 'sent' ? 'id_pm' : '{raw:sort}') . ($pm_options['descending'] ? ' DESC' : ' ASC') . (isset($pm_options['pmsg']) ? '
-				LIMIT ' . $pm_options['start'] . ', ' . $pm_options['limit'] : ''),
+				LIMIT ' . $pm_options['limit'] . ' OFFSET ' . $pm_options['start'] : ''),
 				array(
 					'current_member' => $id_member,
 					'deleted_by' => 0,
@@ -1134,7 +1134,7 @@ function loadPMs($pm_options, $id_member)
 				AND pm.deleted_by_sender = {int:is_deleted}' : '1=1') . (empty($pm_options['pmsg']) ? '' : '
 				AND pm.id_pm = {int:pmsg}') . '
 			ORDER BY ' . ($pm_options['sort_by_query'] == 'pm.id_pm' && $pm_options['folder'] != 'sent' ? 'pmr.id_pm' : '{raw:sort}') . ($pm_options['descending'] ? ' DESC' : ' ASC') . (isset($pm_options['pmsg']) ? '
-			LIMIT ' . $pm_options['start'] . ', ' . $pm_options['limit'] : ''),
+			LIMIT ' . $pm_options['limit'] . ' OFFSET ' . $pm_options['start'] : ''),
 			array(
 				'current_member' => $id_member,
 				'is_deleted' => 0,

--- a/sources/subs/Profile.subs.php
+++ b/sources/subs/Profile.subs.php
@@ -2956,7 +2956,7 @@ function list_getUserWarnings($start, $items_per_page, $sort, $memID)
 		WHERE lc.id_recipient = {int:selected_member}
 			AND lc.comment_type = {string:warning}
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array(
 			'selected_member' => $memID,
 			'warning' => 'warning',
@@ -3054,7 +3054,7 @@ function profileLoadAttachments($start, $items_per_page, $sort, $boardsAllowed, 
 			AND b.id_board NOT IN ({array_int:exclude_boards})' : '') . (!$modSettings['postmod_active'] || $context['user']['is_owner'] ? '' : '
 			AND m.approved = {int:is_approved}') . '
 		ORDER BY {raw:sort}
-		LIMIT {int:offset}, {int:limit}',
+		LIMIT {int:limit} OFFSET {int:offset} ',
 		array(
 			'boards_list' => $boardsAllowed,
 			'exclude_boards' => $exclude_boards,
@@ -3177,7 +3177,7 @@ function getUnwatchedBy($start, $items_per_page, $sort, $memID)
 			AND lt.unwatched = 1
 			AND {query_see_board}
 		ORDER BY {raw:sort}
-		LIMIT {int:offset}, {int:limit}',
+		LIMIT {int:limit} OFFSET {int:offset} ',
 		array(
 			'current_member' => $memID,
 			'sort' => $sort,

--- a/sources/subs/ProfileHistory.subs.php
+++ b/sources/subs/ProfileHistory.subs.php
@@ -70,7 +70,7 @@ function getUserErrors($start, $items_per_page, $sort, $where, $where_vars = arr
 			LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = le.id_member)
 		WHERE ' . $where . '
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array_merge($where_vars, array(
 			'guest_title' => $txt['guest_title'],
 		))
@@ -144,7 +144,7 @@ function getIPMessages($start, $items_per_page, $sort, $where, $where_vars = arr
 			LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = m.id_member)
 		WHERE {query_see_board} AND ' . $where . '
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array_merge($where_vars, array())
 	)->fetch_callback(
 		function ($row) use (&$messages) {
@@ -292,7 +292,7 @@ function getProfileEdits($start, $items_per_page, $sort, $memID)
 		WHERE id_log = {int:log_type}
 			AND id_member = {int:owner}
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array(
 			'log_type' => 2,
 			'owner' => $memID,

--- a/sources/subs/ScheduledTasks.subs.php
+++ b/sources/subs/ScheduledTasks.subs.php
@@ -486,7 +486,7 @@ function getTaskLogEntries($start, $items_per_page, $sort)
 		FROM {db_prefix}log_scheduled_tasks AS lst
 			INNER JOIN {db_prefix}scheduled_tasks AS st ON (st.id_task = lst.id_task)
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array()
 	)->fetch_callback(
 		function ($row) use (&$log_entries) {

--- a/sources/subs/SearchEngines.subs.php
+++ b/sources/subs/SearchEngines.subs.php
@@ -317,7 +317,7 @@ function getSpiders($start, $items_per_page, $sort)
 			id_spider, spider_name, user_agent, ip_info
 		FROM {db_prefix}spiders
 		ORDER BY {raw:sort}
-		LIMIT {int:start}, {int:limit}',
+		LIMIT {int:limit} OFFSET {int:start} ',
 		array(
 			'sort' => $sort,
 			'start' => $start,
@@ -405,7 +405,7 @@ function getSpiderLogs($start, $items_per_page, $sort)
 		FROM {db_prefix}log_spider_hits AS sl
 			INNER JOIN {db_prefix}spiders AS s ON (s.id_spider = sl.id_spider)
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array()
 	)->fetch_all();
 }
@@ -458,7 +458,7 @@ function getSpiderStats($start, $items_per_page, $sort)
 		FROM {db_prefix}log_spider_stats AS ss
 			INNER JOIN {db_prefix}spiders AS s ON (s.id_spider = ss.id_spider)
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array()
 	)->fetch_all();
 }

--- a/sources/subs/Smileys.subs.php
+++ b/sources/subs/Smileys.subs.php
@@ -553,7 +553,7 @@ function list_getSmileys($start, $items_per_page, $sort)
 			id_smiley, code, filename, description, smiley_row, smiley_order, hidden
 		FROM {db_prefix}smileys
 		ORDER BY ' . $sort . '
-		LIMIT ' . $start . ', ' . $items_per_page,
+		LIMIT ' . $items_per_page . '  OFFSET ' . $start,
 		array()
 	)->fetch_all();
 }

--- a/sources/subs/Topic.subs.php
+++ b/sources/subs/Topic.subs.php
@@ -3155,7 +3155,7 @@ function mergeableTopics($id_board, $id_topic, $approved, $offset)
 				AND t.id_topic != {int:id_topic}' . (empty($approved) ? '
 				AND t.approved = {int:is_approved}' : '') . '
 			ORDER BY t.is_sticky DESC, t.id_last_msg DESC
-			LIMIT {int:offset}, {int:limit}
+			LIMIT {int:limit} OFFSET {int:offset} 
 		) AS o 
 	    INNER JOIN {db_prefix}topics AS t ON (o.id_topic = t.id_topic)
 	    INNER JOIN {db_prefix}messages AS m ON (m.id_msg = t.id_first_msg)


### PR DESCRIPTION
All the db's that we support use that syntax, so this make the core postgre/mysql/mariadb compliant.  I left the postgre translation in place for addons usage but perhaps we should remove that ?