### PR TITLE
Header updates

### DIFF
--- a/addons/index.php
+++ b/addons/index.php
@@ -5,10 +5,10 @@
  */
 
 // Look for Settings.php....
-if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
+if (file_exists(dirname(__FILE__, 2) . '/Settings.php'))
 {
 	// Found it!
-	require(dirname(dirname(__FILE__)) . '/Settings.php');
+	require(dirname(__FILE__, 2) . '/Settings.php');
 	header('Location: ' . $boardurl);
 }
 // Can't find it... just forget it.

--- a/attachments/index.php
+++ b/attachments/index.php
@@ -5,10 +5,10 @@
  */
 
 // Look for Settings.php....
-if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
+if (file_exists(dirname(__FILE__, 2) . '/Settings.php'))
 {
 	// Found it!
-	require(dirname(dirname(__FILE__)) . '/Settings.php');
+	require(dirname(__FILE__, 2) . '/Settings.php');
 	header('Location: ' . $boardurl);
 }
 // Can't find it... just forget it.

--- a/avatars/index.php
+++ b/avatars/index.php
@@ -5,10 +5,10 @@
  */
 
 // Look for Settings.php....
-if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
+if (file_exists(dirname(__FILE__, 2) . '/Settings.php'))
 {
 	// Found it!
-	require(dirname(dirname(__FILE__)) . '/Settings.php');
+	require(dirname(__FILE__, 2) . '/Settings.php');
 	header('Location: ' . $boardurl);
 }
 // Can't find it... just forget it.

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -177,7 +177,9 @@ class Bootstrap
 				$host = empty($_SERVER['HTTP_HOST']) ? $_SERVER['SERVER_NAME'] . $port : $_SERVER['HTTP_HOST'];
 				$path = strtr(dirname($_SERVER['PHP_SELF']), '\\', '/') == '/' ? '' : strtr(dirname($_SERVER['PHP_SELF']), '\\', '/');
 
-				header('Location:' . $proto . '://' . $host . $path . '/install/' . $redirec_file . '?v=' . $version_running);
+				\ElkArte\Http\Headers::instance()
+					->header('Location', $proto . '://' . $host . $path . '/install/' . $redirec_file . '?v=' . $version_running)
+					->sendHeaders();
 				die();
 			}
 		}
@@ -394,12 +396,6 @@ class Bootstrap
 		if (!defined('STDIN'))
 		{
 			loadBadBehavior();
-		}
-
-		// @todo: probably not the best place, but somewhere it should be set...
-		if (!headers_sent())
-		{
-			header('Content-Type: text/html; charset=UTF-8');
 		}
 
 		// Take care of any banning that needs to be done.

--- a/cache/index.php
+++ b/cache/index.php
@@ -3,10 +3,10 @@
 // This file is here solely to protect your cache directory.
 
 // Look for Settings.php....
-if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
+if (file_exists(dirname(__FILE__, 2) . '/Settings.php'))
 {
 	// Found it!
-	require(dirname(dirname(__FILE__)) . '/Settings.php');
+	require(dirname(__FILE__, 2) . '/Settings.php');
 	header('Location: ' . $boardurl);
 }
 // Can't find it... just forget it.

--- a/packages/index.php
+++ b/packages/index.php
@@ -5,10 +5,10 @@
  */
 
 // Look for Settings.php....
-if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
+if (file_exists(dirname(__FILE__, 2) . '/Settings.php'))
 {
 	// Found it!
-	require(dirname(dirname(__FILE__)) . '/Settings.php');
+	require(dirname(__FILE__, 2) . '/Settings.php');
 	header('Location: ' . $boardurl);
 }
 // Can't find it... just forget it.

--- a/smileys/index.php
+++ b/smileys/index.php
@@ -5,10 +5,10 @@
  */
 
 // Look for Settings.php....
-if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
+if (file_exists(dirname(__FILE__, 2) . '/Settings.php'))
 {
 	// Found it!
-	require(dirname(dirname(__FILE__)) . '/Settings.php');
+	require(dirname(__FILE__, 2) . '/Settings.php');
 	header('Location: ' . $boardurl);
 }
 // Can't find it... just forget it.

--- a/sources/DumpDatabase.php
+++ b/sources/DumpDatabase.php
@@ -89,7 +89,7 @@ function DumpDatabase2()
 		// Tell the client to save this file, even though it's text.
 		$headers
 			->removeHeader('all')
-			->contentType('application/octet-stream', '';
+			->contentType('application/octet-stream', '');
 
 		// This time the extension should just be .sql.
 		$extension = '.sql';

--- a/sources/ElkArte/AdminController/ManageServer.php
+++ b/sources/ElkArte/AdminController/ManageServer.php
@@ -318,7 +318,7 @@ class ManageServer extends AbstractController
 				$cookiename = $this->_req->post->cookiename;
 				setLoginCookie(60 * $modSettings['cookieTime'], (int) User::$settings['id_member'], hash('sha256', User::$settings['passwd'] . User::$settings['password_salt']));
 
-				redirectexit('action=admin;area=serversettings;sa=cookie;' . $context['session_var'] . '=' . $original_session_id, detectServer()->is('needs_login_fix'));
+				redirectexit('action=admin;area=serversettings;sa=cookie;' . $context['session_var'] . '=' . $original_session_id);
 			}
 
 			redirectexit('action=admin;area=serversettings;sa=cookie;' . $context['session_var'] . '=' . $context['session_id'] . ';msg=' . (!empty($context['settings_message']) ? $context['settings_message'] : 'core_settings_saved'));

--- a/sources/ElkArte/Controller/Announce.php
+++ b/sources/ElkArte/Controller/Announce.php
@@ -185,7 +185,7 @@ class Announce extends AbstractController
 			}
 			elseif (!empty($this->_req->post->goback))
 			{
-				redirectexit('topic=' . $topic . '.new;boardseen#new', isBrowser('ie'));
+				redirectexit('topic=' . $topic . '.new;boardseen#new');
 			}
 			else
 			{

--- a/sources/ElkArte/Controller/Attachment.php
+++ b/sources/ElkArte/Controller/Attachment.php
@@ -399,7 +399,6 @@ class Attachment extends AbstractController
 		}
 
 		$eTag = '"' . substr($id_attach . $real_filename . @filemtime($filename), 0, 64) . '"';
-		$use_compression = !empty($modSettings['enableCompressedOutput']) && @filesize($filename) <= 4194304 && in_array($file_ext, array('txt', 'html', 'htm', 'js', 'doc', 'docx', 'rtf', 'css', 'php', 'log', 'xml', 'sql', 'c', 'java'));
 		$disposition = !isset($this->_req->query->image) ? 'attachment' : 'inline';
 		$do_cache = !(!isset($this->_req->query->image) && getValidMimeImageType($file_ext) !== '');
 
@@ -419,7 +418,7 @@ class Attachment extends AbstractController
 			}
 		}
 
-		$this->prepare_headers($filename, $eTag, $mime_type, $use_compression, $disposition, $real_filename, $do_cache);
+		$this->prepare_headers($filename, $eTag, $mime_type, $disposition, $real_filename, $do_cache);
 		$this->send_file($filename, $mime_type);
 
 		obExit(false);
@@ -452,7 +451,7 @@ class Attachment extends AbstractController
 			throw new Exception('no_access', false);
 		}
 
-		$this->prepare_headers('no_image', 'no_image', 'image/png', false, 'inline', 'no_image.png', true, false);
+		$this->prepare_headers('no_image', 'no_image', 'image/png', 'inline', 'no_image.png', true, false);
 		Headers::instance()->sendHeaders();
 		echo $img;
 
