### PR TITLE
Latest collection of 1.1.7 updates

### DIFF
--- a/sources/subs/Emailpost.subs.php
+++ b/sources/subs/Emailpost.subs.php
@@ -133,6 +133,9 @@ function pbe_fix_email_body($body, $real_name = '', $charset = 'UTF-8')
 	// Remove the \r's now so its done
 	$body = trim(str_replace("\r", '', $body));
 
+	// Remove any control characters
+	$body = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $body);
+
 	// Remove the riff-raff as defined by the ACP filters
 	$body = pbe_filter_email_message($body);
 

--- a/sources/subs/Html2Md.class.php
+++ b/sources/subs/Html2Md.class.php
@@ -1216,7 +1216,7 @@ class Html_2_Md
 	{
 		global $txt;
 
-		$replacement = $this->line_end . '[' . $txt['link'] . '](' . trim($matches[0]) . ')';
+		$replacement = $this->line_end . '[' . $txt['link'] . ']( ' . trim($matches[0]) . ' )';
 
 		return $replacement;
 	}

--- a/sources/subs/Html2Md.class.php
+++ b/sources/subs/Html2Md.class.php
@@ -165,10 +165,12 @@ class Html_2_Md
 		// Wordwrap?
 		if (!empty($this->body_width))
 		{
+			$this->_check_line_lenght($this->markdown);
 			$this->markdown = $this->_utf8_wordwrap($this->markdown, $this->body_width, $this->line_end);
 		}
 
-		return $this->markdown;
+		// The null character will trigger a base64 version in outbound email
+		return $this->markdown . "\n\x00";
 	}
 
 	/**
@@ -402,7 +404,10 @@ class Html_2_Md
 		switch ($tag)
 		{
 			case 'a':
-				$markdown = $this->line_end . $this->_convert_anchor($node);
+				if ($node->getAttribute('data-lightboximage') || $node->getAttribute('data-lightboxmessage'))
+					$markdown = '~`skip`~';
+				else
+					$markdown = $this->line_end . $this->_convert_anchor($node) . $this->line_end;
 				break;
 			case 'abbr':
 				$markdown = $this->_convert_abbr($node);
@@ -449,7 +454,7 @@ class Html_2_Md
 				$markdown = $this->_convert_header($tag, $this->_get_value($node));
 				break;
 			case 'img':
-				$markdown = $this->_convert_image($node);
+				$markdown = $this->_convert_image($node) . $this->line_end;
 				break;
 			case 'ol':
 			case 'ul':
@@ -587,13 +592,8 @@ class Html_2_Md
 		}
 		else
 		{
-			// This will trigger a base64 version in our outbound email
-			$link = "\xF0\x9F\x94\x97";
-			$markdown = '[' . $value . '](' . $href . ' ' . $link . ')';
+			$markdown = '[' . $value . ']( ' . $href . ' )';
 		}
-
-		// Some links can be very long and if we wrap them they break
-		$this->_check_link_lenght($markdown);
 
 		return $markdown;
 	}
@@ -680,7 +680,7 @@ class Html_2_Md
 			{
 				// Adjust the word wrapping since this has code tags, leave it up to
 				// the email client to mess these up ;)
-				$this->_check_link_lenght($markdown, 5);
+				$this->_check_line_lenght($markdown, 5);
 
 				$markdown .= str_repeat(' ', 4) . $line . $this->line_end;
 			}
@@ -771,12 +771,6 @@ class Html_2_Md
 		{
 			$markdown = '![' . $alt . '](' . $src . ')';
 		}
-
-		// Adjust width if needed to maintain the image
-		$this->_check_link_lenght($markdown);
-
-		// Adjust width if needed to maintain the image
-		$this->_check_link_lenght($markdown);
 
 		return $markdown;
 	}
@@ -911,7 +905,7 @@ class Html_2_Md
 			}
 
 			// Adjust the word wrapping since this has a table, will get mussed by email anyway
-			$this->_check_link_lenght($rows[1], 2);
+			$this->_check_line_lenght($rows[1], 2);
 
 			// Return what we did so it can be swapped in
 			return implode($this->line_end, $rows);
@@ -1190,14 +1184,18 @@ class Html_2_Md
 	 * @param string $markdown
 	 * @param bool|int $buffer
 	 */
