### PR TITLE
Fix broken test due to not calling parent setup

### DIFF
--- a/sources/ElkArte/Themes/ThemeLoader.php
+++ b/sources/ElkArte/Themes/ThemeLoader.php
@@ -14,10 +14,10 @@
 namespace ElkArte\Themes;
 
 use ElkArte\Cache\Cache;
-use ElkArte\Themes\Directories;
 use ElkArte\Hooks;
 use ElkArte\HttpReq;
 use ElkArte\User;
+use ElkArte\UserInfo;
 use ElkArte\Util;
 use ElkArte\Debug;
 
@@ -302,6 +302,7 @@ class ThemeLoader
 		require_once($settings['theme_dir'] . '/Theme.php');
 		$class = 'ElkArte\\Themes\\' . $themeName . '\\Theme';
 		static::$dirs = new Directories($settings);
+		User::$info = User::$info ?? new UserInfo([]);
 		$this->theme = new $class($this->id, User::$info, static::$dirs);
 		$context['theme_instance'] = $this->theme;
 	}

--- a/tests/sources/controllers/AuthWeb.php
+++ b/tests/sources/controllers/AuthWeb.php
@@ -9,7 +9,11 @@
  */
 class SupportAuthController extends ElkArteWebSupport
 {
-	public function setUpPage($url = '', $login = false)
+	/**
+	 * Called just before a test run, but after setUp() use to
+	 * auto login or set a default page for initial browser view
+	 */
+	public function setUpPage()
 	{
 		$this->url = 'index.php';
 		$this->login = false;

--- a/tests/sources/controllers/ElkArteWebSupport.php
+++ b/tests/sources/controllers/ElkArteWebSupport.php
@@ -48,7 +48,7 @@ abstract class ElkArteWebSupport extends Selenium2TestCase
 		$this->setDesiredCapabilities([
 			"chromeOptions" => [
 				'w3c' => false,
-			]
+			],
 		]);
 		$this->setPort($this->port);
 		$this->setHost('localhost');
@@ -75,6 +75,8 @@ abstract class ElkArteWebSupport extends Selenium2TestCase
 	 *
 	 * - Calls parent setUpPage
 	 * - sets a window size good for screenshots etc.
+	 * - Logins in the admin (optional)
+	 * - Sets initial browser page (optional)
 	 */
 	public function setUpPage()
 	{
@@ -292,7 +294,5 @@ abstract class ElkArteWebSupport extends Selenium2TestCase
 
 		User::$info = new UserInfo($userData);
 		User::load();
-
-		new ElkArte\Themes\ThemeLoader();
 	}
 }

