### PR TITLE
some more html to md "fixes"

### DIFF
--- a/sources/subs/Html2Md.class.php
+++ b/sources/subs/Html2Md.class.php
@@ -458,7 +458,9 @@ class Html_2_Md
 				break;
 			case 'ol':
 			case 'ul':
-				$markdown = rtrim($this->_get_value($node)) . $this->line_break;
+				$markdown = $this->line_end . rtrim($this->_get_value($node)) . $this->line_break;
+				if ($this->_has_parent_list($node, $this->_parser))
+					$markdown = rtrim($this->_get_value($node)) . $this->line_end;
 				break;
 			case 'li':
 				$markdown = $this->_convert_list($node);

--- a/sources/subs/Html2Md.class.php
+++ b/sources/subs/Html2Md.class.php
@@ -1240,6 +1240,10 @@ class Html_2_Md
 		foreach ($strings as $string)
 		{
 			$in_quote = isset($string[0]) && $string[0] === '>';
+			if (empty($string))
+			{
+				$lines[] = '';
+			}
 			while (!empty($string))
 			{
 				// Get the next #width characters before a break (space, punctuation tab etc)

--- a/tests/sources/subs/HTML2Md.class.Basic.php
+++ b/tests/sources/subs/HTML2Md.class.Basic.php
@@ -71,10 +71,14 @@ Should you have any problems with activation, please visit https://www.awesomefo
 Gracias',
 				'Thank you for registering at Awesome Forum. Your username is SomeUser. If you forget your password, you can reset it by visiting 
 [Link]( https://www.awesomeforum.com/?action=reminder )
+
 Before you can login, you first need to activate your account. To do so, please follow this link:
+
 [Reg Link]( https://www.awesomeforum.com/?action=register;sa=activate;u=12345;code=S5cv#4Xh )
+
 Should you have any problems with activation, please visit 
 [Link]( https://www.awesomeforum.com/?action=register;sa=activate;u=12345 ) use the code "S5cv#4Xh".
+
 Gracias'
 			),
 		);

--- a/tests/sources/subs/HTML2Md.class.Basic.php
+++ b/tests/sources/subs/HTML2Md.class.Basic.php
@@ -45,7 +45,7 @@ class TestHTML2Md extends PHPUnit_Framework_TestCase
 			),
 			array(
 				'Table',
-				'<h3>Simple table</h3><br /><table><thead><tr><th>Header 1</th><th>Header 2</th></tr></thead><tbody><tr><td>Cell 1</td><td>Cell 2</td></tr><tr><td>Cell 3</td><td>Cell 4</td></tr></tbody></table>',
+				'<h3>Simple table</h3><table><thead><tr><th>Header 1</th><th>Header 2</th></tr></thead><tbody><tr><td>Cell 1</td><td>Cell 2</td></tr><tr><td>Cell 3</td><td>Cell 4</td></tr></tbody></table>',
 				"### Simple table\n\n| Header 1 | Header 2 |\n| -------- | -------- | \n| Cell 1   | Cell 2   |\n| Cell 3   | Cell 4   |",
 			),
 			array(


### PR DESCRIPTION
In a previous PR I fixed some nagging line length issues (well lets be honest, its just only a bit better) However that fix forced things through the wrapping function which in review eats empty ```\n``` lines.  

So this update address that functional error and what were likely a couple of "fixes" to work around that behavior, one with nested lists and one with too few line ends compared to the supplied makrup.

Could there be more bumps in here? Why yes, yes there could.