-	private function _check_link_lenght($markdown, $buffer = false)
+	private function _check_line_lenght($markdown, $buffer = false)
 	{
-		// Some links can be very long and if we wrap them they break
-		$line_strlen = Util::strlen($markdown) + (!empty($buffer) ? (int) $buffer : 0);
+		// Some Lines can be very long and if we wrap them they break
+		$lines = explode($this->line_end, $markdown);
+		foreach ($lines as $line)
+		{
+			$line_strlen = Util::strlen($line) + (!empty($buffer) ? (int) $buffer : 0);
 		if ($line_strlen > $this->body_width)
 		{
 			$this->body_width = $line_strlen;
 		}
+	}
 	}
 
 	/**
@@ -1205,7 +1203,7 @@ class Html_2_Md
 	 */
 	private function _convert_plaintxt_links()
 	{
-		$this->markdown = preg_replace_callback('/[^\(\/\]]((https?):\/\/|www\.)[-\p{L}0-9+&@#\/%?=~_|!:,.;]*[\p{L}0-9+&@#\/%=~_|]/iu', array($this, '_plaintxt_callback'), $this->markdown);
+		$this->markdown = preg_replace_callback('/((?<!\]\( |\]\()https?:\/\/|(?<!\]\( |\]\(|:\/\/)www)[-\p{L}0-9+&@#\/%?=~_|!:,.;]*[\p{L}0-9+&@#\/%=~_|]/iu', array($this, '_plaintxt_callback'), $this->markdown);
 	}
 
 	/**
@@ -1219,7 +1217,6 @@ class Html_2_Md
 		global $txt;
 
 		$replacement = $this->line_end . '[' . $txt['link'] . '](' . trim($matches[0]) . ')';
-		$this->_check_link_lenght($replacement);
 
 		return $replacement;
 	}

--- a/sources/subs/Mail.subs.php
+++ b/sources/subs/Mail.subs.php
@@ -251,7 +251,7 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 			$unq_head_array = array();
 
 			// If we are using the post by email functions, then we generate "reply to mail" security keys
-			if ($maillist)
+			if ($maillist && !empty($message_id) && $priority != 4)
 			{
 				$unq_head_array[0] = md5($boardurl . microtime() . rand());
 				$unq_head_array[1] = $message_type;
@@ -657,7 +657,7 @@ function smtp_mail($mail_to_array, $subject, $message, $headers, $priority, $mes
 
 		// Using the post by email functions, and not a digest (priority 4)
 		// then generate "reply to mail" keys and place them in the message
-		if (!empty($modSettings['maillist_enabled']) && $message_id !== null && $priority != 4)
+		if (!empty($modSettings['maillist_enabled']) && !empty($message_id) && $priority != 4)
 		{
 			$unq_head_array[0] = md5($scripturl . microtime() . rand());
 			$unq_head_array[1] = $message_type;

--- a/sources/subs/Package.subs.php
+++ b/sources/subs/Package.subs.php
@@ -2913,7 +2913,7 @@ function elk_chmod($file, $mode = null)
 {
 	$result = false;
 
-	if (!isset($mode))
+	if (empty($mode))
 	{
 		if (is_dir($file))
 		{
@@ -2926,6 +2926,7 @@ function elk_chmod($file, $mode = null)
 	}
 
 	// Make sure we have a form of 0777 or '777' or '0777' so its safe for intval '8'
+	$mode = trim($mode);
 	if ($mode == decoct(octdec("$mode")))
 		$result = @chmod($file, intval($mode, 8));
 

--- a/tests/sources/subs/Curl_Fetch_Webdata.class.Test.php
+++ b/tests/sources/subs/Curl_Fetch_Webdata.class.Test.php
@@ -27,7 +27,7 @@ class TestCurl_Fetch_Webdata extends PHPUnit_Framework_TestCase
 				'https://duckduckgo.com/html',
 				array('q' => 'elkarte', 'ia' => 'about'),
 				200,
-				'<b>ElkArte</b>, Free and Open Source Community Forum Software',
+				'Free and Open Source Community Forum Software',
 			),
 		);
 

--- a/tests/sources/subs/HTML2Md.class.Basic.php
+++ b/tests/sources/subs/HTML2Md.class.Basic.php
@@ -31,12 +31,12 @@ class TestHTML2Md extends PHPUnit_Framework_TestCase
 			array(
 				'Named links',
 				'<a href="http://www.elkarte.net/" class="bbc_link" target="_blank">ElkArte</a>',
-				'[ElkArte](http://www.elkarte.net/ 🔗)',
+				'[ElkArte]( http://www.elkarte.net/ )',
 			),
 			array(
 				'URL link',
 				'<a href="http://www.elkarte.net/" class="bbc_link" target="_blank">http://www.elkarte.net/</a>',
-				'[Link](http://www.elkarte.net/ 🔗)',
+				'[Link]( http://www.elkarte.net/ )',
 			),
 			array(
 				'Lists',
@@ -69,15 +69,12 @@ Before you can login, you first need to activate your account. To do so, please 
 Should you have any problems with activation, please visit https://www.awesomeforum.com/?action=register;sa=activate;u=12345 use the code "S5cv#4Xh".
 
 Gracias',
-				'Thank you for registering at Awesome Forum. Your username is SomeUser. If you forget your
-password, you can reset it by visiting
-[Link](https://www.awesomeforum.com/?action=reminder)
-Before you can login, you first need to activate your account. To do so, please follow this
-link:
-[Reg Link](https://www.awesomeforum.com/?action=register;sa=activate;u=12345;code=S5cv#4Xh 🔗)
-Should you have any problems with activation, please visit
-[Link](https://www.awesomeforum.com/?action=register;sa=activate;u=12345) use the code
-"S5cv#4Xh".
+				'Thank you for registering at Awesome Forum. Your username is SomeUser. If you forget your password, you can reset it by visiting 
+[Link]( https://www.awesomeforum.com/?action=reminder )
+Before you can login, you first need to activate your account. To do so, please follow this link:
+[Reg Link]( https://www.awesomeforum.com/?action=register;sa=activate;u=12345;code=S5cv#4Xh )
+Should you have any problems with activation, please visit 
+[Link]( https://www.awesomeforum.com/?action=register;sa=activate;u=12345 ) use the code "S5cv#4Xh".
 Gracias'
 			),
 		);
@@ -105,10 +102,10 @@ Gracias'
 			$parser = new Html_2_Md($test);
 
 			// Convert the html to bbc
-			$result = $parser->get_markdown();
+			$result = trim($parser->get_markdown(), "\x00");
 
 			// See if its the result we expect
-			$this->assertEquals($expected, $result);
+			$this->assertEquals($expected . "\n", $result, 'Error:: ' . str_replace("\n", "<br>", $result));
 		}
 	}
 }

--- a/themes/default/ManageMembergroups.template.php
+++ b/themes/default/ManageMembergroups.template.php
@@ -54,6 +54,7 @@ function template_new_group()
 					<dd>
 						<fieldset id="group_type">
 							<legend>', $txt['membergroups_edit_select_group_type'], '</legend>
+							<br />
 							<input type="radio" name="group_type" id="group_type_private" value="0" checked="checked" onclick="swapPostGroup(0);" />
 							<label for="group_type_private">', $txt['membergroups_group_type_private'], '</label><br />';
 
@@ -212,6 +213,7 @@ function template_edit_group()
 					<dd>
 						<fieldset id="group_type">
 							<legend>', $txt['membergroups_edit_select_group_type'], '</legend>
+							<br />
 							<input type="radio" name="group_type" id="group_type_private" value="0" ', !$context['group']['is_post_group'] && $context['group']['type'] == 0 ? 'checked="checked"' : '', ' onclick="swapPostGroup(0);" />
 							<label for="group_type_private">', $txt['membergroups_group_type_private'], '</label><br />';
 


### PR DESCRIPTION
- The current static array does not allow addons to supply their own unsubscribe method, this fixes that.
- ILA links in PBE were being double wrapped
- PBE code was being inserted in db and messages where it should not be (e.g. registration).  Harmless until you try to do an 1.0 to 1.1 upgrade since the db codes would be no conforming and the table update failed
- additional adjustments to pbe line length and base64 encoding codes
- the depreciated notice will really not be fixed here, ```octdec``` is likely getting a dec from the filesys and that makes it toss the error (or any whitespace as well which this does address)