@@ -492,13 +491,12 @@ class Attachment extends AbstractController
 	 * @param string $filename Full path+file name of the file in the filesystem
 	 * @param string $eTag ETag cache validator
 	 * @param string $mime_type The mime-type of the file
-	 * @param bool $use_compression If use gzip compression
 	 * @param string $disposition The value of the Content-Disposition header
 	 * @param string $real_filename The original name of the file
 	 * @param bool $do_cache If send the a max-age header or not
 	 * @param bool $check_filename When false, any check on $filename is skipped
 	 */
-	public function prepare_headers($filename, $eTag, $mime_type, $use_compression, $disposition, $real_filename, $do_cache, $check_filename = true)
+	public function prepare_headers($filename, $eTag, $mime_type, $disposition, $real_filename, $do_cache, $check_filename = true)
 	{
 		global $txt;
 
@@ -675,11 +673,9 @@ class Attachment extends AbstractController
 		}
 
 		$eTag = '"' . substr($id_attach . $real_filename . filemtime($filename), 0, 64) . '"';
-		$compressible_files = array('txt', 'html', 'htm', 'js', 'doc', 'docx', 'rtf', 'css', 'php', 'log', 'xml', 'sql', 'c', 'java');
-		$use_compression = !empty($modSettings['enableCompressedOutput']) && @filesize($filename) <= 4194304 && in_array($file_ext, $compressible_files);
 		$do_cache = !(!isset($this->_req->query->image) && getValidMimeImageType($file_ext) !== '');
 
-		$this->prepare_headers($filename, $eTag, $mime_type, $use_compression, 'inline', $real_filename, $do_cache);
+		$this->prepare_headers($filename, $eTag, $mime_type, 'inline', $real_filename, $do_cache);
 
 		if ($resize)
 		{

--- a/sources/ElkArte/Controller/Attachment.php
+++ b/sources/ElkArte/Controller/Attachment.php
@@ -509,9 +509,8 @@ class Attachment extends AbstractController
 
 			$protocol = preg_match('~HTTP/1\.[01]~i', $this->_req->server->SERVER_PROTOCOL) ? $this->_req->server->SERVER_PROTOCOL : 'HTTP/1.0';
 			$headers
-				->httpCode(404)
+				->removeHeader('all')
 				->headerSpecial($protocol . ' 404 Not Found')
-				->contentType('')
 				->sendHeaders();
 
 			// We need to die like this *before* we send any anti-caching headers as below.

--- a/sources/ElkArte/Controller/Auth.php
+++ b/sources/ElkArte/Controller/Auth.php
@@ -893,7 +893,7 @@ function doLogin(UserSettingsLoader $user)
 	// Just log you back out if it's in maintenance mode and you AREN'T an admin.
 	if (empty($maintenance) || allowedTo('admin_forum'))
 	{
-		redirectexit('action=auth;sa=check;member=' . User::$info->id, detectServer()->is('needs_login_fix'));
+		redirectexit('action=auth;sa=check;member=' . User::$info->id);
 	}
 	else
 	{

--- a/sources/ElkArte/Controller/Auth.php
+++ b/sources/ElkArte/Controller/Auth.php
@@ -21,6 +21,8 @@ use ElkArte\AbstractController;
 use ElkArte\Cache\Cache;
 use ElkArte\Errors\Errors;
 use ElkArte\Exceptions\Exception;
+use ElkArte\Http\Headers;
+use ElkArte\Themes\ThemeLoader;
 use ElkArte\User;
 use ElkArte\UserSettingsLoader;
 use ElkArte\Util;
@@ -74,7 +76,7 @@ class Auth extends AbstractController
 		}
 
 		// Load the Login template/language file.
-		\ElkArte\Themes\ThemeLoader::loadLanguageFile('Login');
+		ThemeLoader::loadLanguageFile('Login');
 		theme()->getTemplates()->load('Login');
 		loadJavascriptFile('sha256.js', array('defer' => true));
 		$context['sub_template'] = 'login';
@@ -161,7 +163,7 @@ class Auth extends AbstractController
 			$modSettings['cookieTime'] = (int) $_POST['cookielength'];
 		}
 
-		\ElkArte\Themes\ThemeLoader::loadLanguageFile('Login');
+		ThemeLoader::loadLanguageFile('Login');
 
 		// Load the template stuff
 		theme()->getTemplates()->load('Login');
@@ -656,7 +658,7 @@ class Auth extends AbstractController
 	{
 		global $txt, $context;
 
-		\ElkArte\Themes\ThemeLoader::loadLanguageFile('Login');
+		ThemeLoader::loadLanguageFile('Login');
 		theme()->getTemplates()->load('Login');
 		loadJavascriptFile('sha256.js', array('defer' => true));
 		createToken('login');
@@ -684,14 +686,16 @@ class Auth extends AbstractController
 	{
 		global $txt, $mtitle, $mmessage, $context;
 
-		\ElkArte\Themes\ThemeLoader::loadLanguageFile('Login');
+		ThemeLoader::loadLanguageFile('Login');
 		theme()->getTemplates()->load('Login');
 		loadJavascriptFile('sha256.js', array('defer' => true));
 		createToken('login');
 
 		// Send a 503 header, so search engines don't bother indexing while we're in maintenance mode.
-		\ElkArte\Http\Headers::instance()
-			->headerSpecial('HTTP/1.1 503 Service Temporarily Unavailable');
+		Headers::instance()
+			->headerSpecial('HTTP/1.1 503 Service Temporarily Unavailable')
+			->header('Status', '503 Service Temporarily Unavailable')
+			->header('Retry-After', '3600');
 
 		// Basic template stuff..
 		$context['sub_template'] = 'maintenance';

--- a/sources/ElkArte/Controller/Auth.php
+++ b/sources/ElkArte/Controller/Auth.php
@@ -626,7 +626,7 @@ class Auth extends AbstractController
 		{
 			if (empty($_SESSION['logout_url']))
 			{
-				redirectexit('', detectServer()->is('needs_login_fix'));
+				redirectexit();
 			}
 			elseif (!empty($_SESSION['logout_url']) && (substr($_SESSION['logout_url'], 0, 7) !== 'http://' && substr($_SESSION['logout_url'], 0, 8) !== 'https://'))
 			{
@@ -638,7 +638,7 @@ class Auth extends AbstractController
 				$temp = $_SESSION['logout_url'];
 				unset($_SESSION['logout_url']);
 
-				redirectexit($temp, detectServer()->is('needs_login_fix'));
+				redirectexit($temp);
 			}
 		}
 	}
@@ -690,7 +690,8 @@ class Auth extends AbstractController
 		createToken('login');
 
 		// Send a 503 header, so search engines don't bother indexing while we're in maintenance mode.
-		header('HTTP/1.1 503 Service Temporarily Unavailable');
+		\ElkArte\Http\Headers::instance()
+			->headerSpecial('HTTP/1.1 503 Service Temporarily Unavailable');
 
 		// Basic template stuff..
 		$context['sub_template'] = 'maintenance';
@@ -896,7 +897,7 @@ function doLogin(UserSettingsLoader $user)
 	}
 	else
 	{
-		redirectexit('action=logout;' . $context['session_var'] . '=' . $context['session_id'], detectServer()->is('needs_login_fix'));
+		redirectexit('action=logout;' . $context['session_var'] . '=' . $context['session_id']);
 	}
 }
 

--- a/sources/ElkArte/Controller/Calendar.php
+++ b/sources/ElkArte/Controller/Calendar.php
@@ -409,20 +409,25 @@ class Calendar extends AbstractController
 		obStart(!empty($modSettings['enableCompressedOutput']));
 
 		// Send the file headers
