### PR TITLE
Removed initial default argument on insert

### DIFF
--- a/sources/database/Db-mysql.class.php
+++ b/sources/database/Db-mysql.class.php
@@ -708,7 +708,7 @@ class Database_MySQL extends Database_Abstract
 	 * @param mysqli|null $connection = null
 	 * @throws Elk_Exception
 	 */
-	public function insert($method = 'replace', $table, $columns, $data, $keys, $disable_trans = false, $connection = null)
+	public function insert($method, $table, $columns, $data, $keys, $disable_trans = false, $connection = null)
 	{
 		global $db_prefix;
 

--- a/sources/database/Db-postgresql.class.php
+++ b/sources/database/Db-postgresql.class.php
@@ -551,7 +551,7 @@ class Database_PostgreSQL extends Database_Abstract
 	 * @param resource|null $connection = null
 	 * @throws Elk_Exception
 	 */
-	public function insert($method = 'replace', $table, $columns, $data, $keys, $disable_trans = false, $connection = null)
+	public function insert($method, $table, $columns, $data, $keys, $disable_trans = false, $connection = null)
 	{
 		global $db_prefix;
 

--- a/sources/database/Db.php
+++ b/sources/database/Db.php
@@ -176,7 +176,7 @@ interface Database
 	 * @param resource|null $connection = null
 	 * @return void
 	 */
-	public function insert($method = 'replace', $table, $columns, $data, $keys, $disable_trans = false, $connection = null);
+	public function insert($method, $table, $columns, $data, $keys, $disable_trans = false, $connection = null);
 
 	/**
 	 * This function tries to work out additional error information from a back trace.


### PR DESCRIPTION
It doesn't have any impact or effect when '' is used, as that evaluates to INSERT on the line starting $queryTitle