### PR TITLE
An oldie but a goodie

### DIFF
--- a/sources/subs/Html2Md.class.php
+++ b/sources/subs/Html2Md.class.php
@@ -270,6 +270,9 @@ class Html_2_Md
 			'&gt|?|' => '>?'
 		));
 
+		// We may have hidden content ending in ?<br /> due to the above
+		$this->markdown = str_replace('<br />', "\n\n", $this->markdown);
+
 		// Strip the chaff and any excess blank lines we may have produced
 		$this->markdown = trim($this->markdown);
 		$this->markdown = preg_replace("~(\n(\s)?){3,}~", "\n\n", $this->markdown);


### PR DESCRIPTION
The protection of xml tags so dom parser does not fail, can also silently hide html tags that should be converted to MD

This just fixes the annoying one where you end a sentence with?

So just like above that now trailing ```<br />```, complements of the BBC parser, is hidden during the html->md conversion and then its restored at the end, resulting in``` ?<br />``` being created in the MD output.  This PR fixes the "br" single case.  There have to be others as well, but thats for 2.0