-		header('Pragma: no-cache');
-		header('Cache-Control: no-cache');
-		header('Expires: ' . gmdate('D, d M Y H:i:s', time() + 525600 * 60) . ' GMT');
-		header('Last-Modified: ' . gmdate('D, d M Y H:i:s', time()) . 'GMT');
-		header('Accept-Ranges: bytes');
-		header('Connection: close');
-		header('Content-Disposition: attachment; filename="' . $event['title'] . '.ics"');
+		$headers = \ElkArte\Http\Headers::instance();
+		$headers
+			->header('Pragma', 'no-cache')
+			->header('Cache-Control', 'no-cache')
+			->header('Expires', '' . gmdate('D, d M Y H:i:s', time() + 525600 * 60) . ' GMT')
+			->header('Last-Modified', '' . gmdate('D, d M Y H:i:s', time()) . 'GMT')
+			->header('Accept-Ranges', 'bytes')
+			->header('Connection', 'close')
+			->header('Content-Disposition', 'attachment; filename="' . $event['title'] . '.ics"');
 		if (empty($modSettings['enableCompressedOutput']))
 		{
-			header('Content-Length: ' . Util::strlen($filecontents));
+			$headers->header('Content-Length', Util::strlen($filecontents));
 		}
 
 		// This is a calendar item!
-		header('Content-Type: text/calendar');
+
+		$headers
+			->contentType('text/calendar', 'UTF-8')
+			->sendHeaders();
 
 		// Chuck out the card.
 		echo $filecontents;

--- a/sources/ElkArte/Controller/Jslocale.php
+++ b/sources/ElkArte/Controller/Jslocale.php
@@ -15,8 +15,9 @@ namespace ElkArte\Controller;
 
 use ElkArte\AbstractController;
 use ElkArte\Agreement;
-use ElkArte\Exceptions\Exception;
+use ElkArte\Http\Headers;
 use ElkArte\PrivacyPolicy;
