### PR TITLE
Expose the (add/remove)Directory functions via the theme()->getLayers…

### DIFF
--- a/sources/ElkArte/Themes/Templates.php
+++ b/sources/ElkArte/Themes/Templates.php
@@ -502,4 +502,12 @@ class Templates
 			}
 		}
 	}
+
+    /**
+     * @return Template Directories
+     */
+    public function getDirectory()
+    {
+        return $this->dirs;
+    }
 }


### PR DESCRIPTION
…()->getDirectory() call

This allow's modifications to still add an external Theme directory outside of the Elkarte theme folder structure, similar to how you can on Elkarte 1.1