--- a/tests/sources/controllers/PostTestWeb.php
+++ b/tests/sources/controllers/PostTestWeb.php
@@ -9,7 +9,11 @@
  */
 class PostTestWebController extends ElkArteWebSupport
 {
-	public function setUpPage($url = '', $login = false)
+	/**
+	 * Called just before a test run, but after setUp() use to
+	 * auto login or set a default page for initial browser view
+	 */
+	public function setUpPage()
 	{
 		$this->url = 'index.php';
 		$this->login = true;

--- a/tests/sources/controllers/ProfileForumWeb.php
+++ b/tests/sources/controllers/ProfileForumWeb.php
@@ -9,7 +9,11 @@
  */
 class ProfileForumController extends ElkArteWebSupport
 {
-	public function setUpPage($url = '', $login = false)
+	/**
+	 * Called just before a test run, but after setUp() use to
+	 * auto login or set a default page for initial browser view
+	 */
+	public function setUpPage()
 	{
 		$this->url = 'index.php?action=profile;area=forumprofile';
 		$this->login = true;

--- a/tests/sources/controllers/ProfileInfoWeb.php
+++ b/tests/sources/controllers/ProfileInfoWeb.php
@@ -9,7 +9,11 @@
  */
 class ProfileInfoController extends ElkArteWebSupport
 {
-	public function setUpPage($url = '', $login = false)
+	/**
+	 * Called just before a test run, but after setUp() use to
+	 * auto login or set a default page for initial browser view
+	 */
+	public function setUpPage()
 	{
 		$this->url = 'index.php?action=profile;area=summary';
 		$this->login = true;

--- a/tests/sources/controllers/acpAddGroupWeb.php
+++ b/tests/sources/controllers/acpAddGroupWeb.php
@@ -9,7 +9,11 @@
  */
 class SupportManageMembergroupsController extends ElkArteWebSupport
 {
-	public function setUpPage($url = '', $login = false)
+	/**
+	 * Called just before a test run, but after setUp() use to
+	 * auto login or set a default page for initial browser view
+	 */
+	public function setUpPage()
 	{
 		$this->url = 'index.php';
 		$this->login = true;

--- a/tests/sources/controllers/acpManageMembersWeb.php
+++ b/tests/sources/controllers/acpManageMembersWeb.php
@@ -9,7 +9,11 @@
  */
 class SupportManageMembersController extends ElkArteWebSupport
 {
-	public function setUpPage($url = '', $login = false)
+	/**
+	 * Called just before a test run, but after setUp() use to
+	 * auto login or set a default page for initial browser view
+	 */
+	public function setUpPage()
 	{
 		$this->url = 'index.php';
 		$this->login = true;

--- a/tests/sources/subs/Boards.subs.Test.php
+++ b/tests/sources/subs/Boards.subs.Test.php
@@ -24,6 +24,8 @@ class TestBoards extends ElkArteCommonSetupTest
 		//
 		// @todo might want to insert some boards, topics, and use those all through the tests here
 		require_once(SUBSDIR . '/Boards.subs.php');
+
+		parent::setUp();
 	}
 
 	/**
@@ -68,20 +70,20 @@ class TestBoards extends ElkArteCommonSetupTest
 
 	/**
 	 * Mark the boards read
-	 *
-	 * Not working, fix in the future ::
 	 */
-	public function MarkBoardsRead()
+	public function testMarkBoardsRead()
 	{
 		global $modSettings;
 
 		// Set a max that is greater than what we have done in the tests
 		$modSettings['maxMsgID'] = 10;
 
+		// Mark them as read
 		markBoardsRead(1, false, true);
 
 		require_once(SUBSDIR . '/Topic.subs.php');
-		$num = getUnreadCountSince(1);
+		$num = getUnreadCountSince(1, 0);
+
 		$this->assertEquals(0, $num, 'Missed unread topics, expected 0 saw ' . $num);
 	}
 }


### PR DESCRIPTION
@emanuele45 This one is a bit odd so not sure this is the fix: https://github.com/elkarte/Elkarte/pull/3455/commits/946699e296499bbb3f7b123cd413f73f886901e0

The RegisterWeb tests were failing every time (yes they still fail on occasion, its the pain of headless web testing).  Anyway at first I thought it was a testcase issue but was able to repo on my test site once.  

The general flow is user.php ```load()``` is called ... this will call ```loadUserById()``` which will then call ```compileInfo()``` 

The ```compileInfo()``` function will call ```'language' => $this->getLanguage(),``` which will fail if ```user::info``` has not been loaded by some path.  Now ```user::info``` is loaded as part of the ```compileInfo()```function but that is after that ```'language' => $this->getLanguage(),```  is called so its not in place at that point

I'm uncertain how you get in the fatal "loop" The error path has something to do with when I registered as new member but was then not able to log back in as my old member.  I'm really not sure what happened but the error log in the failing tests show this:

```
Error: /09 18:05:46 [error] 6835#6835: *238 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: Argument 2 passed to ElkArte\Themes\Theme::__construct() must be an instance of ElkArte\ValuesContainer, null given, called in /home/runner/work/Elkarte/Elkarte/elkarte/sources/ElkArte/Themes/ThemeLoader.php on line 305 and defined in /home/runner/work/Elkarte/Elkarte/elkarte/sources/ElkArte/Themes/Theme.php:116
Stack trace:
#0 /home/runner/work/Elkarte/Elkarte/elkarte/sources/ElkArte/Themes/ThemeLoader.php(305): ElkArte\Themes\Theme->__construct(1, NULL, Object(ElkArte\Themes\Directories))
#1 /home/runner/work/Elkarte/Elkarte/elkarte/sources/ElkArte/Themes/ThemeLoader.php(65): ElkArte\Themes\ThemeLoader->initTheme()
#2 /home/runner/work/Elkarte/Elkarte/elkarte/sources/ElkArte/Errors/Errors.php(539): ElkArte\Themes\ThemeLoader->__construct()
#3 /home/runner/work/Elkarte/Elkarte/elkarte/sources/ElkArte/Errors/ErrorHandler.php(139): ElkArte\Errors\Errors->_setup_fatal_ErrorContext('Argument 2 pass...', 0)
#4 /home/runner/work/Elkarte/Elkarte/elkarte/sources" while reading response header from upstream, client: 127.0.0.1, server: 127.0.0.1, request: "GET /mobile.png HTTP/1.1", upstream: "fastcgi://unix:/home/runner/work/Elkarte/Elkarte/elkarte/.github/php-fpm.sock:", host: "127.0.0.1", referrer: "http://127.0.0.1/index.php?action=register"
```

You can see the others in this test run by opening the server error log section: https://github.com/elkarte/Elkarte/runs/1865293433