+use ElkArte\Themes\ThemeLoader;
 
 /**
  * This file is called via ?action=jslocale;sa=sceditor to load in a list of
@@ -93,7 +94,7 @@ class Jslocale extends AbstractController
 
 		if (!empty($language_file))
 		{
-			\ElkArte\Themes\ThemeLoader::loadLanguageFile($language_file);
+			ThemeLoader::loadLanguageFile($language_file);
 		}
 
 		theme()->getLayers()->removeAll();
@@ -108,7 +109,9 @@ class Jslocale extends AbstractController
 	private function _sendFile()
 	{
 		// Make sure they know what type of file we are.
-		header('Content-Type: text/javascript');
+		Headers::instance()
+			->contentType('text/javascript', 'UTF-8')
+			->sendHeaders();
 
 		echo $this->_file_data;
 
@@ -145,7 +148,7 @@ class Jslocale extends AbstractController
 					$context['json_data']['privacypol'] = $privacypol->getParsedText();
 				}
 			}
-			catch (Exception $e)
+			catch (\Exception $e)
 			{
 				$context['json_data'] = $e->getMessage();
 			}

--- a/sources/ElkArte/Controller/News.php
+++ b/sources/ElkArte/Controller/News.php
@@ -259,22 +259,23 @@ class News extends AbstractController
 
 		obStart(!empty($modSettings['enableCompressedOutput']));
 
+		$headers = \ElkArte\Http\Headers::instance();
 		// This is an xml file....
 		if (isset($this->_req->query->debug))
 		{
-			header('Content-Type: text/xml; charset=UTF-8');
+			$headers->contentType('text/xml', 'UTF-8');
 		}
 		elseif ($xml_format === 'rss' || $xml_format === 'rss2')
 		{
-			header('Content-Type: application/rss+xml; charset=UTF-8');
+			$headers->contentType('application/rss+xml', 'UTF-8');
 		}
 		elseif ($xml_format === 'atom')
 		{
-			header('Content-Type: application/atom+xml; charset=UTF-8');
+			$headers->contentType('application/atom+xml', 'UTF-8');
 		}
 		elseif ($xml_format === 'rdf')
 		{
-			header('Content-Type: ' . (isBrowser('ie') ? 'text/xml' : 'application/rdf+xml') . '; charset=UTF-8');
+			$headers->contentType('application/rdf+xml','UTF-8');
 		}
 
 		theme()->getTemplates()->load('Xml');

--- a/sources/ElkArte/Controller/OpenID.php
+++ b/sources/ElkArte/Controller/OpenID.php
@@ -20,6 +20,7 @@ use ElkArte\AbstractController;
 use ElkArte\Cache\Cache;
 use ElkArte\EventManager;
 use ElkArte\Exceptions\Exception;
+use ElkArte\Http\Headers;
 use ElkArte\User;
 use ElkArte\UserSettingsLoader;
 
@@ -263,7 +264,8 @@ class OpenID extends AbstractController
 
 		obStart(!empty($modSettings['enableCompressedOutput']));
 
-		header('Content-Type: application/xrds+xml');
+		Headers::instance()->contentType('application/xrds+xml')->sendHeaders();
+
 		echo '<?xml version="1.0" encoding="UTF-8"?' . '>';
 		// Generate the XRDS data for OpenID 2.0, YADIS discovery..
 		echo '

--- a/sources/ElkArte/Controller/PersonalMessage.php
+++ b/sources/ElkArte/Controller/PersonalMessage.php
@@ -1542,7 +1542,7 @@ class PersonalMessage extends AbstractController
 
 		// Back to the folder.
 		$_SESSION['pm_selected'] = array_keys($to_label);
-		redirectexit($context['current_label_redirect'] . (count($to_label) === 1 ? '#msg_' . $_SESSION['pm_selected'][0] : ''), count($to_label) === 1 && isBrowser('ie'));
+		redirectexit($context['current_label_redirect'] . (count($to_label) === 1 ? '#msg_' . $_SESSION['pm_selected'][0] : ''));
 	}
 
 	/**

--- a/sources/ElkArte/Controller/Post.php
+++ b/sources/ElkArte/Controller/Post.php
@@ -1433,11 +1433,11 @@ class Post extends AbstractController
 		// Return to post if the mod is on.
 		if (isset($_REQUEST['msg']) && !empty($_REQUEST['goback']))
 		{
-			redirectexit('topic=' . $topic . '.msg' . $_REQUEST['msg'] . '#msg' . $_REQUEST['msg'], isBrowser('ie'));
+			redirectexit('topic=' . $topic . '.msg' . $_REQUEST['msg'] . '#msg' . $_REQUEST['msg']);
 		}
 		elseif (!empty($_REQUEST['goback']))
 		{
-			redirectexit('topic=' . $topic . '.new#new', isBrowser('ie'));
+			redirectexit('topic=' . $topic . '.new#new');
 		}
 		// Dut-dut-duh-duh-DUH-duh-dut-duh-duh!  *dances to the Final Fantasy Fanfare...*
 		else

--- a/sources/ElkArte/Controller/ProfileInfo.php
+++ b/sources/ElkArte/Controller/ProfileInfo.php
@@ -23,6 +23,7 @@ use ElkArte\Action;
 use ElkArte\Exceptions\Exception;
 use ElkArte\MembersList;
 use ElkArte\MessagesDelete;
+use ElkArte\Themes\ThemeLoader;
 use ElkArte\Util;
 
 /**
@@ -80,7 +81,7 @@ class ProfileInfo extends AbstractController
 		}
 		$this->_profile->loadContext();
 
-		\ElkArte\Themes\ThemeLoader::loadLanguageFile('Profile');
+		ThemeLoader::loadLanguageFile('Profile');
 	}
 
 	/**
@@ -123,7 +124,7 @@ class ProfileInfo extends AbstractController
 		global $context, $modSettings;
 
 		theme()->getTemplates()->load('ProfileInfo');
-		\ElkArte\Themes\ThemeLoader::loadLanguageFile('Profile');
+		ThemeLoader::loadLanguageFile('Profile');
 
 		// Set a canonical URL for this page.
 		$context['canonical_url'] = getUrl('action', ['action' => 'profile', 'u' => $this->_memID]);
@@ -280,7 +281,7 @@ class ProfileInfo extends AbstractController
 	}
 
 	/**
-	 * Gives there spam level as a posts per day kind of statistic
+	 * Gives their spam level as a posts per day kind of statistic
 	 */
 	private function _determine_posts_per_day()
 	{
@@ -359,7 +360,7 @@ class ProfileInfo extends AbstractController
 		{
 			include_once(SUBSDIR . '/Who.subs.php');
 			$action = determineActions($this->_profile['url']);
-			\ElkArte\Themes\ThemeLoader::loadLanguageFile('index');
+			ThemeLoader::loadLanguageFile('index');
 
 			if ($action !== false)
 			{
@@ -1061,8 +1062,8 @@ class ProfileInfo extends AbstractController
 		// Verify if the user has sufficient permissions.
 		isAllowedTo('manage_permissions');
 
-		\ElkArte\Themes\ThemeLoader::loadLanguageFile('ManagePermissions');
-		\ElkArte\Themes\ThemeLoader::loadLanguageFile('Admin');
+		ThemeLoader::loadLanguageFile('ManagePermissions');
+		ThemeLoader::loadLanguageFile('Admin');
 		theme()->getTemplates()->load('ManageMembers');
 		theme()->getTemplates()->load('ProfileInfo');
 
@@ -1258,7 +1259,6 @@ class ProfileInfo extends AbstractController
 		checkSession('get');
 
 		// Need the ProfileInfo and Index (for helper functions) templates
-		theme()->getTemplates()->load('Index');
 		theme()->getTemplates()->load('ProfileInfo');
 
 		// Prep for a buddy check
@@ -1267,7 +1267,6 @@ class ProfileInfo extends AbstractController
 
 		// This is returned only for ajax request to a jqueryUI tab
 		theme()->getLayers()->removeAll();
-		header('Content-Type: text/html; charset=UTF-8');
 
 		// Some buddies for you
 		if (in_array('buddies', $this->_summary_areas))
@@ -1285,21 +1284,22 @@ class ProfileInfo extends AbstractController
 		global $context, $modSettings;
 
 		// Would you be mine? Could you be mine? Be my buddy :D
-		$context['buddies'] = array();
+		$context['buddies'] = [];
 		if (!empty($modSettings['enable_buddylist'])
 			&& $context['user']['is_owner']
 			&& !empty($this->user->buddies)
 			&& in_array('buddies', $this->_summary_areas))
 		{
-			MembersList::load($this->user->buddies, false, 'profile');
-
-			// Get the info for this buddy
-			foreach ($this->user->buddies as $buddy)
+			if (MembersList::load($this->user->buddies, false, 'profile'))
 			{
-				$member = MembersList::get($buddy);
-				$member->loadContext(true);
+				// Get the info for this buddy
+				foreach ($this->user->buddies as $buddy)
+				{
+					$member = MembersList::get($buddy);
+					$member->loadContext(true);
 
-				$context['buddies'][$buddy] = $member;
+					$context['buddies'][$buddy] = $member;
+				}
 			}
 		}
 	}
@@ -1326,7 +1326,6 @@ class ProfileInfo extends AbstractController
 
 		// Flush everything since we intend to return the information to an ajax handler
 		theme()->getLayers()->removeAll();
-		header('Content-Type: text/html; charset=UTF-8');
 
 		// So, just what have you been up to?
 		if (in_array('posts', $this->_summary_areas))

--- a/sources/ElkArte/Errors/Errors.php
+++ b/sources/ElkArte/Errors/Errors.php
@@ -333,14 +333,16 @@ class Errors extends AbstractModel
 	private function _set_fatal_error_headers()
 	{
 		// Don't cache this page!
-		header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-		header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
-		header('Cache-Control: no-cache');
-
-		// Send the right error codes.
-		header('HTTP/1.1 503 Service Temporarily Unavailable');
-		header('Status: 503 Service Temporarily Unavailable');
-		header('Retry-After: 3600');
+		\ElkArte\Http\Headers::instance()
+			->httpCode(503)
+			->header('Expires', 'Mon, 26 Jul 1997 05:00:00 GMT')
+			->header('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT')
+			->header('Cache-Control', 'no-cache')
+			->contentType('text/html', 'UTF-8')
+			->headerSpecial('HTTP/1.1 503 Service Temporarily Unavailable')
+			->header('Status', '503 Service Temporarily Unavailable')
+			->header('Retry-After', '3600')
+			->sendHeaders();
 	}
 
 	/**

--- a/sources/ElkArte/Http/Headers.php
+++ b/sources/ElkArte/Http/Headers.php
@@ -13,7 +13,6 @@
 namespace ElkArte\Http;
 
 use ElkArte\HttpReq;
-use ElkArte\Notifications;
 
 class Headers
 {
@@ -100,30 +99,8 @@ class Headers
 	 */
 	public function send()
 	{
-		$this->maintance();
+		handleMaintance();
 		$this->sendHeaders();
-	}
-
-	/**
-	 * Do some maintance such as sending notifications, queuing mail, tracking stats
-	 */
-	public function maintance()
-	{
-		global $context;
-
-		// Lets stay on top of our mail queue by writing anything new to the db
-		if (!empty($context['flush_mail']))
-		{
-			// @todo this relies on 'flush_mail' being only set in AddMailQueue itself... :\
-			require_once(SUBSDIR . '/Mail.subs.php');
-			AddMailQueue(true);
-		}
-
-		// And send any notifications that have queued
-		Notifications::instance()->send();
-
-		// Clear out the stat cache.
-		trackStats();
 	}
 
 	/**

--- a/sources/ElkArte/Http/Headers.php
+++ b/sources/ElkArte/Http/Headers.php
@@ -1,0 +1,341 @@
+<?php
+
+/**
+ *
+ * @package   ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ *
+ * @version 2.0 dev
+ *
+ */
+
+namespace ElkArte\Http;
+
+use ElkArte\HttpReq;
+use ElkArte\Notifications;
+
+class Headers
+{
+	/** @var string Default content type */
+	protected $contentType = 'text/html';
+
+	/** @var string Default character set */
+	protected $charset = 'UTF-8';
+
+	/** @var int Default HTTP return code */
+	protected $httpCode = 200;
+
+	/** @var array Holds any normal headers collected */
+	protected $headers = [];
+
+	/** @var array Holds any special (raw) headers collected */
+	protected $specialHeaders = [];
+
+	/** @var \ElkArte\HttpReq|null */
+	protected $req;
+
+	/** @var \ElkArte\Http\Headers Sole private \ElkArte\HttpReq instance */
+	private static $header = null;
+
+	/**
+	 * Headers constructor.
+	 */
+	public function __construct()
+	{
+		$this->req = HttpReq::instance();
+	}
+
+	/**
+	 * Sets a redirect location header
+	 *
+	 * What it does:
+	 *
+	 * - Adds in scripturl if needed
+	 * - Calls call_integration_hook integrate_redirect before headers are sent
+	 *
+	 * @event integrate_redirect called before headers are sent
+	 * @param string $setLocation = '' The URL to redirect to
+	 * @param int $httpCode defaults to 200
+	 */
+	public function redirect($setLocation = '', $httpCode = null)
+	{
+		global $scripturl;
+
+		if ($setLocation === '')
+		{
+			return $this->header('Location');
+		}
+
+		// Convert relative URL to site url
+		if (preg_match('~^(ftp|http)[s]?://~', $setLocation) === 0)
+		{
+			$setLocation = $scripturl . ($setLocation !== '' ? '?' . $setLocation : '');
+		}
+
+		// Put the session ID in.
+		if (empty($_COOKIE) && defined('SID') && !empty(SID))
+		{
+			$setLocation = preg_replace('/^' . preg_quote($scripturl, '/') . '(?!\?' . preg_quote(SID, '/') . ')\\??/', $scripturl . '?' . SID . ';', $setLocation);
+		}
+		// Keep that debug in their for template debugging!
+		elseif (isset($this->req->debug))
+		{
+			$setLocation = preg_replace('/^' . preg_quote($scripturl, '/') . '\\??/', $scripturl . '?debug;', $setLocation);
+		}
+
+		// Maybe integrations want to change where we are heading?
+		call_integration_hook('integrate_redirect', array(&$setLocation));
+
+		// Set the location header and code
+		$this
+			->header('Location', $setLocation)
+			->httpCode = $httpCode ?? 302;
+
+		return $this;
+	}
+
+	/**
+	 * Run maintance function and then send the all collected headers
+	 */
+	public function send()
+	{
+		$this->maintance();
+		$this->sendHeaders();
+	}
+
+	/**
+	 * Do some maintance such as sending notifications, queuing mail, tracking stats
+	 */
+	public function maintance()
+	{
+		global $context;
+
+		// Lets stay on top of our mail queue by writing anything new to the db
+		if (!empty($context['flush_mail']))
+		{
+			// @todo this relies on 'flush_mail' being only set in AddMailQueue itself... :\
+			require_once(SUBSDIR . '/Mail.subs.php');
+			AddMailQueue(true);
+		}
+
+		// And send any notifications that have queued
+		Notifications::instance()->send();
+
+		// Clear out the stat cache.
+		trackStats();
+	}
+
+	/**
+	 * Normally used for a header that starts with the string "HTTP/" (case is not significant),
+	 * which will be used to figure out the HTTP status code to send.  You could stuff in any
+	 * complete header you wanted as the value is sent via header($value)
+	 *
+	 * @param $value
+	 * @return $this
+	 */
+	public function headerSpecial($value)
+	{
+		$this->specialHeaders[] = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Adds headers to the header array for eventual output to browser
+	 *
+	 * @param string $name Name of the header
+	 * @param string|null $value Value for the header
+	 *
+	 * @return $this
+	 */
+	public function header($name, $value = null)
+	{
+		$name = $this->standardizeHeaderName($name);
+
+		// Add new or overwrite
+		$this->headers[$name] = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Converts / Fixes header names in to a standard format to enable consistent
+	 * search replace is etc.
+	 *
+	 * @param string $name
+	 * @return string
+	 */
+	protected function standardizeHeaderName($name)
+	{
+		// Combine spaces and Convert dashes "clear    Site-Data" => "clear Site Data"
+		$name = preg_replace('~\s+~', ' ', str_replace('-', ' ', trim($name)));
+
+		// Now ucword the header and add back the dash => Clear-Site-Data
+		$name = str_replace(' ', '-', ucwords($name));
+
+		return $name;
+	}
+
+	/**
+	 * Set the http header code, like 404, 200, 301, etc  Only output if
+	 * content type is not empty
+	 *
+	 * @param int $httpCode
+	 * @return $this
+	 */
+	public function httpCode($httpCode)
+	{
+		$this->httpCode = intval($httpCode);
+
+		return $this;
+	}
+
+	/**
+	 * Sets the context type based on if this is an image or not.  Calls
+	 * setDownloadFileNameHeader to set the proper content disposition.
+	 *
+	 * @param string $mime_type
+	 * @param string $fileName
+	 * @param false $disposition
+	 * @return $this
+	 */
+	public function setAttachmentFileParams($mime_type, $fileName, $disposition = false)
+	{
+		// If its an image set the content type to the image/type defined in the mime_type
+		if (!empty($mime_type) && strpos($mime_type, 'image/') === 0)
+		{
+			$this->contentType($mime_type, '');
+		}
+		// Otherwise arbitrary binary data
+		else
+		{
+			$this->contentType('application/octet-stream', '');
+		}
+
+		// Set the content disposition and name
+		$this->setDownloadFileNameHeader($fileName, $disposition);
+
+		return $this;
+	}
+
+	/**
+	 * Set the proper filename header accounting for UTF-8 characters in the name
+	 *
+	 * @param string $fileName That would be the name
+	 * @param string $disposition 'inline' or 'attachment'
+	 */
+	private function setDownloadFileNameHeader($fileName, $disposition = false)
+	{
+		$type = ($disposition ? 'inline' : 'attachment');
+
+		$fileName = str_replace('"', '', $fileName);
+
+		// Send as UTF-8 if the name requires that
+		$altName = '';
+		if (preg_match('~[\x80-\xFF]~', $fileName))
+		{
+			$altName = "; filename*=UTF-8''" . rawurlencode($fileName);
+		}
+
+		$this->header('Content-Disposition',$type . '; filename="' . $fileName . '"' . $altName);
+
+		return $this;
+	}
+
+	/**
+	 * Sets the content type and character set.  Replaces an existing one if called multiple times
+	 * so the last call to this method will be what is output.
+	 *
+	 * @param string|null $contentType
+	 * @param string|null $charset
+	 * @return $this|string
+	 */
+	public function contentType($contentType, $charset = null)
+	{
+		$this->contentType = $contentType;
+
+		if ($charset !== null)
+		{
+			$this->charset($charset);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Sets the character set in use, defaults to utf-8
+	 *
+	 * @param null $charset
+	 * @return $this|string
+	 */
+	public function charset($charset = null)
+	{
+		$this->charset = $charset;
+
+		return $this;
+	}
+
+	/**
+	 * Removes a single header if set or all headers if we need to restart
+	 * the process, such as during an error or other.
+	 *
+	 * @param string $name
+	 * @return $this
+	 */
+	public function removeHeader($name)
+	{
+		// Full reset like nothing had been sent
+		if ($name === 'all')
+		{
+			$this->headers = [];
+			$this->specialHeaders = [];
+			$this->contentType = '';
+			$this->charset = 'UTF-8';
+			$this->httpCode = 200;
+		}
+
+		// Or remove a specific header
+		$name = $this->standardizeHeaderName($name);
+		unset($this->headers[$name]);
+
+		return $this;
+	}
+
+	/**
+	 * Send the collection of headers using standard php header() function
+	 */
+	public function sendHeaders()
+	{
+		foreach ($this->headers as $header => $value)
+		{
+			header("$header: $value", true);
+		}
+
+		foreach ($this->specialHeaders as $header)
+		{
+			header($header, true);
+		}
+
+		if ($this->contentType)
+		{
+			header('Content-Type: ' . $this->contentType
+				. ($this->charset ? '; charset=' . $this->charset : ''), true, $this->httpCode);
+		}
+	}
+
+	/**
+	 * Retrieve the sole instance of this class.
+	 *
+	 * @return \ElkArte\Http\Headers
+	 */
+	public static function instance()
+	{
+		if (self::$header === null)
+		{
+			self::$header = new Headers();
+		}
+
+		return self::$header;
+	}
+}

--- a/sources/ElkArte/Http/Headers.php
+++ b/sources/ElkArte/Http/Headers.php
@@ -197,10 +197,10 @@ class Headers
 	 *
 	 * @param string $mime_type
 	 * @param string $fileName
-	 * @param false $disposition
+	 * @param string $disposition 'attachment' or 'inline';
 	 * @return $this
 	 */
-	public function setAttachmentFileParams($mime_type, $fileName, $disposition = false)
+	public function setAttachmentFileParams($mime_type, $fileName, $disposition = 'attachment')
 	{
 		// If its an image set the content type to the image/type defined in the mime_type
 		if (!empty($mime_type) && strpos($mime_type, 'image/') === 0)
@@ -249,7 +249,7 @@ class Headers
 	 *
 	 * @param string|null $contentType
 	 * @param string|null $charset
-	 * @return $this|string
+	 * @return $this
 	 */
 	public function contentType($contentType, $charset = null)
 	{
@@ -266,10 +266,10 @@ class Headers
 	/**
 	 * Sets the character set in use, defaults to utf-8
 	 *
-	 * @param null $charset
-	 * @return $this|string
+	 * @param string $charset
+	 * @return $this
 	 */
-	public function charset($charset = null)
+	public function charset($charset)
 	{
 		$this->charset = $charset;
 

--- a/sources/ElkArte/MemberLoader.php
+++ b/sources/ElkArte/MemberLoader.php
@@ -140,6 +140,8 @@ class MemberLoader
 	 */
 	public function loadById($users, $set = MemberLoader::SET_NORMAL)
 	{
+		$users = array_filter(array_unique((array) $users));
+
 		// Can't just look for no users :P.
 		if (empty($users))
 		{
@@ -147,7 +149,6 @@ class MemberLoader
 		}
 
 		$this->set = $set;
-		$users = array_unique((array) $users);
 		$this->loaded_ids = [];
 		$this->loaded_members = [];
 
@@ -390,16 +391,16 @@ class MemberLoader
 	 */
 	public function loadByName($name, $set = MemberLoader::SET_NORMAL)
 	{
+		$users = array_filter(array_unique((array) $name));
+
 		// Can't just look for no users :P.
-		if (empty($name))
+		if (empty($users))
 		{
 			return false;
 		}
 
 		$this->set = $set;
-		$users = array_unique((array) $name);
 		$this->loaded_ids = [];
-
 		$this->loadByCondition('{column_case_insensitive:mem.member_name}' . (count($users) === 1 ? ' = {string_case_insensitive:users}' : ' IN ({array_string_case_insensitive:users})'), $users);
 
 		$this->loadModerators();

--- a/sources/ElkArte/Request.php
+++ b/sources/ElkArte/Request.php
@@ -13,7 +13,7 @@
 
 namespace ElkArte;
 
-use ElkArte\Util;
+use ElkArte\Http\Headers;
 
 /**
  * Class to parse $_REQUEST for always necessary data, such as 'action', 'board', 'topic', 'start'.
@@ -368,7 +368,10 @@ final class Request
 		// It seems that sticking a URL after the query string is mighty common, well, it's evil - don't.
 		if (strpos($_SERVER['QUERY_STRING'], 'http') === 0)
 		{
-			header('HTTP/1.1 400 Bad Request');
+			Headers::instance()
+				->removeHeader('all')
+				->headerSpecial('HTTP/1.1 400 Bad Request')
+				->sendHeaders();
 			throw new Exceptions\Exception('', false);
 		}
 

--- a/sources/ElkArte/Server.php
+++ b/sources/ElkArte/Server.php
@@ -161,8 +161,6 @@ class Server extends \ArrayObject
 				return $this->_is_web_server('lighttpd');
 			case 'litespeed':
 				return $this->_is_web_server('LiteSpeed');
-			case 'needs_login_fix':
-				return $this->is('cgi') && $this->_is_web_server('Microsoft-IIS');
 			case 'nginx':
 				return $this->_is_web_server('nginx');
 			case 'windows':

--- a/sources/ElkArte/Themes/Templates.php
+++ b/sources/ElkArte/Themes/Templates.php
@@ -16,6 +16,7 @@
 
 namespace ElkArte\Themes;
 
+use ElkArte\Http\Headers;
 use ElkArte\Themes\Directories;
 use BadFunctionCallException;
 use ElkArte\Debug;
@@ -271,9 +272,13 @@ class Templates
 		obStart();
 
 		// Don't cache error pages!!
-		header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-		header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
-		header('Cache-Control: no-cache');
+		Headers::instance()
+			->removeHeader('all')
+			->header('Expires', 'Mon, 26 Jul 1997 05:00:00 GMT')
+			->header('Last-Modified',  gmdate('D, d M Y H:i:s') . ' GMT')
+			->header('Cache-Control', 'no-cache')
+			->contentType('text/html', 'UTF-8')
+			->sendHeaders();
 
 		if (!isset($txt['template_parse_error']))
 		{

--- a/sources/ElkArte/UserSettingsLoader.php
+++ b/sources/ElkArte/UserSettingsLoader.php
@@ -162,7 +162,8 @@ class UserSettingsLoader
 		if ($this->cache->levelLowerThan(2) || $this->cache->getVar($user_settings, 'user_settings-' . $this->id, 60) === false)
 		{
 			$this_user = $this->db->fetchQuery('
-				SELECT mem.*, COALESCE(a.id_attach, 0) AS id_attach, a.filename, a.attachment_type
+				SELECT 
+					mem.*, COALESCE(a.id_attach, 0) AS id_attach, a.filename, a.attachment_type
 				FROM {db_prefix}members AS mem
 					LEFT JOIN {db_prefix}attachments AS a ON (a.id_member = {int:id_member})
 				WHERE mem.id_member = {int:id_member}
@@ -400,7 +401,7 @@ class UserSettingsLoader
 			'mentions' => max(0, (int) $this->settings->mentions),
 			'unread_messages' => (int) $this->settings->unread_messages,
 			'total_time_logged_in' => (int) $this->settings->total_time_logged_in,
-			'buddies' => !empty($modSettings['enable_buddylist']) ? explode(',', (string) $this->settings->buddy_list) : [],
+			'buddies' => !empty($modSettings['enable_buddylist']) ? (!empty($this->settings->buddy_list) ? explode(',', (string) $this->settings->buddy_list) : []) : [],
 			'ignoreboards' => explode(',', (string) $this->settings->ignore_boards),
 			'ignoreusers' => explode(',', (string) $this->settings->pm_ignore_list),
 			'warning' => (int) $this->settings->warning,

--- a/sources/Load.php
+++ b/sources/Load.php
@@ -18,6 +18,8 @@ use BBC\ParserWrapper;
 use ElkArte\Cache\Cache;
 use ElkArte\Debug;
 use ElkArte\Hooks;
+use ElkArte\Http\Headers;
+use ElkArte\Themes\ThemeLoader;
 use ElkArte\User;
 use ElkArte\Util;
 use ElkArte\AttachmentsDirectory;
@@ -252,8 +254,12 @@ function loadBoard()
 			new ElkArte\Themes\ThemeLoader();
 			if (!empty(User::$info->possibly_robot))
 			{
-				header('HTTP/1.1 410 Gone');
+				Headers::instance()
+					->removeHeader('all')
+					->headerSpecial('HTTP/1.1 410 Gone')
+					->sendHeaders();
 			}
+
 			throw new \ElkArte\Exceptions\Exception('topic_gone', false);
 		}
 	}
@@ -484,20 +490,27 @@ function loadBoard()
 		if (!empty($_REQUEST['action']) && $_REQUEST['action'] === 'dlattach')
 		{
 			ob_end_clean();
-			header('HTTP/1.1 403 Forbidden');
+			Headers::instance()
+				->removeHeader('all')
+				->headerSpecial('HTTP/1.1 403 Forbidden')
+				->sendHeaders();
 			exit;
 		}
 		elseif (User::$info->is_guest)
 		{
-			\ElkArte\Themes\ThemeLoader::loadLanguageFile('Errors');
+			ThemeLoader::loadLanguageFile('Errors');
 			is_not_guest($txt['topic_gone']);
 		}
 		else
 		{
 			if (!empty(User::$info->possibly_robot))
 			{
-				header('HTTP/1.1 410 Gone');
+				Headers::instance()
+					->removeHeader('all')
+					->headerSpecial('HTTP/1.1 410 Gone')
+					->sendHeaders();
 			}
+
 			throw new \ElkArte\Exceptions\Exception('topic_gone', false);
 		}
 	}
@@ -789,7 +802,7 @@ function loadEssentialThemeData()
 {
 	\ElkArte\Errors\Errors::instance()->log_deprecated('loadEssentialThemeData()', '\ElkArte\Themes\ThemeLoader::loadEssentialThemeData()');
 
-	return \ElkArte\Themes\ThemeLoader::loadEssentialThemeData();
+	return ThemeLoader::loadEssentialThemeData();
 }
 
 /**
@@ -1128,7 +1141,7 @@ function loadLanguage($template_name, $lang = '', $fatal = true, $force_reload =
 {
 	\ElkArte\Errors\Errors::instance()->log_deprecated('loadLanguage()', '\ElkArte\Themes\ThemeLoader::loadLanguageFile()');
 
-	return \ElkArte\Themes\ThemeLoader::loadLanguageFile($template_name, $lang, $fatal, $force_reload);
+	return ThemeLoader::loadLanguageFile($template_name, $lang, $fatal, $force_reload);
 }
 
 /**
@@ -1532,8 +1545,6 @@ function detectServer()
 		}
 
 		$context['server']['iso_case_folding'] = $server->is('iso_case_folding');
-		// A bug in some versions of IIS under CGI (older ones) makes cookie setting not work with Location: headers.
-		$context['server']['needs_login_fix'] = $server->is('needs_login_fix');
 	}
 
 	return $server;

--- a/sources/Security.php
+++ b/sources/Security.php
@@ -17,6 +17,7 @@
 
 use ElkArte\Controller\Auth;
 use ElkArte\EventManager;
+use ElkArte\Http\Headers;
 use ElkArte\OpenID;
 use ElkArte\TokenHash;
 use ElkArte\User;
@@ -878,7 +879,10 @@ function checkSession($type = 'post', $from_action = '', $is_fatal = true)
 		if (isset($_GET['xml']) || isset($_REQUEST['api']))
 		{
 			@ob_end_clean();
-			header('HTTP/1.1 403 Forbidden - Session timeout');
+			Headers::instance()
+				->removeHeader('all')
+				->headerSpecial('HTTP/1.1 403 Forbidden - Session timeout')
+				->sendHeaders();
 			die;
 		}
 		else
@@ -1844,7 +1848,7 @@ function frameOptionsHeader($override = null)
 	}
 
 	// Finally set it.
-	header('X-Frame-Options: ' . $option);
+	Headers::instance()->header('X-Frame-Options', $option);
 }
 
 /**
@@ -1865,8 +1869,9 @@ function securityOptionsHeader($override = null)
 {
 	if ($override !== true)
 	{
-		header('X-XSS-Protection: 1');
-		header('X-Content-Type-Options: nosniff');
+		Headers::instance()
+			->header('X-XSS-Protection', '1')
+			->header('X-Content-Type-Options', 'nosniff');
 	}
 }
 
@@ -1879,7 +1884,10 @@ function stop_prefetching()
 		|| (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] === 'prefetch'))
 	{
 		@ob_end_clean();
-		header('HTTP/1.1 403 Forbidden');
+		Headers::instance()
+			->removeHeader('all')
+			->headerSpecial('HTTP/1.1 403 Forbidden')
+			->sendHeaders();
 		die;
 	}
 }

--- a/sources/Session.php
+++ b/sources/Session.php
@@ -20,6 +20,7 @@
  *
  */
 
+use ElkArte\Http\Headers;
 use ElkArte\TokenHash;
 
 /**
@@ -114,7 +115,7 @@ function loadSession()
 		// Change it so the cache settings are a little looser than default.
 		if (!empty($modSettings['databaseSession_loose']) || (isset($_REQUEST['action']) && $_REQUEST['action'] == 'search'))
 		{
-			header('Cache-Control: private');
+			Headers::instance()->header('Cache-Control', 'private');
 		}
 	}
 

--- a/sources/index.php
+++ b/sources/index.php
@@ -5,10 +5,10 @@
  */
 
 // Look for Settings.php....
-if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
+if (file_exists(dirname(__FILE__, 2) . '/Settings.php'))
 {
 	// Found it!
-	require(dirname(dirname(__FILE__)) . '/Settings.php');
+	require(dirname(__FILE__, 2) . '/Settings.php');
 	header('Location: ' . $boardurl);
 }
 // Can't find it... just forget it.

--- a/sources/subs/Attachments.subs.php
+++ b/sources/subs/Attachments.subs.php
@@ -1423,12 +1423,11 @@ function bindMessageAttachments($id_msg, $attachment_ids)
  * @param bool $new If this is a new attachment, if so just returns a hash
  * @param string $file_hash The file hash
  *
- * @return null|string|string[]
+ * @return string
  * @todo this currently returns the hash if new, and the full filename otherwise.
  * Something messy like that.
  * @todo and of course everything relies on this behavior and work around it. :P.
  * Converters included.
- * @throws \Exception
  */
 function getAttachmentFilename($filename, $attachment_id, $dir = null, $new = false, $file_hash = '')
 {

--- a/sources/subs/Graphics.subs.php
+++ b/sources/subs/Graphics.subs.php
@@ -18,6 +18,7 @@
  *
  */
 
+use ElkArte\Http\Headers;
 use ElkArte\User;
 
 /**
@@ -418,12 +419,12 @@ function showCodeImage($code)
 	// Show the image.
 	if (function_exists('imagepng'))
 	{
-		header('Content-type: image/png');
+		Headers::instance()->contentType('image/png')->sendHeaders();
 		imagepng($code_image);
 	}
 	else
 	{
-		header('Content-type: image/gif');
+		Headers::instance()->contentType('image/gif')->sendHeaders();
 		imagegif($code_image);
 	}
 

--- a/sources/subs/Mail.subs.php
+++ b/sources/subs/Mail.subs.php
@@ -356,7 +356,6 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
  * @param bool $is_private
  * @param string|null $message_id
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Mail
  */
 function AddMailQueue($flush = false, $to_array = array(), $subject = '', $message = '', $headers = '', $send_html = false, $priority = 3, $is_private = false, $message_id = '')

--- a/sources/subs/ManageSearch.subs.php
+++ b/sources/subs/ManageSearch.subs.php
@@ -109,12 +109,14 @@ function createSphinxConfig()
 		@ob_end_clean();
 	}
 
-	header('Content-Encoding: none');
-	header('Pragma: no-cache');
-	header('Cache-Control: no-cache');
-	header('Connection: close');
-	header('Content-Disposition: attachment; filename="sphinx.conf"');
-	header('Content-Type: application/octet-stream');
+	\ElkArte\Http\Headers::instance()
+		->header('Content-Encoding', 'none')
+		->header('Pragma', 'no-cache')
+		->header('Cache-Control', 'no-cache')
+		->header('Connection', 'close')
+		->header('Content-Disposition', 'attachment; filename="sphinx.conf"')
+		->contentType('application/octet-stream')
+		->sendHeaders();
 
 	$weight_factors = array(
 		'age',

--- a/sources/subs/ManageSearch.subs.php
+++ b/sources/subs/ManageSearch.subs.php
@@ -115,7 +115,7 @@ function createSphinxConfig()
 		->header('Cache-Control', 'no-cache')
 		->header('Connection', 'close')
 		->header('Content-Disposition', 'attachment; filename="sphinx.conf"')
-		->contentType('application/octet-stream')
+		->contentType('application/octet-stream', '')
 		->sendHeaders();
 
 	$weight_factors = array(

--- a/sources/subs/Sound.subs.php
+++ b/sources/subs/Sound.subs.php
@@ -88,7 +88,6 @@ function createWaveFile($word)
 					}
 				}
 				break;
-
 			case 1:
 				for ($j = 0, $n = strlen($sound_letter) - 1; $j < $n; $j += 2)
 				{
@@ -96,7 +95,6 @@ function createWaveFile($word)
 				}
 				$sound_word .= str_repeat($sound_letter[$n], 2);
 				break;
-
 			case 2:
 				$shift = 0;
 				for ($j = 0, $n = strlen($sound_letter); $j < $n; $j++)
@@ -141,19 +139,23 @@ function createWaveFile($word)
 	}
 
 	// Set up our headers
-	header('Content-Encoding: none');
-	header('Content-Duration: ' . round($time, 0));
-	header('Content-Disposition: inline; filename="captcha.wav"');
-	header('Content-Type: audio/x-wav');
-	header('Cache-Control: no-cache');
-	header('Expires: ' . gmdate('D, d M Y H:i:s', time() + 525600 * 60) . ' GMT');
-	header('Accept-Ranges: bytes');
+	$headers = \ElkArte\Http\Headers::instance();
+	$headers
+		->header('Content-Encoding', 'none')
+		->header('Content-Duration', round($time, 0))
+		->header('Content-Disposition', 'inline; filename="captcha.wav"')
+		->contentType('audio/x-wav', '')
+		->header('Cache-Control', 'no-cache')
+		->header('Expires', gmdate('D, d M Y H:i:s', time() + 525600 * 60) . ' GMT')
+		->header('Accept-Ranges', 'bytes');
 
 	// Output the wav.
 	$range = set_range(strlen($wav));
 	$length = $range[1] - $range[0] + 1;
 	$stub = substr($wav, $range[0], $length);
-	header('Content-Length: ' . strlen($stub));
+	$headers
+		->header('Content-Length', strlen($stub))
+		->sendHeaders();
 	echo $stub;
 
 	return true;
@@ -194,8 +196,9 @@ function set_range($file_size)
 			$range = array($file_size - intval($matches[2]), $file_size - 1);
 		}
 
-		header('HTTP/1.1 206 Partial Content');
-		header('Content-Range: bytes ' . $range[0] . '-' . $range[1] . '/' . $file_size);
+		\ElkArte\Http\Headers::instance()
+			->headerSpecial('HTTP/1.1 206 Partial Content')
+			->header('Content-Range', 'bytes ' . $range[0] . '-' . $range[1] . '/' . $file_size);
 	}
 
 	return $range;

--- a/sources/subs/Sound.subs.php
+++ b/sources/subs/Sound.subs.php
@@ -17,6 +17,7 @@
  */
 
 use ElkArte\Cache\Cache;
+use ElkArte\Http\Headers;
 use ElkArte\User;
 
 /**
@@ -139,7 +140,7 @@ function createWaveFile($word)
 	}
 
 	// Set up our headers
-	$headers = \ElkArte\Http\Headers::instance();
+	$headers = Headers::instance();
 	$headers
 		->header('Content-Encoding', 'none')
 		->header('Content-Duration', round($time, 0))
@@ -196,7 +197,7 @@ function set_range($file_size)
 			$range = array($file_size - intval($matches[2]), $file_size - 1);
 		}
 
-		\ElkArte\Http\Headers::instance()
+		Headers::instance()
 			->headerSpecial('HTTP/1.1 206 Partial Content')
 			->header('Content-Range', 'bytes ' . $range[0] . '-' . $range[1] . '/' . $file_size);
 	}

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -15,9 +15,11 @@
  *
  */
 
-// Start things rolling by getting the forum alive...
+use ElkArte\Http\Headers;
+use ElkArte\Themes\ThemeLoader;
 use ElkArte\Util;
 
+// Start things rolling by getting the forum alive...
 if (!file_exists(dirname(__FILE__) . '/bootstrap.php'))
 {
 	die('Unable to initialize');
@@ -36,12 +38,12 @@ require_once(SUBSDIR . '/PaidSubscriptions.subs.php');
 require_once(SUBSDIR . '/Admin.subs.php');
 require_once(SUBSDIR . '/Members.subs.php');
 
-\ElkArte\Themes\ThemeLoader::loadLanguageFile('ManagePaid');
+ThemeLoader::loadLanguageFile('ManagePaid');
 
 // If there's literally nothing coming in, let's take flight!
 if (empty($_POST))
 {
-	header('Content-Type: text/html; charset=UTF-8');
+	Headers::instance()->contentType('text/html', 'UTF-8')->sendHeaders();
 	die($txt['paid_no_data']);
 }
 

--- a/themes/default/images/mime_images/index.php
+++ b/themes/default/images/mime_images/index.php
@@ -3,10 +3,10 @@
 // This file is here solely to protect your generic_images directory.
 
 // Look for Settings.php....
-if (file_exists(dirname(dirname(dirname(__FILE__))) . '/Settings.php'))
+if (file_exists(dirname(__FILE__, 3) . '/Settings.php'))
 {
 	// Found it!
-	require(dirname(dirname(dirname(__FILE__))) . '/Settings.php');
+	require(dirname(__FILE__, 3) . '/Settings.php');
 	header('Location: ' . $boardurl);
 }
 // Can't find it... just forget it.

--- a/themes/index.php
+++ b/themes/index.php
@@ -5,10 +5,10 @@ namespace Themes;
 // This file is here solely to protect your Themes directory.
 
 // Look for Settings.php....
-if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
+if (file_exists(dirname(__FILE__, 2) . '/Settings.php'))
 {
 	// Found it!
-	require(dirname(dirname(__FILE__)) . '/Settings.php');
+	require(dirname(__FILE__, 2) . '/Settings.php');
 	header('Location: ' . $boardurl);
 }
 // Can't find it... just forget it.


### PR DESCRIPTION
This moves ```header()``` calls to a class that simply accumulates them and then outputs them when requested.  Sending in a duplicate header replaces an existing ones.  Moved most of redirect to this class as well since that was header work with a maintance task.

The goal is to prevent headers already sent errors and allow an easy way to change a header before it ever gets sent.  Its a static method as where we do final output is not consolidated in one area.

Also updated the attachment area, the headers were a bit messy but I think they are all cleaned up now.  I also changed the compressed file output.  It now looks at the mime type and if its ```text/xyz``` it will attempt to compress the file.  This replaces the old file extension sniff.  It also drops the use of the output buffer to compress the file and instead calls gzencode directly on the file and echos that result.  This potentially uses more memory but the old method would not compress larger files due to buffer overflow and might use readfile or might use file get contents or might use fread .. the update simply uses one to keep it simple.

Bonus updates are a couple of bug fixes found while trying to test this.  Also the protection index.php files (which still have standard header calls) were updated to remove that ugly nested dirname stuff