### PR TITLE
Only docblock the exceptions from where they are actually thrown

### DIFF
--- a/sources/subs/Admin.subs.php
+++ b/sources/subs/Admin.subs.php
@@ -27,7 +27,6 @@ use ElkArte\User;
  *
  * @return array
  * @package Admin
- * @throws \ImagickException
  */
 function getServerVersions($checkFor)
 {
@@ -447,7 +446,6 @@ function updateAdminPreferences()
  * @param string $template
  * @param mixed[] $replacements
  * @param int[] $additional_recipients
- * @throws \ElkArte\Exceptions\Exception
  * @package Admin
  */
 function emailAdmins($template, $replacements = array(), $additional_recipients = array())
@@ -534,7 +532,6 @@ function emailAdmins($template, $replacements = array(), $additional_recipients 
  * @param bool $value the "new" status of the profile fields
  * (true => enabled, false => disabled)
  * @package Admin
- * @throws \ElkArte\Exceptions\Exception
  */
 function custom_profiles_toggle_callback($value)
 {
@@ -604,7 +601,6 @@ function postbyemail_toggle_callback($value)
  * @param string[] $controllers list of controllers on which the module is
  *                 activated
  * @package Admin
- * @throws \ElkArte\Exceptions\Exception
  */
 function enableModules($module, $controllers)
 {
@@ -634,7 +630,6 @@ function enableModules($module, $controllers)
  * @param string[] $controllers list of controllers on which the module is
  *                 activated
  * @package Admin
- * @throws \ElkArte\Exceptions\Exception
  */
 function disableModules($module, $controllers)
 {

--- a/sources/subs/Attachments.subs.php
+++ b/sources/subs/Attachments.subs.php
@@ -552,7 +552,6 @@ function getAttachmentFromTopic($id_attach, $id_topic)
  *
  * @return array
  * @package Attachments
- * @throws \Exception
  */
 function getAttachmentThumbFromTopic($id_attach, $id_topic)
 {
@@ -634,7 +633,6 @@ function getAttachmentThumbFromTopic($id_attach, $id_topic)
  *
  * @return array|bool
  * @package Attachments
- * @throws \Exception
  */
 function isAttachmentImage($id_attach)
 {
@@ -678,7 +676,6 @@ function isAttachmentImage($id_attach)
  *
  * @param int $id_attach
  * @package Attachments
- * @throws \ElkArte\Exceptions\Exception
  */
 function increaseDownloadCounter($id_attach)
 {
@@ -710,7 +707,6 @@ function increaseDownloadCounter($id_attach)
  * @param int $max_width
  * @param int $max_height
  * @return bool whether the download and resize was successful.
- * @throws \ElkArte\Exceptions\Exception
  * @package Attachments
  */
 function saveAvatar($temporary_path, $memID, $max_width, $max_height)
@@ -887,7 +883,6 @@ function url_image_size($url)
  *
  * @return string
  * @package Attachments
- * @throws \Exception
  */
 function getAvatarPath()
 {
@@ -909,7 +904,6 @@ function getAvatarPath()
  * and the ID of the current attachment folder otherwise.
  * NB: the latter could also be 1.
  * @package Attachments
- * @throws \Exception
  */
 function getAvatarPathID()
 {
@@ -938,7 +932,6 @@ function getAvatarPathID()
  *
  * @return array
  * @package Attachments
- * @throws \Exception
  */
 function getAttachments($messages, $includeUnapproved = false, $filter = null, $all_posters = array())
 {
@@ -1083,7 +1076,6 @@ function getServerStoredAvatars($directory)
  * @param int $old_id_thumb = 0 id of thumbnail to remove, such as from our post form
  * @param string $real_filename the fully qualified hash name of where the file is
  * @return array The updated information
- * @throws \ElkArte\Exceptions\Exception
  * @package Attachments
  */
 function updateAttachmentThumbnail($filename, $id_attach, $id_msg, $old_id_thumb = 0, $real_filename = '')
@@ -1214,7 +1206,6 @@ function attachmentsSizeForMessage($id_msg, $include_count = true)
  * @todo change this pre-condition, too fragile and error-prone.
  *
  * @package Attachments
- * @throws \ElkArte\Exceptions\Exception
  */
 function loadAttachmentContext($id_msg)
 {

--- a/sources/subs/Auth.subs.php
+++ b/sources/subs/Auth.subs.php
@@ -194,7 +194,6 @@ function url_parts($local, $global)
  *   wanted if their password is correct, otherwise they can try again.
  *
  * @param string $type = 'admin'
- * @throws \ElkArte\Exceptions\Exception
  * @package Authorization
  */
 function adminLogin($type = 'admin')
@@ -352,7 +351,6 @@ function construct_query_string($get)
  * @param bool $buddies_only = false,
  * @param int $max = 500 retrieves a maximum of max members, if passed
  * @return array containing information about the matching members
- * @throws \ElkArte\Exceptions\Exception
  * @package Authorization
  */
 function findMembers($names, $use_wildcards = false, $buddies_only = false, $max = 500)
@@ -541,7 +539,6 @@ function resetPassword($memID, $username = null)
  * @param bool $check_reserved_name
  * @param bool $fatal pass through to isReservedName
  * @return string
- * @throws \ElkArte\Exceptions\Exception
  * @package Authorization
  */
 function validateUsername($memID, $username, $ErrorContext = 'register', $check_reserved_name = true, $fatal = true)
@@ -888,7 +885,6 @@ function findUser($where, $where_params, $fatal = true)
  * @param string $email
  * @param string|null $username
  * @return false|int on failure, int of member on success
- * @throws \Exception
  * @package Authorization
  */
 function userByEmail($email, $username = null)
@@ -938,7 +934,6 @@ function generateValidationCode($length = 10)
  * @param string $name
  * @param bool $is_id if true it treats $name as a member ID and try to load the data for that ID
  * @return mixed[]|false false if nothing is found
- * @throws \Exception
  * @package Authorization
  */
 function loadExistingMember($name, $is_id = false)

--- a/sources/subs/Bans.subs.php
+++ b/sources/subs/Bans.subs.php
@@ -47,7 +47,6 @@ use ElkArte\Util;
  * @param int $member
  * @param int $trigger_id
  * @return mixed array with the saved triggers or false on failure
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  */
 function saveTriggers($suggestions, $ban_group, $member = 0, $trigger_id = 0)
@@ -119,7 +118,6 @@ function saveTriggers($suggestions, $ban_group, $member = 0, $trigger_id = 0)
  * @param int[]|int $items_ids
  * @param int|bool $group_id
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  */
 function removeBanTriggers($items_ids = array(), $group_id = false)
@@ -182,7 +180,6 @@ function removeBanTriggers($items_ids = array(), $group_id = false)
  *
  * @param int[]|int $group_ids
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  */
 function removeBanGroups($group_ids)
@@ -222,7 +219,6 @@ function removeBanGroups($group_ids)
  *
  * @param int[]|int|null $ids (optional)
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  */
 function removeBanLogs($ids = array())
@@ -268,7 +264,6 @@ function removeBanLogs($ids = array())
  * @param mixed[] $triggers
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  *
  */
@@ -443,7 +438,6 @@ function validateTriggers(&$triggers)
  * @param mixed[] $triggers associative array of trigger keys and the values
  * @param mixed[] $logs
  * @return bool
- * @throws \Exception
  * @package Bans
  */
 function addTriggers($group_id = 0, $triggers = array(), $logs = array())
@@ -550,7 +544,6 @@ function addTriggers($group_id = 0, $triggers = array(), $logs = array())
  * @param int $group_id
  * @param mixed[] $trigger associative array of ban trigger => value
  * @param mixed[] $logs
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  */
 function updateTriggers($ban_item = 0, $group_id = 0, $trigger = array(), $logs = array())
@@ -672,7 +665,6 @@ function logTriggersUpdates($logs, $new = true)
  *
  * @param mixed[] $ban_info
  * @return int|bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  */
 function updateBanGroup($ban_info = array())
@@ -753,7 +745,6 @@ function updateBanGroup($ban_info = array())
  *
  * @param mixed[] $ban_info
  * @return int the ban group's ID
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  */
 function insertBanGroup($ban_info = array())
@@ -910,7 +901,6 @@ function range2ip($low, $high)
  * @param string $fullip
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  *
  */
@@ -1162,7 +1152,6 @@ function getMemberData($id)
  * @param string $sort A string indicating how to sort the results
  * @param string $trigger_type
  * @return array
- * @throws \Exception
  * @package Bans
  */
 function list_getBanTriggers($start, $items_per_page, $sort, $trigger_type)
@@ -1202,7 +1191,6 @@ function list_getBanTriggers($start, $items_per_page, $sort, $trigger_type)
  * @param string $email
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  *
  */
@@ -1295,7 +1283,6 @@ function BanCheckUser($memID, $hostname = '', $email = '')
  *
  * @param string $trigger_type
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  */
 function list_getNumBanTriggers($trigger_type)
@@ -1333,7 +1320,6 @@ function list_getNumBanTriggers($trigger_type)
  * @param string $sort A string indicating how to sort the results
  *
  * @return array
- * @throws \Exception
  * @package Bans
  *
  */
@@ -1378,7 +1364,6 @@ function list_getNumBanLogEntries()
  * Get the total number of ban from the ban group table
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  */
 function list_getNumBans()
@@ -1514,7 +1499,6 @@ function list_getBanItems($start = 0, $items_per_page = 0, $sort = 0, $ban_group
  * @param int $items_per_page The number of items to show per page
  * @param string $sort A string indicating how to sort the results
  * @return array
- * @throws \Exception
  * @package Bans
  */
 function list_getBans($start, $items_per_page, $sort)
@@ -1540,7 +1524,6 @@ function list_getBans($start, $items_per_page, $sort)
  * Gets the number of ban items belonging to a certain ban group
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  */
 function list_getNumBanItems()
@@ -1573,7 +1556,6 @@ function list_getNumBanItems()
  * @param int $member_id
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  *
  */
@@ -1607,7 +1589,6 @@ function banLoadAdditionalIPsMember($member_id)
  * @param int $member_id
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Bans
  *
  */
@@ -1669,7 +1650,6 @@ function banLoadAdditionalIPs($member_id)
  * @param int|bool $ban_group
  *
  * @return array
- * @throws \Exception
  * @package Bans
  *
  */

--- a/sources/subs/Cache.subs.php
+++ b/sources/subs/Cache.subs.php
@@ -29,7 +29,6 @@ use ElkArte\Cache\CacheMethod\AbstractCacheMethod;
  * @param int $level = 1
  *
  * @return mixed
- * @throws \Exception
  * @deprecated since 2.0
  *
  */
@@ -53,7 +52,6 @@ function cache_quick_get($key, $file, $function, $params, $level = 1)
  * @param string $key
  * @param string|int|mixed[]|null $value
  * @param int $ttl = 120
- * @throws \Exception
  * @deprecated since 2.0
  *
  */
@@ -73,7 +71,6 @@ function cache_put_data($key, $value, $ttl = 120)
  * @param int $ttl = 120
  *
  * @return bool|null
- * @throws \Exception
  * @deprecated since 2.0
  *
  */
@@ -95,7 +92,6 @@ function cache_get_data($key, $ttl = 120)
  * For cache engines that do not distinguish on types, a full cache flush will be done
  *
  * @param string $type = ''
- * @throws \Exception
  * @deprecated since 2.0
  *
  */

--- a/sources/subs/Calendar.subs.php
+++ b/sources/subs/Calendar.subs.php
@@ -29,7 +29,6 @@ use ElkArte\Util;
  * @param string $low_date inclusive, YYYY-MM-DD
  * @param string $high_date inclusive, YYYY-MM-DD
  * @return mixed[] days, each of which an array of birthday information for the context
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function getBirthdayRange($low_date, $high_date)
@@ -111,7 +110,6 @@ function getBirthdayRange($low_date, $high_date)
  * @param bool $use_permissions = true
  * @param int|null $limit
  * @return array contextual information if use_permissions is true, and an array of the data needed to build that otherwise
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function getEventRange($low_date, $high_date, $use_permissions = true, $limit = null)
@@ -245,7 +243,6 @@ function getEventRange($low_date, $high_date, $use_permissions = true, $limit = 
  * @param string $low_date YYYY-MM-DD
  * @param string $high_date YYYY-MM-DD
  * @return array an array of days, which are all arrays of holiday names.
- * @throws \Exception
  * @package Calendar
  */
 function getHolidayRange($low_date, $high_date)
@@ -309,6 +306,7 @@ function getHolidayRange($low_date, $high_date)
  *
  * @package Calendar
  * @todo pass $board, $topic and User::$info->id as arguments with fallback for 1.1
+ * @throws \ElkArte\Exceptions\Exception missing_board_id, missing_topic_id
  */
 function canLinkEvent()
 {
@@ -830,7 +828,6 @@ function cache_getRecentEvents($eventOptions)
  *
  * @param mixed[] $cache_block
  * @param mixed[] $params
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function cache_getRecentEvents_post_retri_eval(&$cache_block, $params)
@@ -890,7 +887,6 @@ function cache_getRecentEvents_post_retri_eval(&$cache_block, $params)
  *
  * @param int $event_id
  * @return int|bool the id of the poster or false if the event was not found
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function getEventPoster($event_id)
@@ -933,7 +929,6 @@ function getEventPoster($event_id)
  * - does not check any permissions of any sort.
  *
  * @param mixed[] $eventOptions
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function insertEvent(&$eventOptions)
@@ -1001,7 +996,6 @@ function insertEvent(&$eventOptions)
  *
  * @param int $event_id
  * @param mixed[] $eventOptions
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function modifyEvent($event_id, &$eventOptions)
@@ -1074,7 +1068,6 @@ function modifyEvent($event_id, &$eventOptions)
  * - does no permission checks.
  *
  * @param int $event_id
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function removeEvent($event_id)
@@ -1102,7 +1095,6 @@ function removeEvent($event_id)
  * @param int $event_id
  * @param bool $calendar_only
  * @return mixed[]|bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function getEventProperties($event_id, $calendar_only = false)
@@ -1172,7 +1164,6 @@ function getEventProperties($event_id, $calendar_only = false)
  * @param int $id_topic
  *
  * @return array
- * @throws \Exception
  * @package Calendar
  *
  */
@@ -1201,7 +1192,6 @@ function eventInfoForTopic($id_topic)
  * @param int $items_per_page The number of items to show per page
  * @param string $sort A string indicating how to sort the results
  * @return array
- * @throws \Exception
  * @package Calendar
  */
 function list_getHolidays($start, $items_per_page, $sort)
@@ -1224,7 +1214,6 @@ function list_getHolidays($start, $items_per_page, $sort)
  * Helper function to get the total number of holidays
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function list_getNumHolidays()
@@ -1247,7 +1236,6 @@ function list_getNumHolidays()
  * Remove a holiday from the calendar.
  *
  * @param int|int[] $holiday_ids An array of ids for holidays.
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function removeHolidays($holiday_ids)
@@ -1278,7 +1266,6 @@ function removeHolidays($holiday_ids)
  * @param int $holiday
  * @param int $date
  * @param string $title
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function editHoliday($holiday, $date, $title)
@@ -1307,7 +1294,6 @@ function editHoliday($holiday, $date, $title)
  *
  * @param int $date
  * @param string $title
- * @throws \ElkArte\Exceptions\Exception
  * @package Calendar
  */
 function insertHoliday($date, $title)
@@ -1335,7 +1321,6 @@ function insertHoliday($date, $title)
  *
  * @param int $id_holiday
  * @return array
- * @throws \Exception
  * @package Calendar
  */
 function getHoliday($id_holiday)

--- a/sources/subs/Categories.subs.php
+++ b/sources/subs/Categories.subs.php
@@ -23,7 +23,6 @@ use ElkArte\BoardsTree;
  *
  * @param int $category_id
  * @param mixed[] $catOptions
- * @throws \ElkArte\Exceptions\Exception
  */
 function modifyCategory($category_id, $catOptions)
 {
@@ -138,7 +137,6 @@ function modifyCategory($category_id, $catOptions)
  * returns the ID of the newly created category.
  *
  * @param mixed[] $catOptions
- * @throws \Exception
  */
 function createCategory($catOptions)
 {
@@ -202,7 +200,6 @@ function createCategory($catOptions)
  *
  * @param int[] $categories
  * @param int|null $moveBoardsTo = null
- * @throws \ElkArte\Exceptions\Exception
  */
 function deleteCategories($categories, $moveBoardsTo = null)
 {
@@ -282,7 +279,6 @@ function deleteCategories($categories, $moveBoardsTo = null)
  * @param string $new_status
  * @param int[]|null $members = null
  * @param bool $check_collapsable = true
- * @throws \ElkArte\Exceptions\Exception
  */
 function collapseCategories($categories, $new_status, $members = null, $check_collapsable = true)
 {
@@ -384,7 +380,6 @@ function collapseCategories($categories, $new_status, $members = null, $check_co
  *
  * @param int $id_cat
  * @return string
- * @throws \ElkArte\Exceptions\Exception
  */
 function categoryName($id_cat)
 {

--- a/sources/subs/Drafts.subs.php
+++ b/sources/subs/Drafts.subs.php
@@ -21,7 +21,6 @@ use ElkArte\Util;
  *
  * @param mixed[] $draft
  * @param string[] $recipientList
- * @throws \Exception
  * @package Drafts
  */
 function create_pm_draft($draft, $recipientList)
@@ -66,7 +65,6 @@ function create_pm_draft($draft, $recipientList)
  *
  * @param mixed[] $draft
  * @param string[] $recipientList
- * @throws \ElkArte\Exceptions\Exception
  * @package Drafts
  */
 function modify_pm_draft($draft, $recipientList)
@@ -102,7 +100,6 @@ function modify_pm_draft($draft, $recipientList)
  * Create a new post draft in the database
  *
  * @param mixed[] $draft
- * @throws \Exception
  * @package Drafts
  */
 function create_post_draft($draft)
@@ -156,7 +153,6 @@ function create_post_draft($draft)
  * Update a Post draft with the supplied data
  *
  * @param mixed[] $draft
- * @throws \ElkArte\Exceptions\Exception
  * @package Drafts
  */
 function modify_post_draft($draft)
@@ -208,7 +204,6 @@ function modify_post_draft($draft)
  * @param bool $check - validate the draft is by the user, true by default
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Drafts
  *
  */
@@ -264,7 +259,6 @@ function load_draft($id_draft, $uid, $type = 0, $drafts_keep_days = 0, $check = 
  * @param string $limit - optional parameter to limit the number returned 0,15
  *
  * @return array
- * @throws \Exception
  * @package Drafts
  *
  */
@@ -316,7 +310,6 @@ function load_user_drafts($member_id, $draft_type = 0, $topic = false, $order = 
  * @param bool $check
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Drafts
  *
  */
@@ -360,7 +353,6 @@ function deleteDrafts($id_draft, $member_id = -1, $check = true)
  * @param int $member_id
  * @param int $draft_type
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Drafts
  */
 function draftsCount($member_id, $draft_type = 0)
@@ -431,7 +423,6 @@ function draftsRecipients($allRecipients, $recipient_ids)
  * @param int $days
  *
  * @return array
- * @throws \Exception
  * @package Drafts
  *
  */
@@ -463,7 +454,6 @@ function getOldDrafts($days)
  *
  * @param mixed[] $draft
  * @param bool $check_last_save
- * @throws \ElkArte\Exceptions\Exception
  * @package Drafts
  */
 function saveDraft($draft, $check_last_save = false)
@@ -538,7 +528,6 @@ function saveDraft($draft, $check_last_save = false)
  * @param bool $check_last_save
  *
  * @return bool|void
- * @throws \ElkArte\Exceptions\Exception
  * @package Drafts
  *
  */
@@ -653,7 +642,6 @@ function prepareDraft(&$draft, $draft_info)
  * @param bool $load - load it for use in a form
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Drafts
  *
  */

--- a/sources/subs/Editor.subs.php
+++ b/sources/subs/Editor.subs.php
@@ -37,7 +37,6 @@ use ElkArte\User;
  *   - preview_type => 2 how to act on preview click, see template_control_richedit_buttons
  *
  * @event integrate_editor_plugins
- * @throws \ElkArte\Exceptions\Exception
  * @uses GenericControls template
  * @uses Post language
  */

--- a/sources/subs/Emailpost.subs.php
+++ b/sources/subs/Emailpost.subs.php
@@ -44,7 +44,6 @@ use ElkArte\Util;
  * @uses Html2BBC.class.php for the html to bbc conversion
  * @uses markdown.php for text to html conversions
  * @package Maillist
- * @throws \Exception
  */
 function pbe_email_to_bbc($text, $html)
 {
@@ -110,7 +109,6 @@ function pbe_email_to_bbc($text, $html)
  *
  * @param string $text
  * @return string
- * @throws \Exception
  */
 function pbe_run_parsers($text)
 {
@@ -144,7 +142,6 @@ function pbe_run_parsers($text)
  * @param string $charset character set of the text
  *
  * @return mixed|null|string|string[]
- * @throws \Exception
  * @package Maillist
  *
  * @uses EmailFormat.class.php
@@ -361,7 +358,6 @@ function pbe_email_quote_depth(&$string, $update = true)
  *
  * @param string $body
  * @return bool on find
- * @throws \Exception
  * @package Maillist
  */
 function pbe_parse_email_message(&$body)
@@ -426,7 +422,6 @@ function pbe_parse_email_message(&$body)
  * @param string $text
  *
  * @return mixed|null|string|string[]
- * @throws \Exception
  * @package Maillist
  *
  */
@@ -691,7 +686,6 @@ function pbe_check_moderation(&$pbe)
  * @param \ElkArte\EmailParse $email_message
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  *
  */
@@ -835,7 +829,6 @@ function pbe_emailError($error, $email_message)
  * @param \ElkArte\EmailParse $email_message
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  *
  */
@@ -1108,7 +1101,6 @@ function pbe_prepare_text(&$message, &$subject = '', &$signature = '')
  * When finished, fire off a site notification informing the user of the action and reason
  *
  * @param \ElkArte\EmailParse $email_message
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  */
 function pbe_disable_user_notify($email_message)
@@ -1226,7 +1218,6 @@ function quote_callback_2($matches)
  * @param string $email
  *
  * @return array|bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  *
  */
@@ -1326,7 +1317,6 @@ function query_load_user_info($email)
  * @param string $type board to load board permissions, otherwise general permissions
  * @param mixed[] $pbe
  * @param mixed[] $topic_info
- * @throws \Exception
  * @package Maillist
  */
 function query_load_permissions($type, &$pbe, $topic_info = array())
@@ -1377,7 +1367,6 @@ function query_load_permissions($type, &$pbe, $topic_info = array())
  *
  * @param string $from
  * @return mixed[]
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  */
 function query_sender_wrapper($from)
@@ -1419,7 +1408,6 @@ function query_sender_wrapper($from)
  * @param string $email email address to lookup
  *
  * @return array
- * @throws \Exception
  * @package Maillist
  *
  */
@@ -1445,7 +1433,6 @@ function query_user_keys($email)
  *
  * @param \ElkArte\EmailParse $email_message
  * @return string email address the key was sent to
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  */
 function query_key_owner($email_message)
@@ -1488,7 +1475,6 @@ function query_key_owner($email_message)
  * @param string $email
  *
  * @return bool|string
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  *
  */
@@ -1588,7 +1574,6 @@ function query_load_subject($message_id, $message_type, $email)
  * @param mixed[] $pbe
  *
  * @return array|bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  *
  */
@@ -1671,7 +1656,6 @@ function query_load_message($message_type, $message_id, $pbe)
  * @param int $message_id
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  *
  */
@@ -1700,7 +1684,6 @@ function query_load_board($message_id)
  * @param int $board_id
  * @param mixed[] $pbe
  * @return mixed[]
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  */
 function query_load_board_details($board_id, $pbe)
@@ -1734,7 +1717,6 @@ function query_load_board_details($board_id, $pbe)
  * @param mixed[] $board_info
  *
  * @return array
- * @throws \Exception
  * @package Maillist
  *
  */
@@ -1791,7 +1773,6 @@ function query_get_theme($id_member, $id_theme, $board_info)
  * @param int $id_topic
  * @param bool $auto_notify
  * @param mixed[] $permissions
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  */
 function query_notifications($id_member, $id_board, $id_topic, $auto_notify, $permissions)
@@ -1853,7 +1834,6 @@ function query_notifications($id_member, $id_board, $id_topic, $auto_notify, $pe
  *
  * @param \ElkArte\EmailParse $email_message
  * @param mixed[] $pbe
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  */
 function query_mark_pms($email_message, $pbe)
@@ -1920,7 +1900,6 @@ function query_mark_pms($email_message, $pbe)
  * - Also removes any old keys to minimize security issues
  *
  * @param \ElkArte\EmailParse $email_message
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  */
 function query_key_maintenance($email_message)
@@ -1972,7 +1951,6 @@ function query_key_maintenance($email_message)
  * @param mixed[] $pbe
  * @param \ElkArte\EmailParse $email_message
  * @param mixed[] $topic_info
- * @throws \Exception
  * @package Maillist
  */
 function query_update_member_stats($pbe, $email_message, $topic_info = array())
@@ -2046,7 +2024,6 @@ function query_update_member_stats($pbe, $email_message, $topic_info = array())
  * @param mixed[] $pbe
  *
  * @return mixed|null|string|string[]
- * @throws \Exception
  * @package Maillist
  *
  */
@@ -2103,7 +2080,6 @@ function pbe_load_text(&$html, $email_message, $pbe)
  * @param mixed[] $topic_info
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  *
  */
@@ -2233,7 +2209,6 @@ function pbe_create_post($pbe, $email_message, $topic_info)
  * @param mixed[] $pm_info
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  *
  * @uses sendpm to do the actual "sending"
@@ -2301,7 +2276,6 @@ function pbe_create_pm($pbe, $email_message, $pm_info)
  * @param mixed[] $board_info
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  *
  * @uses createPost to do the actual "posting"

--- a/sources/subs/FollowUps.subs.php
+++ b/sources/subs/FollowUps.subs.php
@@ -19,7 +19,6 @@
  * @param bool $include_approved
  *
  * @return array
- * @throws \Exception
  */
 function followupTopics($messages, $include_approved = false)
 {
@@ -55,7 +54,6 @@ function followupTopics($messages, $include_approved = false)
  * @param bool $include_approved
  *
  * @return array
- * @throws \Exception
  */
 function topicStartedHere($topic, $include_approved = false)
 {
@@ -88,7 +86,6 @@ function topicStartedHere($topic, $include_approved = false)
  *
  * @param int $msg message id
  * @param int $topic topic id
- * @throws \Exception
  */
 function linkMessages($msg, $topic)
 {
@@ -108,7 +105,6 @@ function linkMessages($msg, $topic)
  *
  * @param int $msg message id
  * @param int $topic topic id
- * @throws \ElkArte\Exceptions\Exception
  * @todo remove?
  */
 function unlinkMessages($msg, $topic)
@@ -131,7 +127,6 @@ function unlinkMessages($msg, $topic)
  * Removes all the follow-ups from the db by topics
  *
  * @param int|int[] $topics topic id
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeFollowUpsByTopic($topics)
 {
@@ -150,7 +145,6 @@ function removeFollowUpsByTopic($topics)
  * Removes all the follow-ups from the db by message id
  *
  * @param int[]|int $msgs int or array of ints for the message id's to work on
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeFollowUpsByMessage($msgs)
 {

--- a/sources/subs/Karma.subs.php
+++ b/sources/subs/Karma.subs.php
@@ -16,7 +16,6 @@
  *
  * @param int $karmaWaitTime
  * @package Karma
- * @throws \ElkArte\Exceptions\Exception
  */
 function clearKarma($karmaWaitTime)
 {
@@ -41,7 +40,6 @@ function clearKarma($karmaWaitTime)
  *
  * @return null
  * @package Karma
- * @throws \ElkArte\Exceptions\Exception
  */
 function lastActionOn($id_executor, $id_target)
 {
@@ -76,7 +74,6 @@ function lastActionOn($id_executor, $id_target)
  * @param int $id_target
  * @param int $direction - options: -1 or 1
  * @package Karma
- * @throws \Exception
  */
 function addKarma($id_executor, $id_target, $direction)
 {
@@ -102,7 +99,6 @@ function addKarma($id_executor, $id_target, $direction)
  * @param int $id_target
  * @param int $direction - options: -1 or 1
  * @package Karma
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateKarma($id_executor, $id_target, $direction)
 {

--- a/sources/subs/Language.subs.php
+++ b/sources/subs/Language.subs.php
@@ -18,7 +18,6 @@ use ElkArte\XmlArray;
  * Removes the given language from all members..
  *
  * @param int $lang_id
- * @throws \ElkArte\Exceptions\Exception
  * @package Languages
  */
 function removeLanguageFromMember($lang_id)
@@ -442,7 +441,6 @@ function list_getLanguagesList()
  * @param string $lang
  *
  * @return array|bool
- * @throws \ElkArte\Exceptions\Exception
  */
 function findPossiblePackages($lang)
 {

--- a/sources/subs/Likes.subs.php
+++ b/sources/subs/Likes.subs.php
@@ -25,7 +25,6 @@ use ElkArte\Util;
  * @param string $direction - + for like - for unlike a previous liked one
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Likes
  *
  */
@@ -59,7 +58,6 @@ function likePost($id_liker, $liked_message, $direction)
  * @param bool $prepare
  *
  * @return array|int[]
- * @throws \Exception
  * @package Likes
  *
  */
@@ -170,7 +168,6 @@ function prepareLikes($likes)
  * Clear the likes log of older actions ... used to prevent a like love fest
  *
  * @param int $likeWaitTime
- * @throws \ElkArte\Exceptions\Exception
  * @package Likes
  */
 function clearLikes($likeWaitTime)
@@ -199,7 +196,6 @@ function clearLikes($likeWaitTime)
  * @param int $id_liker
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Likes
  *
  */
@@ -235,7 +231,6 @@ function lastLikeOn($id_liker)
  * @param int $id_liker
  * @param int[] $liked_message
  * @param string $direction - options: - or +
- * @throws \ElkArte\Exceptions\Exception
  * @package Likes
  */
 function updateLike($id_liker, $liked_message, $direction)
@@ -318,7 +313,6 @@ function updateLike($id_liker, $liked_message, $direction)
  *
  * @param int $id_topic - the topic
  * @param string $direction +/- liking or unliking
- * @throws \ElkArte\Exceptions\Exception
  * @package Likes
  */
 function increaseTopicLikes($id_topic, $direction)
@@ -344,7 +338,6 @@ function increaseTopicLikes($id_topic, $direction)
  * @param bool $given
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Likes
  *
  */
@@ -386,7 +379,6 @@ function likesCount($memberID, $given = true)
  * @param int $memberID
  *
  * @return array
- * @throws \Exception
  * @package Likes
  *
  */
@@ -439,7 +431,6 @@ function likesPostsGiven($start, $items_per_page, $sort, $memberID)
  * @param int $memberID
  *
  * @return array
- * @throws \Exception
  * @package Likes
  *
  */
@@ -490,7 +481,6 @@ function likesPostsReceived($start, $items_per_page, $sort, $memberID)
  * @param bool $simple
  *
  * @return array
- * @throws \Exception
  * @package Likes
  *
  */
@@ -550,7 +540,6 @@ function postLikers($start, $items_per_page, $sort, $messageID, $simple = true)
  * @param int $message
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Likes
  *
  */
@@ -585,7 +574,6 @@ function messageLikeCount($message)
  * @param int $limit the number of top liked messages to fetch
  *
  * @return array
- * @throws \Exception
  * @package Likes
  */
 function dbMostLikedMessage($limit = 10)
@@ -685,7 +673,6 @@ function dbMostLikedMessage($limit = 10)
  * @param int $limit the maximum number of liked posts to return
  *
  * @return array
- * @throws \Exception
  * @package Likes
  */
 function dbMostLikedMessagesByTopic($topic, $limit = 5)
@@ -774,7 +761,6 @@ function dbMostLikedMessagesByTopic($topic, $limit = 5)
  * @param int $limit - Optional, number of topics to return (default 10).
  *
  * @return array
- * @throws \Exception
  * @package Likes
  *
  */
@@ -911,7 +897,6 @@ function dbMostLikedBoard()
  * @param int $limit the number of most liked members to return
  *
  * @return array
- * @throws \Exception
  * @package Likes
  *
  */
@@ -983,7 +968,6 @@ function dbMostLikesReceivedUser($limit = 10)
  * @param int $limit then number of top posts to return
  *
  * @return array
- * @throws \Exception
  */
 function dbMostLikedPostsByUser($id_member, $limit = 10)
 {
@@ -1040,7 +1024,6 @@ function dbMostLikedPostsByUser($id_member, $limit = 10)
  * @param int $limit the number of members to return
  *
  * @return array
- * @throws \Exception
  * @package Likes
  *
  */
@@ -1108,7 +1091,6 @@ function dbMostLikesGivenUser($limit = 10)
  * @param int $id_liker the userid to find recently liked posts
  * @param int $limit number of recently liked posts to fetch
  * @return array
- * @throws \Exception
  */
 function dbRecentlyLikedPostsGivenUser($id_liker, $limit = 5)
 {
@@ -1166,7 +1148,6 @@ function dbRecentlyLikedPostsGivenUser($id_liker, $limit = 5)
  * for that message.
  *
  * @param int[]|int $messages
- * @throws \Exception
  */
 function decreaseLikeCounts($messages)
 {

--- a/sources/subs/Logging.subs.php
+++ b/sources/subs/Logging.subs.php
@@ -150,7 +150,6 @@ function updateLogActivity($update_parameters, $setStringUpdate, $insert_keys, $
  * @param int $id_member
  * @param string $ip
  * @param string $ip2
- * @throws \Exception
  */
 function logLoginHistory($id_member, $ip, $ip2)
 {
@@ -178,7 +177,6 @@ function logLoginHistory($id_member, $ip, $ip2)
  * @param string $type
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  */
 function loadLogReported($msg_id, $topic_id, $type = 'msg')
 {

--- a/sources/subs/Mail.subs.php
+++ b/sources/subs/Mail.subs.php
@@ -36,7 +36,6 @@ use ElkArte\User;
  * @param string|null $from_wrapper - used to provide envelope from wrapper based on if we sharing a users display name
  * @param int|null $reference - The parent topic id for use in a References header
  * @return bool whether or not the email was accepted properly.
- * @throws \ElkArte\Exceptions\Exception
  * @package Mail
  */
 function sendmail($to, $subject, $message, $from = null, $message_id = null, $send_html = false, $priority = 3, $hotmail_fix = null, $is_private = false, $from_wrapper = null, $reference = null)
@@ -601,7 +600,6 @@ function mimespecialchars_callback($match)
  * @param int $priority
  * @param string|null $message_id
  * @return bool whether it sent or not.
- * @throws \Exception
  * @internal
  * @package Mail
  */
@@ -831,7 +829,6 @@ function smtp_mail($mail_to_array, $subject, $message, $headers, $priority, $mes
  * @param resource $socket - socket to send on
  * @param string $response - the expected response code
  * @return string|bool it responded as such.
- * @throws \Exception
  * @internal
  * @package Mail
  */
@@ -1112,7 +1109,6 @@ function user_info_callback($matches)
  * @param int $items_per_page The number of items to show per page
  * @param string $sort A string indicating how to sort the results
  * @return array
- * @throws \Exception
  * @package Mail
  */
 function list_getMailQueue($start, $items_per_page, $sort)
@@ -1149,7 +1145,6 @@ function list_getMailQueue($start, $items_per_page, $sort)
  * Returns the total count of items in the mail queue.
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Mail
  */
 function list_getMailQueueSize()
@@ -1172,7 +1167,6 @@ function list_getMailQueueSize()
  * Deletes items from the mail queue
  *
  * @param int[] $items
- * @throws \ElkArte\Exceptions\Exception
  * @package Mail
  */
 function deleteMailQueueItems($items)
@@ -1217,7 +1211,6 @@ function list_MailQueueStatus()
  * - It is used to keep track of failed emails attempts and next try.
  *
  * @param mixed[] $failed_emails
- * @throws \ElkArte\Exceptions\Exception
  * @package Mail
  */
 function updateFailedQueue($failed_emails)
@@ -1312,7 +1305,6 @@ function resetNextSendTime()
  * - Requires an affected row
  *
  * @return int|bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Mail
  */
 function updateNextSendTime()
@@ -1348,7 +1340,6 @@ function updateNextSendTime()
  *
  * @param int $number
  * @return array
- * @throws \Exception
  * @package Mail
  */
 function emailsInfo($number)
@@ -1633,7 +1624,6 @@ function reduceMailQueue($batch_size = false, $override_limit = false, $force_se
  * @param int $id_msg the id of a message
  * @param int $topic_id the topic the message belongs to
  * @return mixed[] the poster's details
- * @throws \ElkArte\Exceptions\Exception
  * @todo very similar to mailFromMessage
  * @package Mail
  */

--- a/sources/subs/Maillist.subs.php
+++ b/sources/subs/Maillist.subs.php
@@ -26,7 +26,6 @@ use ElkArte\Util;
  * @param string $sort A string indicating how to sort the results
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  *
  */
@@ -170,7 +169,6 @@ function list_maillist_count_unapproved()
  * Removes an single entry from the postby_emails_error table
  *
  * @param int $id
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  */
 function maillist_delete_error_entry($id)
@@ -200,7 +198,6 @@ function maillist_delete_error_entry($id)
  * @param string $style = filter Filter to fetch filters or parsers for parsers
  *
  * @return array
- * @throws \Exception
  * @package Maillist
  *
  */
@@ -259,7 +256,6 @@ function list_get_filter_parser($start, $items_per_page, $sort = '', $id = 0, $s
  * @param string $style
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  *
  */
@@ -330,7 +326,6 @@ function maillist_load_filter_parser($id, $style)
  * Removes a specific filter or parser from the system
  *
  * @param int $id ID of the filter/parser
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  */
 function maillist_delete_filter_parser($id)
@@ -384,7 +379,6 @@ function maillist_board_list()
  * Turns on or off the "fake" cron job for imap email retrieval
  *
  * @param bool $switch
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  */
 function enable_maillist_imap_cron($switch)
@@ -411,7 +405,6 @@ function enable_maillist_imap_cron($switch)
  * @param string|null $subject - A subject for the template
  *
  * @return array
- * @throws \Exception
  * @package Maillist
  *
  */
@@ -451,7 +444,6 @@ function maillist_templates($template_type, $subject = null)
  * Log in post-by emails an email being sent
  *
  * @param mixed[] $sent associative array of id_email, time_sent, email_to
- * @throws \Exception
  * @package Maillist
  */
 function log_email($sent)
@@ -477,7 +469,6 @@ function log_email($sent)
  *
  * @param string $replace constructed as WHEN fieldname=value THEN new viewvalue WHEN .....
  * @param int[] $filters list of ids in the WHEN clause to keep from updating the entire table
- * @throws \ElkArte\Exceptions\Exception
  * @package Maillist
  */
 function updateParserFilterOrder($replace, $filters)

--- a/sources/subs/Maintenance.subs.php
+++ b/sources/subs/Maintenance.subs.php
@@ -18,7 +18,6 @@
  * Counts the total number of messages
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Maintenance
  */
 function countMessages()
@@ -76,7 +75,6 @@ function flushLogTables()
  * Gets the table columns from the messages table, just a wrapper function
  *
  * @return array
- * @throws \Exception
  * @package Maintenance
  */
 function getMessageTableColumns()
@@ -112,7 +110,6 @@ function fetchBodyType()
  * Resizes the body column from the messages table
  *
  * @param string $type
- * @throws \Exception
  * @package Maintenance
  */
 function resizeMessageTableBody($type)
@@ -128,7 +125,6 @@ function resizeMessageTableBody($type)
  * @param int $increment
  *
  * @return array
- * @throws \Exception
  * @package Maintenance
  *
  */
@@ -161,7 +157,6 @@ function detectExceedingMessages($start, $increment)
  *
  * @param int[] $msg
  * @return array
- * @throws \Exception
  * @package Maintenance
  */
 function getExceedingMessages($msg)
@@ -191,7 +186,6 @@ function getExceedingMessages($msg)
  * - Additional tables from addons are also included.
  *
  * @return array
- * @throws \Exception
  * @package Maintenance
  */
 function getElkTables()
@@ -219,7 +213,6 @@ function getElkTables()
  * Gets the last topics id.
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Maintenance
  */
 function getMaxTopicID()
@@ -243,7 +236,6 @@ function getMaxTopicID()
  *
  * @param int $start The item to start with (for pagination purposes)
  * @param int $increment
- * @throws \Exception
  * @package Maintenance
  */
 function recountApprovedMessages($start, $increment)
@@ -278,7 +270,6 @@ function recountApprovedMessages($start, $increment)
  *
  * @param int $start The item to start with (for pagination purposes)
  * @param int $increment
- * @throws \Exception
  * @package Maintenance
  */
 function recountUnapprovedMessages($start, $increment)
@@ -317,7 +308,6 @@ function recountUnapprovedMessages($start, $increment)
  * @param string $column
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Maintenance
  *
  */
@@ -350,7 +340,6 @@ function resetBoardsCounter($column)
  * @param string $type - can be 'posts', 'topic', 'unapproved_posts', 'unapproved_topics'
  * @param int $start The item to start with (for pagination purposes)
  * @param int $increment
- * @throws \Exception
  * @package Maintenance
  */
 function updateBoardsCounter($type, $start, $increment)
@@ -534,7 +523,6 @@ function updatePersonalMessagesCounter()
  *
  * @param int $start The item to start with (for pagination purposes)
  * @param int $increment
- * @throws \ElkArte\Exceptions\Exception
  * @package Maintenance
  */
 function updateMessagesBoardID($start, $increment)
@@ -661,7 +649,6 @@ function updateBoardsLastMessage()
  *
  * @param int $id_board
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Maintenance
  */
 function countTopicsFromBoard($id_board)
@@ -689,7 +676,6 @@ function countTopicsFromBoard($id_board)
  * @param int $id_board
  *
  * @return int[]
- * @throws \Exception
  * @package Maintenance
  */
 function getTopicsToMove($id_board)
@@ -717,7 +703,6 @@ function getTopicsToMove($id_board)
  * Counts members with posts > 0, we name them contributors
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Maintenance
  */
 function countContributors()
@@ -747,7 +732,6 @@ function countContributors()
  * @param int $start The item to start with (for pagination purposes)
  * @param int $increment
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Maintenance
  */
 function updateMembersPostCount($start, $increment)
@@ -840,7 +824,6 @@ function updateZeroPostMembers()
  * @param int[] $groups
  * @param int $time_limit
  * @return array
- * @throws \Exception
  * @package Maintenance
  */
 function purgeMembers($type, $groups, $time_limit)

--- a/sources/subs/ManageFeatures.subs.php
+++ b/sources/subs/ManageFeatures.subs.php
@@ -23,7 +23,6 @@ use ElkArte\Util;
  *
  * @param int $start_member
  * @return array
- * @throws \Exception
  */
 function getSignatureFromMembers($start_member)
 {
@@ -67,7 +66,6 @@ function updateSignature($id_member, $signature)
  * Update all signatures given a new set of constraints
  *
  * @param int $applied_sigs
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateAllSignatures($applied_sigs)
 {
@@ -362,7 +360,6 @@ function updateAllSignatures($applied_sigs)
  * @param bool $standardFields
  *
  * @return array
- * @throws \Exception
  */
 function list_getProfileFields($start, $items_per_page, $sort, $standardFields)
 {
@@ -438,7 +435,6 @@ function list_getProfileFieldSize()
  *
  * @param int $id_field
  * @return array $field
- * @throws \Exception
  */
 function getProfileField($id_field)
 {
@@ -498,7 +494,6 @@ function getProfileField($id_field)
  * @param string $initial_colname
  * @param bool $unique
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  */
 function ensureUniqueProfileField($colname, $initial_colname, $unique = false)
 {
@@ -537,7 +532,6 @@ function ensureUniqueProfileField($colname, $initial_colname, $unique = false)
  * @param mixed[] $newOptions
  * @param string $name
  * @param string $option
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateRenamedProfileField($key, $newOptions, $name, $option)
 {
@@ -562,7 +556,6 @@ function updateRenamedProfileField($key, $newOptions, $name, $option)
  * Update the custom profile fields active status on/off
  *
  * @param int[] $enabled
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateRenamedProfileStatus($enabled)
 {
@@ -582,7 +575,6 @@ function updateRenamedProfileStatus($enabled)
  * Update the profile field
  *
  * @param mixed[] $field_data
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateProfileField($field_data)
 {
@@ -632,7 +624,6 @@ function updateProfileField($field_data)
  * Done as a CASE WHEN one two three ELSE 0 END in place of many updates
  *
  * @param string $replace constructed as WHEN fieldname=value THEN new viewvalue WHEN .....
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateProfileFieldOrder($replace)
 {
@@ -650,7 +641,6 @@ function updateProfileFieldOrder($replace)
  *
  * @param string[] $newOptions
  * @param string $fieldname
- * @throws \ElkArte\Exceptions\Exception
  */
 function deleteOldProfileFieldSelects($newOptions, $fieldname)
 {
@@ -673,7 +663,6 @@ function deleteOldProfileFieldSelects($newOptions, $fieldname)
  * Used to add a new custom profile field
  *
  * @param mixed[] $field
- * @throws \Exception
  */
 function addProfileField($field)
 {
@@ -705,7 +694,6 @@ function addProfileField($field)
  * Delete all user data for a specified custom profile field
  *
  * @param string $name
- * @throws \ElkArte\Exceptions\Exception
  */
 function deleteProfileFieldUserData($name)
 {
@@ -727,7 +715,6 @@ function deleteProfileFieldUserData($name)
  * Deletes a custom profile field.
  *
  * @param int $id
- * @throws \ElkArte\Exceptions\Exception
  */
 function deleteProfileField($id)
 {
@@ -938,7 +925,6 @@ function scanFileSystemForControllers($iterator, $namespace = '')
  *
  * @param int $applied_sigs
  * @param int $sig_start
- * @throws \ElkArte\Exceptions\Exception
  * @todo Merge with other pause functions?
  *    pausePermsSave(), pauseAttachmentMaintenance(), pauseRepairProcess()
  *

--- a/sources/subs/ManagePermissions.subs.php
+++ b/sources/subs/ManagePermissions.subs.php
@@ -721,7 +721,6 @@ function loadAllPermissions()
  * @param string[]|null $hidden_permissions array of permission names to skip in the count totals
  *
  * @return int[] [id_group][num_permissions][denied] = count, [id_group][num_permissions][allowed] = count
- * @throws \Exception
  * @package Permissions
  */
 function countPermissions($groups, $hidden_permissions = null)
@@ -757,7 +756,6 @@ function countPermissions($groups, $hidden_permissions = null)
  * @param int|null $profile_id
  *
  * @return int[]
- * @throws \Exception
  * @package Permissions
  */
 function countBoardPermissions($groups, $hidden_permissions = null, $profile_id = null)
@@ -793,7 +791,6 @@ function countBoardPermissions($groups, $hidden_permissions = null, $profile_id 
  *
  * @param int $profile
  * @param int $board
- * @throws \ElkArte\Exceptions\Exception
  * @package Permissions
  */
 function assignPermissionProfileToBoard($profile, $board)
@@ -819,7 +816,6 @@ function assignPermissionProfileToBoard($profile, $board)
  * @param int[] $groups
  * @param string[] $illegal_permissions
  * @param string[] $non_guest_permissions
- * @throws \ElkArte\Exceptions\Exception
  * @todo another function with the same name in Membergroups.subs.php
  * @package Permissions
  */
@@ -892,7 +888,6 @@ function copyPermission($copy_from, $groups, $illegal_permissions, $non_guest_pe
  * @param int[] $groups The target groups
  * @param int $profile_id
  * @param string[] $non_guest_permissions
- * @throws \Exception
  * @package Permissions
  */
 function copyBoardPermission($copy_from, $groups, $profile_id, $non_guest_permissions)
@@ -949,7 +944,6 @@ function copyBoardPermission($copy_from, $groups, $profile_id, $non_guest_permis
  * @param int[] $groups
  * @param string $permission
  * @param string[] $illegal_permissions
- * @throws \ElkArte\Exceptions\Exception
  * @package Permissions
  */
 function deletePermission($groups, $permission, $illegal_permissions)
@@ -975,7 +969,6 @@ function deletePermission($groups, $permission, $illegal_permissions)
  * @param int[] $group
  * @param int $profile_id
  * @param string $permission
- * @throws \ElkArte\Exceptions\Exception
  * @package Permissions
  */
 function deleteBoardPermission($group, $profile_id, $permission)
@@ -999,7 +992,6 @@ function deleteBoardPermission($group, $profile_id, $permission)
  * Replaces existing membergroup permissions with the given ones.
  *
  * @param mixed[] $permChange associative array permission, id_group, add_deny
- * @throws \Exception
  * @package Permissions
  */
 function replacePermission($permChange)
@@ -1021,7 +1013,6 @@ function replacePermission($permChange)
  * Replaces existing board permissions with the given ones.
  *
  * @param mixed[] $permChange associative array of 'permission', 'id_group', 'add_deny', 'id_profile'
- * @throws \Exception
  * @package Permissions
  */
 function replaceBoardPermission($permChange)
@@ -1059,7 +1050,6 @@ function removeModeratorPermissions()
  *
  * @param int $id_group
  * @return array
- * @throws \Exception
  * @package Permissions
  */
 function fetchPermissions($id_group)
@@ -1096,7 +1086,6 @@ function fetchPermissions($id_group)
  * @param int $profile_id
  *
  * @return array
- * @throws \Exception
  * @package Permissions
  *
  */
@@ -1133,7 +1122,6 @@ function fetchBoardPermissions($id_group, $permission_type, $profile_id)
  *
  * @param int $id_group
  * @param string[] $illegal_permissions
- * @throws \ElkArte\Exceptions\Exception
  * @package Permissions
  */
 function deleteInvalidPermissions($id_group, $illegal_permissions)
@@ -1156,7 +1144,6 @@ function deleteInvalidPermissions($id_group, $illegal_permissions)
  *
  * @param int[] $groups
  * @param int $id_profile
- * @throws \ElkArte\Exceptions\Exception
  * @package Permissions
  */
 function deleteAllBoardPermissions(array $groups, $id_profile)
@@ -1255,7 +1242,6 @@ function clearPostgroupPermissions()
  *
  * @param string $profile_name
  * @param int $copy_from
- * @throws \Exception
  * @package Permissions
  */
 function copyPermissionProfile($profile_name, $copy_from)
@@ -1307,7 +1293,6 @@ function copyPermissionProfile($profile_name, $copy_from)
  *
  * @param int $id_profile
  * @param string $name
- * @throws \ElkArte\Exceptions\Exception
  * @package Permissions
  */
 function renamePermissionProfile($id_profile, $name)
@@ -1374,7 +1359,6 @@ function deletePermissionProfiles($profiles)
  * @param int[] $profiles
  *
  * @return int[]
- * @throws \Exception
  * @package Permissions
  */
 function permProfilesInUse($profiles)
@@ -1410,7 +1394,6 @@ function permProfilesInUse($profiles)
  * @param int[] $profile
  * @param string[] $permissions
  * @package Permissions
- * @throws \ElkArte\Exceptions\Exception
  */
 function deleteBoardPermissions($groups, $profile, $permissions)
 {
@@ -1434,7 +1417,6 @@ function deleteBoardPermissions($groups, $profile, $permissions)
  * Adds a new board permission to the board_permissions table.
  *
  * @param mixed[] $new_permissions
- * @throws \Exception
  * @package Permissions
  */
 function insertBoardPermission($new_permissions)
@@ -1456,7 +1438,6 @@ function insertBoardPermission($new_permissions)
  * @param int $profile
  * @param string[] $permissions
  * @return array
- * @throws \Exception
  * @package Permissions
  */
 function getPermission($group, $profile, $permissions)

--- a/sources/subs/Membergroups.subs.php
+++ b/sources/subs/Membergroups.subs.php
@@ -30,7 +30,6 @@ use ElkArte\Util;
  *
  * @param int[]|int $groups
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function deleteMembergroups($groups)
@@ -239,7 +238,6 @@ function deleteMembergroups($groups)
  * @param bool $permissionCheckDone = false
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function removeMembersFromGroups($members, $groups = null, $permissionCheckDone = false)
@@ -484,7 +482,6 @@ function removeMembersFromGroups($members, $groups = null, $permissionCheckDone 
  *                     available. If not, assign it to the additional group.
  * @param bool $permissionCheckDone = false if true, it checks permission of the current user to add groups ('manage_membergroups')
  * @return bool success or failure
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function addMembersToGroup($members, $group, $type = 'auto', $permissionCheckDone = false)
@@ -618,7 +615,6 @@ function addMembersToGroup($members, $group, $type = 'auto', $permissionCheckDon
  * @param int $membergroup
  * @param int|null $limit = null
  * @return bool
- * @throws \Exception
  * @package Membergroups
  */
 function listMembergroupMembers_Href(&$members, $membergroup, $limit = null)
@@ -704,7 +700,6 @@ function cache_getMembergroupList()
  * @param int|null $pid - profile id
  *
  * @return array
- * @throws \Exception
  * @package Membergroups
  *
  */
@@ -937,7 +932,6 @@ function list_getMembergroups($start, $items_per_page, $sort, $membergroup_type,
  * @param bool $include_moderators if true, includes board moderators too (default false).
  * @param bool $include_non_active if true, includes non active members (default false).
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function membersInGroups($postGroups, $normalGroups = array(), $include_hidden = false, $include_moderators = false, $include_non_active = false)
@@ -1048,7 +1042,6 @@ function membersInGroups($postGroups, $normalGroups = array(), $include_hidden =
  *     true adds to above: description, min_posts, online_color, max_messages, icons, hidden, id_parent.
  * @param bool $assignable = false determine if the group is assignable or not and return that information.
  * @return array
- * @throws \Exception
  * @package Membergroups
  */
 function membergroupsById($group_ids, $limit = 1, $detailed = false, $assignable = false)
@@ -1096,7 +1089,6 @@ function membergroupsById($group_ids, $limit = 1, $detailed = false, $assignable
  * @param bool $assignable
  *
  * @return bool|mixed
- * @throws \Exception
  * @package Membergroups
  *
  */
@@ -1132,7 +1124,6 @@ function membergroupById($group_id, $detailed = false, $assignable = false)
  * @param string|null $sort_order
  * @param bool|null $split splits postgroups and membergroups
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function getBasicMembergroupData($includes = array(), $excludes = array(), $sort_order = null, $split = null)
@@ -1276,7 +1267,6 @@ function getBasicMembergroupData($includes = array(), $excludes = array(), $sort
  *
  * @param int[] $groupList
  * @return array with ('id', 'name', 'member_count')
- * @throws \Exception
  * @package Membergroups
  */
 function getGroups($groupList)
@@ -1323,7 +1313,6 @@ function getGroups($groupList)
  * Gets the last assigned group id.
  *
  * @return int $id_group
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function getMaxGroupID()
@@ -1348,7 +1337,6 @@ function getMaxGroupID()
  * @param string $groupname
  * @param int $minposts
  * @param string $type
- * @throws \Exception
  * @package Membergroups
  */
 function createMembergroup($groupname, $minposts, $type)
@@ -1377,7 +1365,6 @@ function createMembergroup($groupname, $minposts, $type)
  * @param int $id_group
  * @param int $copy_from
  * @param string[]|null $illegal_permissions
- * @throws \Exception
  * @todo another function with the same name in ManagePermissions.subs.php
  * @package Membergroups
  */
@@ -1420,7 +1407,6 @@ function copyPermissions($id_group, $copy_from, $illegal_permissions)
  *
  * @param int $id_group
  * @param int $copy_from
- * @throws \Exception
  * @package Membergroups
  */
 function copyBoardPermissions($id_group, $copy_from)
@@ -1457,7 +1443,6 @@ function copyBoardPermissions($id_group, $copy_from)
  *
  * @param int $id_group
  * @param int $copy_from
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function updateCopiedGroup($id_group, $copy_from)
@@ -1489,7 +1474,6 @@ function updateCopiedGroup($id_group, $copy_from)
  *
  * @param int $id_group
  * @param int $copy_id
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function updateInheritedGroup($id_group, $copy_id)
@@ -1514,7 +1498,6 @@ function updateInheritedGroup($id_group, $copy_id)
  * the group to update. The rest of the keys are details to update it with.
  *
  * @param mixed[] $properties
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function updateMembergroupProperties($properties)
@@ -1570,7 +1553,6 @@ function updateMembergroupProperties($properties)
  * @param int $id_group
  * @param mixed[] $boards
  * @param string $access_list ('allow', 'deny')
- * @throws \Exception
  * @package Membergroups
  */
 function detachGroupFromBoards($id_group, $boards, $access_list)
@@ -1612,7 +1594,6 @@ function detachGroupFromBoards($id_group, $boards, $access_list)
  * @param int $id_group
  * @param mixed[] $boards
  * @param string $access_list ('allow', 'deny')
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function assignGroupToBoards($id_group, $boards, $access_list)
@@ -1639,7 +1620,6 @@ function assignGroupToBoards($id_group, $boards, $access_list)
  * Membergroup was deleted? We need to detach that group from our members, too...
  *
  * @param int $id_group
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function detachDeletedGroupFromMembers($id_group)
@@ -1684,7 +1664,6 @@ function detachDeletedGroupFromMembers($id_group)
  * Make the given group hidden. Hidden groups are stored in the additional_groups.
  *
  * @param int $id_group
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function setGroupToHidden($id_group)
@@ -1760,7 +1739,6 @@ function validateShowGroupMembership()
  * Detaches group moderators from a deleted group.
  *
  * @param int $id_group
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function detachGroupModerators($id_group)
@@ -1782,7 +1760,6 @@ function detachGroupModerators($id_group)
  * @param string[] $moderators
  *
  * @return int[]
- * @throws \Exception
  * @package Membergroups
  */
 function getIDMemberFromGroupModerators($moderators)
@@ -1810,7 +1787,6 @@ function getIDMemberFromGroupModerators($moderators)
  *
  * @param int $id_group
  * @param int[] $group_moderators
- * @throws \Exception
  * @package Membergroups
  */
 function assignGroupModerators($id_group, $group_moderators)
@@ -1836,7 +1812,6 @@ function assignGroupModerators($id_group, $group_moderators)
  *
  * @param int $id_group
  * @return array moderators as array(id => name)
- * @throws \Exception
  * @package Membergroups
  */
 function getGroupModerators($id_group)
@@ -1870,7 +1845,6 @@ function getGroupModerators($id_group)
  *
  * @param int|bool $id_group
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function getInheritableGroups($id_group = false)
@@ -1910,7 +1884,6 @@ function getInheritableGroups($id_group = false)
  * List all membergroups and prepares them to assign permissions to..
  *
  * @return array
- * @throws \Exception
  * @package Membergroups
  */
 function prepareMembergroupPermissions()
@@ -1989,7 +1962,6 @@ function prepareMembergroupPermissions()
  * @param int $min_posts minimum number of posts for the group (-1 for non-post based groups)
  *
  * @return array
- * @throws \Exception
  * @package Membergroups
  */
 function loadGroups($id_member, $show_hidden = false, $min_posts = -1)
@@ -2034,7 +2006,6 @@ function loadGroups($id_member, $show_hidden = false, $min_posts = -1)
  * - does not include post count based groups
  *
  * @return array
- * @throws \Exception
  * @package Membergroups
  */
 function accessibleGroups()
@@ -2079,7 +2050,6 @@ function accessibleGroups()
  * @param string $where
  * @param string[] $where_parameters
  * @return int the count of group requests
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function list_getGroupRequestCount($where, $where_parameters)
@@ -2116,7 +2086,6 @@ function list_getGroupRequestCount($where, $where_parameters)
  *   'group_link'
  *   'reason'
  *   'time_submitted'
- * @throws \Exception
  * @package Membergroups
  */
 function list_getGroupRequests($start, $items_per_page, $sort, $where, $where_parameters)
@@ -2153,7 +2122,6 @@ function list_getGroupRequests($start, $items_per_page, $sort, $where, $where_pa
  * Deletes old group requests.
  *
  * @param int[] $groups
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function deleteGroupRequests($groups)
@@ -2176,7 +2144,6 @@ function deleteGroupRequests($groups)
  *
  * @param int[]|null $members = null The members to update, null if all
  * @param string[]|null $parameter2 = null
- * @throws \ElkArte\Exceptions\Exception
  * @package Membergroups
  */
 function updatePostGroupStats($members = null, $parameter2 = null)
@@ -2248,7 +2215,6 @@ function updatePostGroupStats($members = null, $parameter2 = null)
  *
  * @param bool $ignore_protected To ignore protected groups
  * @return int[]
- * @throws \Exception
  */
 function getUnassignableGroups($ignore_protected)
 {
@@ -2276,7 +2242,6 @@ function getUnassignableGroups($ignore_protected)
  * Returns a list of groups that a member can be assigned to
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function getGroupsList()
 {

--- a/sources/subs/Memberlist.subs.php
+++ b/sources/subs/Memberlist.subs.php
@@ -102,7 +102,6 @@ function ml_CustomProfile()
  * @param int $cache_step_size
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function ml_memberCache($cache_step_size)
 {
@@ -173,7 +172,6 @@ function ml_memberCount()
  * @param string $start single letter to start with
  *
  * @return string
- * @throws \ElkArte\Exceptions\Exception
  */
 function ml_alphaStart($start)
 {
@@ -204,7 +202,6 @@ function ml_alphaStart($start)
  * @param string $where
  * @param int $limit
  * @param string $sort
- * @throws \ElkArte\Exceptions\Exception
  */
 function ml_selectMembers($query_parameters, $where = '', $limit = 0, $sort = '')
 {
@@ -241,7 +238,6 @@ function ml_selectMembers($query_parameters, $where = '', $limit = 0, $sort = ''
  * @param string $where
  * @param int $limit
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function ml_searchMembers($query_parameters, $customJoin = '', $where = '', $limit = 0)
 {
@@ -330,7 +326,6 @@ function ml_findSearchableCustomFields()
  * Puts results of request into the context for the sub template.
  *
  * @param resource $request
- * @throws \ElkArte\Exceptions\Exception
  */
 function printMemberListRows($request)
 {

--- a/sources/subs/Members.subs.php
+++ b/sources/subs/Members.subs.php
@@ -44,7 +44,6 @@ use ElkArte\Util;
  *
  * @param int[]|int $users
  * @param bool $check_not_admin = false
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  */
 function deleteMembers($users, $check_not_admin = false)
@@ -1123,7 +1122,6 @@ function groupsAllowedTo($permission, $board_id = null)
  * @param int|null $board_id = null
  *
  * @return int[] an array containing member ID's.
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  */
 function membersAllowedTo($permission, $board_id = null)
@@ -1170,7 +1168,6 @@ function membersAllowedTo($permission, $board_id = null)
  * @param bool|false|string $email = false
  * @param bool|false|string $membername = false
  * @param bool $post_count = false
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  *
  */
@@ -1268,7 +1265,6 @@ function reattributePosts($memID, $email = false, $membername = false, $post_cou
  * @param bool $get_duplicates
  *
  * @return array
- * @throws \Exception
  * @package Members
  *
  */
@@ -1308,7 +1304,6 @@ function list_getMembers($start, $items_per_page, $sort, $where, $where_params =
  * @param mixed[] $where_params
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  *
  */
@@ -1346,7 +1341,6 @@ function list_getNumMembers($where, $where_params = array())
  * @param mixed[] $members
  *
  * @return bool
- * @throws \Exception
  * @package Members
  *
  */
@@ -1482,7 +1476,6 @@ function populateDuplicateMembers(&$members)
  * @param bool $ip2 (optional, default false) If the query should check IP2 as well
  *
  * @return array
- * @throws \Exception
  * @package Members
  *
  */
@@ -1549,7 +1542,6 @@ function membersByIP($ip1, $match = 'exact', $ip2 = false)
  * @param int $memberID ID of the member, to compare with.
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  *
  */
@@ -1585,7 +1577,6 @@ function isAnotherAdmin($memberID)
  * @param bool $only_active see prepareMembersByQuery
  *
  * @return array
- * @throws \Exception
  * @package Members
  *
  */
@@ -1632,7 +1623,6 @@ function membersBy($query, $query_params, $details = false, $only_active = true)
  * @param bool $only_active see prepareMembersByQuery
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  *
  */
@@ -1768,7 +1758,6 @@ function prepareMembersByQuery($query, &$query_params, $only_active = true)
  * @param int $id_admin = 0 if requested, only data about a specific admin is retrieved
  *
  * @return array
- * @throws \Exception
  * @package Members
  *
  */
@@ -1802,7 +1791,6 @@ function admins($id_admin = 0)
  * Get the last known id_member
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function maxMemberID()
 {
@@ -1833,7 +1821,6 @@ function maxMemberID()
  *    is_activated, validation_code, passwd_flood, password_salt
  * - 'preferences' (bool) includes lngfile, mod_prefs, notify_types, signature
  * @return mixed[]
- * @throws \Exception
  * @package Members
  */
 function getBasicMemberData($member_ids, $options = array())
@@ -1910,7 +1897,6 @@ function getBasicMemberData($member_ids, $options = array())
  * Counts all inactive members
  *
  * @return array $inactive_members
- * @throws \Exception
  * @package Members
  */
 function countInactiveMembers()
@@ -1943,7 +1929,6 @@ function countInactiveMembers()
  * @param string $name
  * @param bool $flexible if true searches for both real_name and member_name (default false)
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  */
 function getMemberByName($name, $flexible = false)
@@ -1980,7 +1965,6 @@ function getMemberByName($name, $flexible = false)
  * @param int[]|null $buddies
  *
  * @return array
- * @throws \Exception
  * @package Members
  *
  */
@@ -2040,7 +2024,6 @@ function getMember($search, $buddies = array())
  * - order_by (string)
  * - limit (int)
  * @return array
- * @throws \Exception
  * @package Members
  */
 function retrieveMemberData($conditions)
@@ -2132,7 +2115,6 @@ function retrieveMemberData($conditions)
  * - members (array of integers)
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  *
  */
@@ -2209,7 +2191,6 @@ function approveMembers($conditions)
  * - validation_code (string) must be present
  * - members (array of integers)
  * - time_before (integer)
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  */
 function enforceReactivation($conditions)
@@ -2256,7 +2237,6 @@ function enforceReactivation($conditions)
  *
  * @param int $id_group
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  */
 function countMembersInGroup($id_group = 0)
@@ -2284,7 +2264,6 @@ function countMembersInGroup($id_group = 0)
  *
  * @param string[] $conditions
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  */
 function countMembersOnline($conditions)
@@ -2313,7 +2292,6 @@ function countMembersOnline($conditions)
  * @param string $sort_direction
  * @param int $start
  * @return array
- * @throws \Exception
  * @package Members
  */
 function onlineMembers($conditions, $sort_method, $sort_direction, $start)
@@ -2349,7 +2327,6 @@ function onlineMembers($conditions, $sort_method, $sort_direction, $start)
  * @param int $limit
  *
  * @return array
- * @throws \Exception
  * @package Members
  *
  */
@@ -2376,7 +2353,6 @@ function recentMembers($limit)
  * @param int $member
  * @param int $primary_group
  * @param int[] $additional_groups
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  */
 function assignGroupsToMember($member, $primary_group, $additional_groups)
@@ -2391,7 +2367,6 @@ function assignGroupsToMember($member, $primary_group, $additional_groups)
  * @param string $where
  * @param bool $change_groups = false
  * @return mixed
- * @throws \Exception
  * @package Members
  */
 function getConcernedMembers($groups, $where, $change_groups = false)
@@ -2486,7 +2461,6 @@ function getConcernedMembers($groups, $where, $change_groups = false)
  * @param int $who The id of the user to contact
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  *
  */
@@ -2540,7 +2514,6 @@ function canContact($who)
  *
  * @param int|null $id_member = null If not an integer reload from the database
  * @param string|null $real_name = null
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  */
 function updateMemberStats($id_member = null, $real_name = null)
@@ -2607,7 +2580,6 @@ function updateMemberStats($id_member = null, $real_name = null)
  *
  * @param int $id_member a valid member id
  * @return string Query string
- * @throws \Exception
  * @package Members
  */
 function memberQuerySeeBoard($id_member)
@@ -2837,7 +2809,6 @@ function updateMemberData($members, $data)
  * @param string $ip_var
  *
  * @return array
- * @throws \Exception
  */
 function loadMembersIPs($ip_string, $ip_var)
 {
@@ -2869,7 +2840,6 @@ function loadMembersIPs($ip_string, $ip_var)
  * @param int $id_member
  * @param string $ip
  * @param string $agreement_version
- * @throws \Exception
  */
 function registerAgreementAccepted($id_member, $ip, $agreement_version)
 {

--- a/sources/subs/MembersOnline.subs.php
+++ b/sources/subs/MembersOnline.subs.php
@@ -27,7 +27,6 @@ use ElkArte\Util;
  *
  * @param mixed[] $membersOnlineOptions
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  */
 function getMembersOnlineStats($membersOnlineOptions)
@@ -204,7 +203,6 @@ function getMembersOnlineStats($membersOnlineOptions)
  * @param mixed[] $membersOnlineStats
  * @param string $sortFunction
  * @return mixed[]
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  */
 function filter_members_online($membersOnlineStats, $sortFunction)
@@ -241,7 +239,6 @@ function filter_members_online($membersOnlineStats, $sortFunction)
  * Check if the number of users online is a record and store it.
  *
  * @param int $total_users_online
- * @throws \ElkArte\Exceptions\Exception
  * @package Members
  */
 function trackStatsUsersOnline($total_users_online)

--- a/sources/subs/Mentions.subs.php
+++ b/sources/subs/Mentions.subs.php
@@ -22,7 +22,6 @@ use ElkArte\User;
  * @param string|null $id_member : the id of the member the counts are for, defaults to user_info['id']
  *
  * @return mixed
- * @throws \ElkArte\Exceptions\Exception
  * @package Mentions
  *
  */
@@ -78,7 +77,6 @@ function countUserMentions($all = false, $type = '', $id_member = null)
  * @param string[]|string $type : the type of the mention can be a string or an array of strings.
  *
  * @return array
- * @throws \Exception
  * @package Mentions
  *
  */
@@ -132,7 +130,6 @@ function getUserMentions($start, $limit, $sort, $all = false, $type = '')
  * @param int[] $id_mentions the mention ids
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Mentions
  *
  */
@@ -165,7 +162,6 @@ function removeMentions($id_mentions)
  *
  * @param int[] $msgs array of messages that you want to toggle
  * @param bool $approved direction of the toggle read / unread
- * @throws \ElkArte\Exceptions\Exception
  * @package Mentions
  */
 function toggleMentionsApproval($msgs, $approved)
@@ -207,7 +203,6 @@ function toggleMentionsApproval($msgs, $approved)
  *
  * @param string $type type of the mention that you want to toggle
  * @param bool $enable if true enables the mentions, otherwise disables them
- * @throws \ElkArte\Exceptions\Exception
  * @package Mentions
  */
 function toggleMentionsVisibility($type, $enable)
@@ -246,7 +241,6 @@ function toggleMentionsVisibility($type, $enable)
  *
  * @param int[] $mentions an array of mention id
  * @param bool $access if true make the mentions accessible (if visible and other things), otherwise marks them as inaccessible
- * @throws \ElkArte\Exceptions\Exception
  * @package Mentions
  */
 function toggleMentionsAccessibility($mentions, $access)
@@ -302,7 +296,6 @@ function validate_ownmention($field, $input, $validation_parameters = null)
  * @param int $id_mention the id of an existing mention
  * @param int $id_member id of a member
  * @return bool true if the mention belongs to the member, false otherwise
- * @throws \ElkArte\Exceptions\Exception
  * @package Mentions
  */
 function findMemberMention($id_mention, $id_member)
@@ -332,7 +325,6 @@ function findMemberMention($id_mention, $id_member)
  *
  * @param int|null $status
  * @param int $member_id
- * @throws \ElkArte\Exceptions\Exception
  * @package Mentions
  */
 function updateMentionMenuCount($status, $member_id)
@@ -361,7 +353,6 @@ function updateMentionMenuCount($status, $member_id)
  *
  * @param int $id_member
  * @return int A timestamp (log_time)
- * @throws \Exception
  * @package Mentions
  */
 function getTimeLastMention($id_member)
@@ -393,7 +384,6 @@ function getTimeLastMention($id_member)
  * @param int $id_member
  * @param int $timestamp
  * @return int Number of new mentions
- * @throws \Exception
  * @package Mentions
  */
 function getNewMentions($id_member, $timestamp)

--- a/sources/subs/Menu.subs.php
+++ b/sources/subs/Menu.subs.php
@@ -69,7 +69,6 @@ use ElkArte\Menu\Menu;
  *     - default_include_dir       => directory to include for function support
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function createMenu($menuData, $menuOptions = [])
 {
@@ -146,7 +145,6 @@ function destroyMenu($menu_id = 'last')
  * developers don't remove this until 3.0-dev
  *
  * @param array $selectedMenu
- * @throws \ElkArte\Exceptions\Exception
  */
 function callMenu($selectedMenu)
 {
@@ -162,7 +160,6 @@ function callMenu($selectedMenu)
  * Loads up all the default menu entries available.
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function loadDefaultMenuButtons()
 {

--- a/sources/subs/MessageIcons.subs.php
+++ b/sources/subs/MessageIcons.subs.php
@@ -68,7 +68,6 @@ function fetchMessageIconsDetails()
  * Delete a message icon.
  *
  * @param int[] $icons
- * @throws \ElkArte\Exceptions\Exception
  */
 function deleteMessageIcons($icons)
 {
@@ -88,7 +87,6 @@ function deleteMessageIcons($icons)
  * Updates a message icon.
  *
  * @param mixed[] $icon array of values to use in the $db->insert
- * @throws \Exception
  */
 function updateMessageIcon($icon)
 {
@@ -106,7 +104,6 @@ function updateMessageIcon($icon)
  * Adds a new message icon.
  *
  * @param mixed[] $icon associative array to use in the insert
- * @throws \Exception
  */
 function addMessageIcon($icon)
 {
@@ -129,7 +126,6 @@ function addMessageIcon($icon)
  *
  * @param int $board_id
  * @return array
- * @throws \Exception
  */
 function getMessageIcons($board_id)
 {

--- a/sources/subs/MessageIndex.subs.php
+++ b/sources/subs/MessageIndex.subs.php
@@ -31,7 +31,6 @@
  *     'custom_selects' => loads additional values from the tables used in the query, for addon use
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function messageIndexTopics($id_board, $id_member, $start, $items_per_page, $sort_by, $sort_column, $indexOptions)
 {
@@ -169,7 +168,6 @@ function messageIndexSort()
  * @param int[] $topic_ids array of topics ids to check for participation
  *
  * @return array
- * @throws \Exception
  */
 function topicsParticipation($id_member, $topic_ids)
 {

--- a/sources/subs/Messages.subs.php
+++ b/sources/subs/Messages.subs.php
@@ -32,7 +32,6 @@ use ElkArte\User;
  * @param int $attachment_type = 0
  *
  * @return array|bool
- * @throws \Exception
  */
 function messageDetails($id_msg, $id_topic = 0, $attachment_type = 0)
 {
@@ -102,7 +101,6 @@ function messageDetails($id_msg, $id_topic = 0, $attachment_type = 0)
  * @param bool $detailed
  *
  * @return mixed[]|false array of message details or false if no message found.
- * @throws \ElkArte\Exceptions\Exception
  */
 function basicMessageInfo($id_msg, $override_permissions = false, $detailed = false)
 {
@@ -144,7 +142,6 @@ function basicMessageInfo($id_msg, $override_permissions = false, $detailed = fa
  * @param bool $modify
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @todo why it doesn't take into account post moderation?
  */
 function quoteMessageInfo($id_msg, $modify)
@@ -278,7 +275,6 @@ function prepareMessageContext($message)
  * first messages of a topic
  *
  * @param int $memID The member id
- * @throws \Exception
  */
 function removeNonTopicMessages($memID)
 {
@@ -312,7 +308,6 @@ function removeNonTopicMessages($memID)
  *
  * @param int $message The message id
  * @param bool $decreasePostCount if true users' post count will be reduced
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeMessage($message, $decreasePostCount = true)
 {
@@ -382,7 +377,6 @@ function associatedTopic($msg_id, $topicID = null)
  * @param int $id_msg a message id
  * @param bool $check_approval if true messages are checked for approval (default true)
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  */
 function canAccessMessage($id_msg, $check_approval = true)
 {
@@ -416,7 +410,6 @@ function canAccessMessage($id_msg, $check_approval = true)
  * @param bool $next = true if true, it increases the pointer, otherwise it decreases it
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function messagePointer($id_msg, $id_topic, $next = true)
 {
@@ -446,7 +439,6 @@ function messagePointer($id_msg, $id_topic, $next = true)
  * @param int $id_topic
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function previousMessage($id_msg, $id_topic)
 {
@@ -460,7 +452,6 @@ function previousMessage($id_msg, $id_topic)
  * @param int $id_topic
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function nextMessage($id_msg, $id_topic)
 {
@@ -479,7 +470,6 @@ function nextMessage($id_msg, $id_topic)
  *      - 'limit' => mixed - the number of values to return (if false, no limits applied)
  *
  * @return array
- * @throws \Exception
  * @todo very similar to selectMessages in Topics.subs.php
  */
 function messageAt($start, $id_topic, $params = array())
@@ -533,7 +523,6 @@ function messageAt($start, $id_topic, $params = array())
  * @param string $poster_comment the comment made by the reporter
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  */
 function recordReport($message, $poster_comment)
 {
@@ -632,7 +621,6 @@ function recordReport($message, $poster_comment)
  * @param array $topicinfo
  * @param int $timestamp
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function countNewPosts($topic, $topicinfo, $timestamp)
 {
@@ -670,7 +658,6 @@ function countNewPosts($topic, $topicinfo, $timestamp)
  * @param mixed[] $optional
  *
  * @return resource A request object
- * @throws \ElkArte\Exceptions\Exception
  */
 function loadMessageRequest($msg_selects, $msg_tables, $msg_parameters, $optional = array())
 {
@@ -701,7 +688,6 @@ function loadMessageRequest($msg_selects, $msg_tables, $msg_parameters, $optiona
  * @param mixed[] $msg_parameters
  * @param mixed[] $optional
  * @return array
- * @throws \Exception
  */
 function loadMessageDetails($msg_selects, $msg_tables, $msg_parameters, $optional = array())
 {
@@ -741,7 +727,6 @@ function loadMessageDetails($msg_selects, $msg_tables, $msg_parameters, $optiona
  * @param int[] $messages
  * @param bool $allowed_all
  * @return array
- * @throws \Exception
  */
 function determineRemovableMessages($topic, $messages, $allowed_all)
 {
@@ -786,7 +771,6 @@ function determineRemovableMessages($topic, $messages, $allowed_all)
  * @param int[] $selection
  *
  * @return array
- * @throws \Exception
  */
 function countSplitMessages($topic, $include_unapproved, $selection = array())
 {
@@ -819,7 +803,6 @@ function countSplitMessages($topic, $include_unapproved, $selection = array())
  *
  * @param int $id_msg the id of a message
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @todo very similar to posterDetails
  *
  */
@@ -850,7 +833,6 @@ function mailFromMessage($id_msg)
  *
  * @param bool|null $increment = null If true and $max_msg_id != null, then increment the total messages by one, otherwise recount all messages and get the max message id
  * @param int|null $max_msg_id = null, Only used if $increment === true
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateMessageStats($increment = null, $max_msg_id = null)
 {
@@ -893,7 +875,6 @@ function updateMessageStats($increment = null, $max_msg_id = null)
  *
  * @param int $id_topic
  * @param string|null $subject
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateSubjectStats($id_topic, $subject = null)
 {

--- a/sources/subs/Moderation.subs.php
+++ b/sources/subs/Moderation.subs.php
@@ -31,7 +31,6 @@ use ElkArte\Util;
  *                           returns the both number of open PM and message reports
  *
  * @return array
- * @throws \Exception
  */
 function recountOpenReports($flush = true, $count_pms = false)
 {
@@ -95,7 +94,6 @@ function recountOpenReports($flush = true, $count_pms = false)
  *
  * @param string|null $approve_query
  * @return array of values
- * @throws \ElkArte\Exceptions\Exception
  */
 function recountUnapprovedPosts($approve_query = null)
 {
@@ -153,7 +151,6 @@ function recountUnapprovedPosts($approve_query = null)
  * @param string|null $approve_query
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function recountFailedEmails($approve_query = null)
 {
@@ -191,7 +188,6 @@ function recountFailedEmails($approve_query = null)
  * @param bool $show_pms
  *
  * @return int
- * @throws \Exception
  */
 function totalReports($status = 0, $show_pms = false)
 {
@@ -223,7 +219,6 @@ function totalReports($status = 0, $show_pms = false)
  * @param int $status the status of the property (mainly: 0 or 1)
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateReportsStatus($reports_id, $property = 'close', $status = 0)
 {
@@ -265,7 +260,6 @@ function updateReportsStatus($reports_id, $property = 'close', $status = 0)
  * @param int|null $brd
  *
  * @return mixed
- * @throws \ElkArte\Exceptions\Exception
  */
 function loadModeratorMenuCounts($brd = null)
 {
@@ -409,7 +403,6 @@ function loadModeratorMenuCounts($brd = null)
  * @param string $subject
  * @param string $body
  * @return int
- * @throws \Exception
  */
 function logWarningNotice($subject, $body)
 {
@@ -438,7 +431,6 @@ function logWarningNotice($subject, $body)
  * @param int $id_notice
  * @param int $level_change
  * @param string $warn_reason
- * @throws \Exception
  */
 function logWarning($memberID, $real_name, $id_notice, $level_change, $warn_reason)
 {
@@ -465,7 +457,6 @@ function logWarning($memberID, $real_name, $id_notice, $level_change, $warn_reas
  *
  * @param int $id_tpl id of the template to remove
  * @param string $template_type type of template, defaults to warntpl
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeWarningTemplate($id_tpl, $template_type = 'warntpl')
 {
@@ -516,7 +507,6 @@ function removeWarningTemplate($id_tpl, $template_type = 'warntpl')
  * @param string $template_type type of template to load
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function warningTemplates($start, $items_per_page, $sort, $template_type = 'warntpl')
 {
@@ -567,7 +557,6 @@ function warningTemplates($start, $items_per_page, $sort, $template_type = 'warn
  * @param string $template_type
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function warningTemplateCount($template_type = 'warntpl')
 {
@@ -603,7 +592,6 @@ function warningTemplateCount($template_type = 'warntpl')
  * @param mixed[] $query_params
  *
  * @return array
- * @throws \Exception
  */
 function warnings($start, $items_per_page, $sort, $query_string = '', $query_params = array())
 {
@@ -654,7 +642,6 @@ function warnings($start, $items_per_page, $sort, $query_string = '', $query_par
  * @param mixed[] $query_params
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function warningCount($query_string = '', $query_params = array())
 {
@@ -683,7 +670,6 @@ function warningCount($query_string = '', $query_params = array())
  *
  * @param int $id_template
  * @param string $template_type
- * @throws \Exception
  */
 function modLoadTemplate($id_template, $template_type = 'warntpl')
 {
@@ -725,7 +711,6 @@ function modLoadTemplate($id_template, $template_type = 'warntpl')
  * @param int $id_template
  * @param bool $edit true to update, false to insert a new row
  * @param string $type
- * @throws \ElkArte\Exceptions\Exception
  */
 function modAddUpdateTemplate($recipient_id, $template_title, $template_body, $id_template, $edit = true, $type = 'warntpl')
 {
@@ -779,7 +764,6 @@ function modAddUpdateTemplate($recipient_id, $template_title, $template_body, $i
  * @param bool $show_pms
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  */
 function modReportDetails($id_report, $show_pms = false)
 {
@@ -824,7 +808,6 @@ function modReportDetails($id_report, $show_pms = false)
  * @param bool $show_pms
  *
  * @return array
- * @throws \Exception
  * @todo move to createList?
  */
 function getModReports($status = 0, $start = 0, $limit = 10, $show_pms = false)
@@ -865,7 +848,6 @@ function getModReports($status = 0, $start = 0, $limit = 10, $show_pms = false)
  * @param int[] $id_reports an array of report ids
  *
  * @return array
- * @throws \Exception
  */
 function getReportsUserComments($id_reports)
 {
@@ -898,7 +880,6 @@ function getReportsUserComments($id_reports)
  * @param int $id_report the id of a report
  *
  * @return array
- * @throws \Exception
  */
 function getReportModeratorsComments($id_report)
 {
@@ -987,7 +968,6 @@ function approveAllUnapproved()
  *
  * @param int $warning_watch
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function watchedUserCount($warning_watch = 0)
 {
@@ -1019,7 +999,6 @@ function watchedUserCount($warning_watch = 0)
  * @param string $sort A string indicating how to sort the results
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function watchedUsers($start, $items_per_page, $sort)
 {
@@ -1129,7 +1108,6 @@ function watchedUsers($start, $items_per_page, $sort)
  * @param string $approve_query
  * @param int $warning_watch
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function watchedUserPostsCount($approve_query, $warning_watch)
 {
@@ -1170,7 +1148,6 @@ function watchedUserPostsCount($approve_query, $warning_watch)
  * @param int[] $delete_boards
  *
  * @return array
- * @throws \Exception
  */
 function watchedUserPosts($start, $items_per_page, $approve_query, $delete_boards)
 {
@@ -1318,7 +1295,6 @@ function basicWatchedUsers()
  * @param bool $show_pms
  *
  * @return array
- * @throws \Exception
  */
 function reportedPosts($show_pms = false)
 {
@@ -1367,7 +1343,6 @@ function reportedPosts($show_pms = false)
  * Remove a moderator note.
  *
  * @param int $id_note
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeModeratorNote($id_note)
 {
@@ -1389,7 +1364,6 @@ function removeModeratorNote($id_note)
  * Get the number of moderator notes stored on the site.
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function countModeratorNotes()
 {
@@ -1423,7 +1397,6 @@ function countModeratorNotes()
  * @param int $id_poster who is posting the add
  * @param string $poster_name a name to show
  * @param string $contents what they are posting
- * @throws \Exception
  */
 function addModeratorNote($id_poster, $poster_name, $contents)
 {
@@ -1448,7 +1421,6 @@ function addModeratorNote($id_poster, $poster_name, $contents)
  *
  * @param int $report
  * @param string $newComment
- * @throws \Exception
  */
 function addReportComment($report, $newComment)
 {
@@ -1475,7 +1447,6 @@ function addReportComment($report, $newComment)
  * @param int $offset
  *
  * @return array
- * @throws \Exception
  */
 function moderatorNotes($offset)
 {
@@ -1520,7 +1491,6 @@ function moderatorNotes($offset)
  * @param int $id_notice
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function moderatorNotice($id_notice)
 {
@@ -1556,7 +1526,6 @@ function moderatorNotice($id_notice)
  * @param int $member The member we are going to issue the warning to
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function warningDailyLimit($member)
 {
@@ -1601,7 +1570,6 @@ function warningDailyLimit($member)
  * @param int $limit number of elements to return (default 10)
  *
  * @return array
- * @throws \Exception
  */
 function getUnapprovedPosts($approve_query, $current_view, $boards_allowed, $start, $limit = 10)
 {

--- a/sources/subs/Modlog.subs.php
+++ b/sources/subs/Modlog.subs.php
@@ -26,7 +26,6 @@ use ElkArte\Util;
  * @param int $log_type
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function list_getModLogEntryCount($query_string = '', $query_params = array(), $log_type = 1)
 {
@@ -69,7 +68,6 @@ function list_getModLogEntryCount($query_string = '', $query_params = array(), $
  * @param int $log_type
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '', $query_params = array(), $log_type = 1)
 {
@@ -446,7 +444,6 @@ class ModLogEntriesReplacement
  * @param int $id_log
  * @param int $time
  * @param string[]|null $delete
- * @throws \ElkArte\Exceptions\Exception
  */
 function deleteLogAction($id_log, $time, $delete = null)
 {
@@ -472,7 +469,6 @@ function deleteLogAction($id_log, $time, $delete = null)
  * @param int $time Timeframe since the last time the action has been performed
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  */
 function recentlyLogged($action, $time = 60)
 {

--- a/sources/subs/News.subs.php
+++ b/sources/subs/News.subs.php
@@ -56,7 +56,6 @@ function getNews()
  * - Only get the ones that can't login to turn off notification.
  *
  * @return array
- * @throws \Exception
  * @package News
  */
 function excludeBannedMembers()
@@ -128,7 +127,6 @@ function excludeBannedMembers()
  * Get a list of our local board moderators.
  *
  * @return array
- * @throws \Exception
  * @package News
  */
 function getModerators()
@@ -164,7 +162,6 @@ function getModerators()
  * @param int $increment
  * @param int $counter
  * @return array
- * @throws \Exception
  * @package News
  */
 function getNewsletterRecipients($sendQuery, $sendParams, $start, $increment, $counter)
@@ -212,7 +209,6 @@ function getNewsletterRecipients($sendQuery, $sendParams, $start, $increment, $c
  * @param int $limit
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package News
  *
  */
@@ -293,7 +289,6 @@ function getXMLNews($query_this_board, $board, $limit)
  * @param int $limit
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package News
  *
  */

--- a/sources/subs/Notification.subs.php
+++ b/sources/subs/Notification.subs.php
@@ -453,7 +453,6 @@ function sendNotifications($topics, $type, $exclude = array(), $members_only = a
  * loads the Post language file multiple times for each language if the userLanguage setting is set.
  *
  * @param mixed[] $topicData
- * @throws \ElkArte\Exceptions\Exception
  */
 function sendBoardNotifications(&$topicData)
 {
@@ -642,7 +641,6 @@ function sendBoardNotifications(&$topicData)
  * A special function for handling the hell which is sending approval notifications.
  *
  * @param mixed[] $topicData
- * @throws \ElkArte\Exceptions\Exception
  */
 function sendApprovalNotifications(&$topicData)
 {
@@ -804,7 +802,6 @@ function sendApprovalNotifications(&$topicData)
  * @param string $type types supported are 'approval', 'activation', and 'standard'.
  * @param int $memberID
  * @param string|null $member_name = null
- * @throws \ElkArte\Exceptions\Exception
  * @uses the Login language file.
  */
 function sendAdminNotifications($type, $memberID, $member_name = null)
@@ -914,7 +911,6 @@ function sendAdminNotifications($type, $memberID, $member_name = null)
  * @param bool $email_perm
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  */
 function validateNotificationAccess($row, $maillist, &$email_perm = true)
 {

--- a/sources/subs/Package.subs.php
+++ b/sources/subs/Package.subs.php
@@ -34,7 +34,6 @@ use ElkArte\XmlArray;
  * @param bool $overwrite = false
  * @param string[]|null $files_to_extract = null
  * @return array|bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Packages
  */
 function read_tgz_file($gzfilename, $destination, $single_file = false, $overwrite = false, $files_to_extract = null)
@@ -88,7 +87,6 @@ function read_tgz_file($gzfilename, $destination, $single_file = false, $overwri
  * @param bool $overwrite = false,
  * @param string[]|null $files_to_extract = null
  * @return mixed[]|bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Packages
  */
 function read_tgz_data($data, $destination, $single_file = false, $overwrite = false, $files_to_extract = null)
@@ -119,7 +117,6 @@ function read_tgz_data($data, $destination, $single_file = false, $overwrite = f
  * @param bool $overwrite
  * @param string[]|null $files_to_extract
  * @return mixed[]|bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Packages
  */
 function read_zip_data($data, $destination, $single_file = false, $overwrite = false, $files_to_extract = null)
@@ -173,7 +170,6 @@ function url_exists($url)
  * - Default sort order is package_installed time
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Packages
  */
 function loadInstalledPackages()
@@ -243,7 +239,6 @@ function loadInstalledPackages()
  * @param string $gzfilename
  *
  * @return array|string error string on error array on success
- * @throws \ElkArte\Exceptions\Exception
  * @package Packages
  */
 function getPackageInfo($gzfilename)
@@ -325,7 +320,6 @@ function getPackageInfo($gzfilename)
  * @param mixed[] $chmodOptions
  * @param bool $restore_write_status
  * @return array|bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Packages
  */
 function create_chmod_control($chmodFiles = array(), $chmodOptions = array(), $restore_write_status = false)
@@ -676,7 +670,6 @@ function list_restoreFiles($dummy1, $dummy2, $dummy3, $do_change)
  * @param bool $return = false
  *
  * @return null|string[]
- * @throws \ElkArte\Exceptions\Exception
  * @package Packages
  *
  */
@@ -2836,7 +2829,6 @@ function package_crypt($pass)
  * @param string $id
  *
  * @return bool
- * @throws \Exception
  * @package Packages
  *
  */
@@ -3060,7 +3052,6 @@ function fetch_web_data($url, $post_data = '', $keep_alive = false, $redirection
  * @param string|null $install_id to check
  *
  * @return array
- * @throws \Exception
  * @package Packages
  */
 function isPackageInstalled($id, $install_id = null)
@@ -3115,7 +3106,6 @@ function isPackageInstalled($id, $install_id = null)
  *
  * @param string $id package_id to update
  * @param string $install_id install id of the package
- * @throws \ElkArte\Exceptions\Exception
  * @package Packages
  */
 function setPackageState($id, $install_id)
@@ -3146,7 +3136,6 @@ function setPackageState($id, $install_id)
  * @param string $id
  *
  * @return string
- * @throws \Exception
  * @package Packages
  *
  */
@@ -3185,7 +3174,6 @@ function checkPackageDependency($id)
  * @param string $db_changes
  * @param bool $is_upgrade
  * @param string $credits_tag
- * @throws \Exception
  * @package Packages
  */
 function addPackageLog($packageInfo, $failed_step_insert, $themes_installed, $db_changes, $is_upgrade, $credits_tag)

--- a/sources/subs/PackageServers.subs.php
+++ b/sources/subs/PackageServers.subs.php
@@ -16,7 +16,6 @@
  *
  * @param int|null $server
  * @return array
- * @throws \Exception
  * @package Packages
  */
 function fetchPackageServers($server = null)
@@ -51,7 +50,6 @@ function fetchPackageServers($server = null)
  * Delete a package server
  *
  * @param int $id
- * @throws \ElkArte\Exceptions\Exception
  * @package Packages
  */
 function deletePackageServer($id)
@@ -72,7 +70,6 @@ function deletePackageServer($id)
  *
  * @param string $name
  * @param string $url
- * @throws \Exception
  * @package Packages
  */
 function addPackageServer($name, $url)

--- a/sources/subs/PaidSubscriptions.subs.php
+++ b/sources/subs/PaidSubscriptions.subs.php
@@ -25,7 +25,6 @@ use ElkArte\Util;
  * @param mixed[] $search_vars = array()
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @todo refactor away
  *
  */
@@ -64,7 +63,6 @@ function list_getSubscribedUserCount($id_sub, $search_string, $search_vars = arr
  * @param mixed[] $search_vars
  *
  * @return array
- * @throws \Exception
  * @todo refactor outta here
  *
  */
@@ -115,7 +113,6 @@ function list_getSubscribedUsers($start, $items_per_page, $sort, $id_sub, $searc
  * Reapplies all subscription rules for each of the users.
  *
  * @param int[]|int $users
- * @throws \ElkArte\Exceptions\Exception
  */
 function reapplySubscriptions($users)
 {
@@ -197,7 +194,6 @@ function reapplySubscriptions($users)
  * @param string $renewal options 'D', 'W', 'M', 'Y', ''
  * @param int $forceStartTime = 0
  * @param int $forceEndTime = 0
- * @throws \ElkArte\Exceptions\Exception
  */
 function addSubscription($id_subscribe, $id_member, $renewal = '', $forceStartTime = 0, $forceEndTime = 0)
 {
@@ -597,7 +593,6 @@ function loadSubscriptions()
  * @param mixed[] $active_subscriptions array of active subscriptions they can have
  *
  * @return array
- * @throws \Exception
  */
 function loadMemberSubscriptions($memID, $active_subscriptions)
 {
@@ -646,7 +641,6 @@ function loadMemberSubscriptions($memID, $active_subscriptions)
  * @param int $sub_id id of the subscription we are looking for
  *
  * @return array
- * @throws \Exception
  */
 function loadAllSubsctiptions($sub_id)
 {
@@ -690,7 +684,6 @@ function loadAllSubsctiptions($sub_id)
  * were related to the subscription
  *
  * @param int $id
- * @throws \ElkArte\Exceptions\Exception
  */
 function deleteSubscription($id)
 {
@@ -759,7 +752,6 @@ function deleteSubscription($id)
  * Adds a new subscription
  *
  * @param mixed[] $insert
- * @throws \Exception
  */
 function insertSubscription($insert)
 {
@@ -788,7 +780,6 @@ function insertSubscription($insert)
  *
  * @param int $sub_id
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function countActiveSubscriptions($sub_id)
 {
@@ -817,7 +808,6 @@ function countActiveSubscriptions($sub_id)
  *
  * @param mixed[] $update
  * @param int $ignore_active - used to ignore already active subscriptions.
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateSubscription($update, $ignore_active)
 {
@@ -853,7 +843,6 @@ function updateSubscription($update, $ignore_active)
  * (one-time payment)
  *
  * @param mixed[] $subscription_info
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateNonrecurrent($subscription_info)
 {
@@ -877,7 +866,6 @@ function updateNonrecurrent($subscription_info)
  *
  * @param int $sub_id
  * @return array
- * @throws \Exception
  */
 function getSubscriptionDetails($sub_id)
 {
@@ -973,7 +961,6 @@ function validateSubscriptionID($id)
  * @param int $id_sub
  * @param int $id_member
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  */
 function alreadySubscribed($id_sub, $id_member)
 {
@@ -1040,7 +1027,6 @@ function getSubscriptionStatus($log_id)
  * Somebody paid again? we need to log that.
  *
  * @param int[] $item
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateSubscriptionItem($item)
 {
@@ -1067,7 +1053,6 @@ function updateSubscriptionItem($item)
  * @param mixed[] $subscription_info the subscription information array
  * @param int $member_id
  * @param int $time
- * @throws \ElkArte\Exceptions\Exception
  */
 function handleRefund($subscription_info, $member_id, $time)
 {
@@ -1111,7 +1096,6 @@ function handleRefund($subscription_info, $member_id, $time)
  *
  * @param int[] $toDelete
  * @return array $delete
- * @throws \Exception
  */
 function prepareDeleteSubscriptions($toDelete)
 {
@@ -1140,7 +1124,6 @@ function prepareDeleteSubscriptions($toDelete)
  *
  * @param int $log_id
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function getPendingSubscriptions($log_id)
 {
@@ -1165,7 +1148,6 @@ function getPendingSubscriptions($log_id)
  * Somebody paid the first time? Let's log ...
  *
  * @param mixed[] $details associative array for the insert
- * @throws \Exception
  */
 function logSubscription($details)
 {
@@ -1191,7 +1173,6 @@ function logSubscription($details)
  * @param int $sub_id
  * @param int $memID
  * @param string $pending_details
- * @throws \Exception
  */
 function logNewSubscription($sub_id, $memID, $pending_details)
 {
@@ -1215,7 +1196,6 @@ function logNewSubscription($sub_id, $memID, $pending_details)
  *
  * @param int $sub_id
  * @param string $details
- * @throws \ElkArte\Exceptions\Exception
  */
 function updatePendingSubscription($sub_id, $details)
 {
@@ -1241,7 +1221,6 @@ function updatePendingSubscription($sub_id, $details)
  * @param int $sub_id
  * @param int $memID
  * @param string $details
- * @throws \ElkArte\Exceptions\Exception
  */
 function updatePendingSubscriptionCount($pending_count, $sub_id, $memID, $details)
 {
@@ -1271,7 +1250,6 @@ function updatePendingSubscriptionCount($pending_count, $sub_id, $memID, $detail
  * @param int $sub_id
  * @param int $memID
  * @param string $details
- * @throws \ElkArte\Exceptions\Exception
  */
 function updatePendingStatus($sub_id, $memID, $details)
 {
@@ -1297,7 +1275,6 @@ function updatePendingStatus($sub_id, $memID, $details)
  * @param int $id_subscribe
  * @param int $id_member
  * @param bool $delete
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeSubscription($id_subscribe, $id_member, $delete = false)
 {

--- a/sources/subs/PersonalMessage.subs.php
+++ b/sources/subs/PersonalMessage.subs.php
@@ -67,7 +67,6 @@ function loadMessageLimit()
  *
  * @return mixed[]
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadPMLabels($labels)
 {
@@ -114,7 +113,6 @@ function loadPMLabels($labels)
  * @param string $labelQuery
  * @return int
  * @package PersonalMessage
- * @throws \Exception
  */
 function getPMCount($descending = false, $pmID = null, $labelQuery = '')
 {
@@ -170,7 +168,6 @@ function getPMCount($descending = false, $pmID = null, $labelQuery = '')
  * @param string|null $folder = null
  * @param int|int[]|null $owner = null
  * @package PersonalMessage
- * @throws \Exception
  */
 function deleteMessages($personal_messages, $folder = null, $owner = null)
 {
@@ -335,7 +332,6 @@ function deleteMessages($personal_messages, $folder = null, $owner = null)
  * @param string|null $label = null, if label is set, only marks messages with that label
  * @param int|null $owner = null, if owner is set, marks messages owned by that member id
  * @package PersonalMessage
- * @throws \Exception
  */
 function markMessages($personal_messages = null, $label = null, $owner = null)
 {
@@ -378,7 +374,6 @@ function markMessages($personal_messages = null, $label = null, $owner = null)
  *
  * @param int|int[] $personal_messages
  * @package PersonalMessage
- * @throws \Exception
  */
 function markMessagesUnread($personal_messages)
 {
@@ -424,7 +419,6 @@ function markMessagesUnread($personal_messages)
  *
  * @param int $owner
  * @package PersonalMessage
- * @throws \Exception
  */
 function updatePMMenuCounts($owner)
 {
@@ -544,7 +538,6 @@ function isAccessiblePM($pmID, $validFor = 'in_or_outbox')
  * @param mixed[]|null $from - an array with the id, name, and username of the member.
  * @param int $pm_head - the ID of the chain being replied to - if any.
  * @return mixed[] an array with log entries telling how many recipients were successful and which recipients it failed to send to.
- * @throws \ElkArte\Exceptions\Exception
  * @package PersonalMessage
  */
 function sendpm($recipients, $subject, $message, $store_outbox = true, $from = null, $pm_head = 0)
@@ -1020,7 +1013,6 @@ function sendpm($recipients, $subject, $message, $store_outbox = true, $from = n
  *
  * @return array
  * @package PersonalMessage
- * @throws \ElkArte\Exceptions\Exception
  */
 function loadPMs($pm_options, $id_member)
 {
@@ -1189,7 +1181,6 @@ function loadPMs($pm_options, $id_member)
  *
  * @return mixed
  * @package PersonalMessage
- * @throws \Exception
  */
 function pmCount($id_member, $time)
 {
@@ -1222,7 +1213,6 @@ function pmCount($id_member, $time)
  *
  * @param bool $all_messages = false
  * @package PersonalMessage
- * @throws \Exception
  */
 function applyRules($all_messages = false)
 {
@@ -1354,7 +1344,6 @@ function applyRules($all_messages = false)
  *
  * @param bool $reload = false
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadRules($reload = false)
 {
@@ -1415,7 +1404,6 @@ function loadRules($reload = false)
  * @param int $id_member
  * @param bool $new = false
  * @package PersonalMessage
- * @throws \Exception
  */
 function toggleNewPM($id_member, $new = false)
 {
@@ -1441,7 +1429,6 @@ function toggleNewPM($id_member, $new = false)
  *
  * @return array
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadPMLimits($id_group = false)
 {
@@ -1477,7 +1464,6 @@ function loadPMLimits($id_group = false)
  *
  * @return array
  * @package PersonalMessage
- * @throws \Exception
  */
 function getDiscussions($id_pms)
 {
@@ -1508,7 +1494,6 @@ function getDiscussions($id_pms)
  *
  * @return array
  * @package PersonalMessage
- * @throws \Exception
  */
 function getPmsFromDiscussion($pm_heads)
 {
@@ -1541,7 +1526,6 @@ function getPmsFromDiscussion($pm_heads)
  * @param int $user_id
  * @return int|null
  * @package PersonalMessage
- * @throws \Exception
  */
 function changePMLabels($to_label, $label_type, $user_id)
 {
@@ -1610,7 +1594,6 @@ function changePMLabels($to_label, $label_type, $user_id)
  * @param int $user_id
  * @return int|null
  * @package PersonalMessage
- * @throws \Exception
  */
 function updateLabelsToPM($searchArray, $new_labels, $user_id)
 {
@@ -1671,7 +1654,6 @@ function updateLabelsToPM($searchArray, $new_labels, $user_id)
  * @param int $user_id
  * @return int
  * @package PersonalMessage
- * @throws \Exception
  */
 function updatePMLabels($to_update, $user_id)
 {
@@ -1715,7 +1697,6 @@ function updatePMLabels($to_update, $user_id)
  * @param int $time timestamp with a specific date
  * @return array
  * @package PersonalMessage
- * @throws \Exception
  */
 function getPMsOlderThan($user_id, $time)
 {
@@ -1772,7 +1753,6 @@ function getPMsOlderThan($user_id, $time)
  * @param int $id_member
  * @param int[] $rule_changes
  * @package PersonalMessage
- * @throws \Exception
  */
 function deletePMRules($id_member, $rule_changes)
 {
@@ -1796,7 +1776,6 @@ function deletePMRules($id_member, $rule_changes)
  * @param int $id_member
  * @param mixed[] $actions
  * @package PersonalMessage
- * @throws \Exception
  */
 function updatePMRuleAction($id_rule, $id_member, $actions)
 {
@@ -1826,7 +1805,6 @@ function updatePMRuleAction($id_rule, $id_member, $actions)
  * @param int $doDelete
  * @param int $isOr
  * @package PersonalMessage
- * @throws \Exception
  */
 function addPMRule($id_member, $ruleName, $criteria, $actions, $doDelete, $isOr)
 {
@@ -1856,7 +1834,6 @@ function addPMRule($id_member, $ruleName, $criteria, $actions, $doDelete, $isOr)
  * @param int $doDelete
  * @param int $isOr
  * @package PersonalMessage
- * @throws \Exception
  */
 function updatePMRule($id_member, $id_rule, $ruleName, $criteria, $actions, $doDelete, $isOr)
 {
@@ -1887,7 +1864,6 @@ function updatePMRule($id_member, $id_rule, $ruleName, $criteria, $actions, $doD
  * @param int $id_member
  * @param int $replied_to
  * @package PersonalMessage
- * @throws \Exception
  */
 function setPMRepliedStatus($id_member, $replied_to)
 {
@@ -1917,7 +1893,6 @@ function setPMRepliedStatus($id_member, $replied_to)
  *
  * @return array
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadConversationList($head, &$recipients, $folder = '')
 {
@@ -1978,7 +1953,6 @@ function loadConversationList($head, &$recipients, $folder = '')
  *
  * @return array
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadConversationUnreadStatus($pms)
 {
@@ -2049,7 +2023,6 @@ function loadConversationUnreadStatus($pms)
  *
  * @return array
  * @package PersonalMessage
- * @throws \Exception
  *
  */
 function loadPMRecipientInfo($all_pms, &$recipients, $folder = '', $search = false)
@@ -2125,7 +2098,6 @@ function loadPMRecipientInfo($all_pms, &$recipients, $folder = '', $search = fal
  * @param string[] $orderBy raw query defining how to order the results
  * @return bool|resource
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadPMSubjectRequest($pms, $orderBy)
 {
@@ -2164,7 +2136,6 @@ function loadPMSubjectRequest($pms, $orderBy)
  * @param string $folder current pm folder
  * @return bool|resource
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadPMMessageRequest($display_pms, $sort_by_query, $sort_by, $descending, $display_mode = '', $folder = '')
 {
@@ -2196,7 +2167,6 @@ function loadPMMessageRequest($display_pms, $sort_by_query, $sort_by, $descendin
  *
  * @return bool
  * @package PersonalMessage
- * @throws \Exception
  */
 function checkPMReceived($pmsg)
 {
@@ -2228,7 +2198,6 @@ function checkPMReceived($pmsg)
  *
  * @return bool
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadPMQuote($pmsg, $isReceived)
 {
@@ -2269,7 +2238,6 @@ function loadPMQuote($pmsg, $isReceived)
  *
  * @return array
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadPMRecipientsAll($pmsg, $bcc_count = false)
 {
@@ -2377,7 +2345,6 @@ function loadPersonalMessage($pm_id)
  * @param mixed[] $searchq_parameters value parameters used in the above query
  * @return int
  * @package PersonalMessage
- * @throws \Exception
  */
 function numPMSeachResults($userQuery, $labelQuery, $timeQuery, $searchQuery, $searchq_parameters)
 {
@@ -2421,7 +2388,6 @@ function numPMSeachResults($userQuery, $labelQuery, $timeQuery, $searchQuery, $s
  *
  * @return array
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadPMSearchMessages($userQuery, $labelQuery, $timeQuery, $searchQuery, $searchq_parameters, $search_params)
 {
@@ -2471,7 +2437,6 @@ function loadPMSearchMessages($userQuery, $labelQuery, $timeQuery, $searchQuery,
  *
  * @return array
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadPMSearchHeads($head_pms)
 {
@@ -2512,7 +2477,6 @@ function loadPMSearchHeads($head_pms)
  *
  * @return array
  * @package PersonalMessage
- * @throws \Exception
  */
 function loadPMSearchResults($foundMessages, $search_params)
 {

--- a/sources/subs/Poll.subs.php
+++ b/sources/subs/Poll.subs.php
@@ -46,7 +46,6 @@ function associatedPoll($topicID, $pollID = null)
  * Remove a poll.
  *
  * @param int[]|int $pollID The id of the poll to remove
- * @throws \ElkArte\Exceptions\Exception
  */
 function removePoll($pollID)
 {
@@ -86,7 +85,6 @@ function removePoll($pollID)
  * Reset votes for the poll.
  *
  * @param int $pollID The ID of the poll to reset the votes on
- * @throws \ElkArte\Exceptions\Exception
  */
 function resetVotes($pollID)
 {
@@ -136,7 +134,6 @@ function resetVotes($pollID)
  *             This param is currently used only in SSI, it may be useful in any
  *             kind of integration
  * @return array|false array of poll information, or false if no poll is found
- * @throws \ElkArte\Exceptions\Exception
  */
 function pollInfo($id_poll, $ignore_permissions = true)
 {
@@ -209,7 +206,6 @@ function pollInfo($id_poll, $ignore_permissions = true)
  * @param int $topicID the topic with an associated poll.
  *
  * @return string[]|bool
- * @throws \ElkArte\Exceptions\Exception
  */
 function pollInfoForTopic($topicID)
 {
@@ -249,7 +245,6 @@ function pollInfoForTopic($topicID)
  *
  * @param int $pollID the topic with an associated poll.
  * @return array the topic id and the board id, false if no topics found
- * @throws \ElkArte\Exceptions\Exception
  */
 function topicFromPoll($pollID)
 {
@@ -298,7 +293,6 @@ function topicFromPoll($pollID)
  * @param int $id_member The id of the member
  *
  * @return array
- * @throws \Exception
  */
 function pollOptionsForMember($id_poll, $id_member)
 {
@@ -335,7 +329,6 @@ function pollOptionsForMember($id_poll, $id_member)
  * @param int $id_poll The id of the poll to load its options
  *
  * @return array
- * @throws \Exception
  */
 function pollOptions($id_poll)
 {
@@ -373,7 +366,6 @@ function pollOptions($id_poll)
  * @param int $can_guest_vote = 0 If guests can vote
  * @param mixed[] $options = array() The poll options
  * @return int the id of the created poll
- * @throws \Exception
  */
 function createPoll($question, $id_member, $poster_name, $max_votes = 1, $hide_results = 1, $expire = 0, $can_change_vote = 0, $can_guest_vote = 0, array $options = array())
 {
@@ -415,7 +407,6 @@ function createPoll($question, $id_member, $poster_name, $max_votes = 1, $hide_r
  * @param int $expire = 0 The time in days that this poll will expire
  * @param int $can_change_vote = 0 If you can change your vote
  * @param int $can_guest_vote = 0 If guests can vote
- * @throws \ElkArte\Exceptions\Exception
  */
 function modifyPoll($id_poll, $question, $max_votes = 1, $hide_results = 1, $expire = 0, $can_change_vote = 0, $can_guest_vote = 0)
 {
@@ -449,7 +440,6 @@ function modifyPoll($id_poll, $question, $max_votes = 1, $hide_results = 1, $exp
  *
  * @param int $id_poll The id of the poll you're adding the options to
  * @param mixed[] $options The options to choose from
- * @throws \Exception
  */
 function addPollOptions($id_poll, array $options)
 {
@@ -473,7 +463,6 @@ function addPollOptions($id_poll, array $options)
  * Insert some options to an already created poll
  *
  * @param mixed[] $options An array holding the poll choices
- * @throws \Exception
  */
 function insertPollOptions($options)
 {
@@ -493,7 +482,6 @@ function insertPollOptions($options)
  * Add a single option to an already created poll
  *
  * @param mixed[] $options An array holding the poll choices
- * @throws \ElkArte\Exceptions\Exception
  */
 function modifyPollOption($options)
 {
@@ -521,7 +509,6 @@ function modifyPollOption($options)
  *
  * @param int $id_poll The id of the poll you're deleting the options from
  * @param int[] $id_options An array holding the choice id
- * @throws \ElkArte\Exceptions\Exception
  */
 function deletePollOptions($id_poll, $id_options)
 {
@@ -555,7 +542,6 @@ function deletePollOptions($id_poll, $id_options)
  * @param int $id_topic The id of the topic
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function pollStarters($id_topic)
 {
@@ -589,7 +575,6 @@ function pollStarters($id_topic)
  *
  * @param int $topic the topic with an associated poll
  * @return mixed[]
- * @throws \Exception
  */
 function checkVote($topic)
 {
@@ -617,7 +602,6 @@ function checkVote($topic)
  *
  * @param int $id_member The id of the member
  * @param int $id_poll The topic with an associated poll.
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeVote($id_member, $id_poll)
 {
@@ -639,7 +623,6 @@ function removeVote($id_member, $id_poll)
  *
  * @param int $id_poll The id of the poll to lower the vote count
  * @param int[] $options The available poll options
- * @throws \ElkArte\Exceptions\Exception
  */
 function decreaseVoteCounter($id_poll, $options)
 {
@@ -665,7 +648,6 @@ function decreaseVoteCounter($id_poll, $options)
  *
  * @param int $id_poll The id of the poll to increase the vote count
  * @param int[] $options The available poll options
- * @throws \ElkArte\Exceptions\Exception
  */
 function increaseVoteCounter($id_poll, $options)
 {
@@ -688,7 +670,6 @@ function increaseVoteCounter($id_poll, $options)
  * Add a vote to a poll.
  *
  * @param mixed[] $insert array of vote details, includes member and their choice
- * @throws \Exception
  */
 function addVote($insert)
 {
@@ -706,7 +687,6 @@ function addVote($insert)
  * Increase the vote counter for guest votes.
  *
  * @param int $id_poll The id of the poll to increase
- * @throws \ElkArte\Exceptions\Exception
  */
 function increaseGuestVote($id_poll)
 {
@@ -730,7 +710,6 @@ function increaseGuestVote($id_poll)
  * @param int $id_poll id fo the poll the member voted in
  *
  * @return int[]
- * @throws \Exception
  */
 function determineVote($id_member, $id_poll)
 {
@@ -761,7 +740,6 @@ function determineVote($id_member, $id_poll)
  *
  * @param int $id_topic
  * @return string[]|bool
- * @throws \Exception
  * @deprecated since 2.0 - use pollInfoForTopic instead
  */
 function pollStatus($id_topic)
@@ -776,7 +754,6 @@ function pollStatus($id_topic)
  *
  * @param int $id_poll The id of the poll to check
  * @param int $locked the value to set in voting_locked
- * @throws \ElkArte\Exceptions\Exception
  */
 function lockPoll($id_poll, $locked)
 {
@@ -799,7 +776,6 @@ function lockPoll($id_poll, $locked)
  *
  * @param int $id_poll The id of the poll
  * @return array
- * @throws \Exception
  */
 function getPollChoices($id_poll)
 {
@@ -868,7 +844,6 @@ function getPollStarter($id_topic)
  * Loads in $context whatever is needed to show a poll
  *
  * @param int $poll_id simply a poll id...
- * @throws \ElkArte\Exceptions\Exception
  */
 function loadPollContext($poll_id)
 {

--- a/sources/subs/Post.subs.php
+++ b/sources/subs/Post.subs.php
@@ -67,7 +67,6 @@ function un_preparsecode($message)
  * @param mixed[] $posterOptions
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Posts
  *
  */
@@ -449,7 +448,6 @@ function createPost(&$msgOptions, &$topicOptions, &$posterOptions)
  * @param mixed[] $posterOptions
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Posts
  *
  */
@@ -625,7 +623,6 @@ function modifyPost(&$msgOptions, &$topicOptions, &$posterOptions)
  * @param bool $approve = true
  *
  * @return bool|void
- * @throws \ElkArte\Exceptions\Exception
  * @package Posts
  *
  */
@@ -910,7 +907,6 @@ function approvePosts($msgs, $approve = true)
  * @param int $id_msg = 0
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  * @package Posts
  *
  */
@@ -1073,7 +1069,6 @@ function updateLastMessages($setboards, $id_msg = 0)
  * - respects approved, recycled, and board permissions
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package Posts
  */
 function lastPost()
@@ -1144,7 +1139,7 @@ function lastPost()
  * @param int $msg_id
  *
  * @return false|mixed[]
- * @throws \ElkArte\Exceptions\Exception
+ * @throws \ElkArte\Exceptions\Exception quoted_post_deleted
  * @package Posts
  *
  */
@@ -1259,7 +1254,6 @@ function getFormMsgSubject($editing, $topic, $first_subject = '', $msg_id = 0)
  * @param string $custom_subject
  * @param string $response_prefix = ''
  * @param bool $all = false
- * @throws \ElkArte\Exceptions\Exception
  * @package Posts
  */
 function topicSubject($topic_info, $custom_subject, $response_prefix = '', $all = false)

--- a/sources/subs/Profile.subs.php
+++ b/sources/subs/Profile.subs.php
@@ -1165,7 +1165,6 @@ function loadProfileFields($force_reload = false)
  *
  * @param string[] $fields
  * @param string $hook
- * @throws \ElkArte\Exceptions\Exception
  */
 function saveProfileFields($fields, $hook)
 {
@@ -1346,7 +1345,6 @@ function saveProfileFields($fields, $hook)
  * @param int $memID = 0
  *
  * @return bool|string
- * @throws \Exception
  */
 function profileValidateEmail($email, $memID = 0)
 {
@@ -1386,7 +1384,6 @@ function profileValidateEmail($email, $memID = 0)
  *
  * @param mixed[] $profile_vars
  * @param int $memID id_member
- * @throws \ElkArte\Exceptions\Exception
  */
 function saveProfileChanges(&$profile_vars, $memID)
 {
@@ -1459,8 +1456,12 @@ function saveProfileChanges(&$profile_vars, $memID)
 	// Here's where we sort out all the 'other' values...
 	if ($changeOther)
 	{
+		// Make any theme changes
 		makeThemeChanges($memID, isset($_POST['id_theme']) ? (int) $_POST['id_theme'] : $old_id_theme);
+
+		// Make any notification changes
 		makeNotificationChanges($memID);
+
 		if (!empty($_REQUEST['sa']))
 		{
 			makeCustomFieldChanges($memID, $_REQUEST['sa'], false);
@@ -1505,8 +1506,7 @@ function saveProfileChanges(&$profile_vars, $memID)
  *
  * @param int $memID
  * @param int $id_theme
- *
- * @throws \ElkArte\Exceptions\Exception no_access
+ * @throws \ElkArte\Exceptions\Exception
  */
 function makeThemeChanges($memID, $id_theme)
 {
@@ -1633,7 +1633,6 @@ function makeThemeChanges($memID, $id_theme)
  * Make any notification changes that need to be made.
  *
  * @param int $memID id_member
- * @throws \ElkArte\Exceptions\Exception
  */
 function makeNotificationChanges($memID)
 {
@@ -1653,6 +1652,7 @@ function makeNotificationChanges($memID)
 					$to_save[$mention] = 0;
 					continue;
 				}
+
 				foreach ($_POST['notify'][$mention]['status'] as $method)
 				{
 					// This ensures that the $method passed by the user is valid and safe to INSERT.
@@ -1742,7 +1742,6 @@ function makeNotificationChanges($memID)
 			);
 		}
 	}
-
 	// We are editing topic notifications......
 	elseif (isset($_POST['edit_notify_topics']) && !empty($_POST['notify_topics']))
 	{
@@ -1773,7 +1772,6 @@ function makeNotificationChanges($memID)
  * @param int $memID
  * @param string $area
  * @param bool $sanitize = true
- * @throws \ElkArte\Exceptions\Exception
  */
 function makeCustomFieldChanges($memID, $area, $sanitize = true)
 {
@@ -2009,7 +2007,6 @@ function profileSendActivation()
  * Load key signature context data.
  *
  * @return bool
- * @throws \ElkArte\Exceptions\Exception
  */
 function profileLoadSignatureData()
 {
@@ -2266,7 +2263,6 @@ function profileReloadUser()
  * @param string $value
  *
  * @return bool|string
- * @throws \ElkArte\Exceptions\Exception
  */
 function profileValidateSignature(&$value)
 {
@@ -2958,7 +2954,6 @@ function profileSaveGroups(&$value)
  * @param int $memID the member ID
  *
  * @return array
- * @throws \Exception
  */
 function list_getUserWarnings($start, $items_per_page, $sort, $memID)
 {
@@ -3005,7 +3000,6 @@ function list_getUserWarnings($start, $items_per_page, $sort, $memID)
  *
  * @param int $memID
  * @return int the number of warnings
- * @throws \ElkArte\Exceptions\Exception
  */
 function list_getUserWarningCount($memID)
 {
@@ -3040,7 +3034,6 @@ function list_getUserWarningCount($memID)
  * @param int[]|null|bool $exclude_boards
  *
  * @return array
- * @throws \Exception
  */
 function profileLoadAttachments($start, $items_per_page, $sort, $boardsAllowed, $memID, $exclude_boards = null)
 {
@@ -3129,7 +3122,6 @@ function profileLoadAttachments($start, $items_per_page, $sort, $boardsAllowed, 
  * @param int[] $boardsAllowed
  * @param int $memID
  * @return int number of attachments
- * @throws \ElkArte\Exceptions\Exception
  */
 function getNumAttachments($boardsAllowed, $memID)
 {
@@ -3175,7 +3167,6 @@ function getNumAttachments($boardsAllowed, $memID)
  * @param int $memID
  *
  * @return array
- * @throws \Exception
  */
 function getUnwatchedBy($start, $items_per_page, $sort, $memID)
 {
@@ -3239,7 +3230,6 @@ function getUnwatchedBy($start, $items_per_page, $sort, $memID)
  *
  * @param int $memID
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function getNumUnwatchedBy($memID)
 {
@@ -3273,7 +3263,6 @@ function getNumUnwatchedBy($memID)
  * @param int $memID
  * @param int|null $board
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function count_user_posts($memID, $board = null)
 {
@@ -3311,7 +3300,6 @@ function count_user_posts($memID, $board = null)
  * @param int $memID
  * @param int|null $board
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function count_user_topics($memID, $board = null)
 {
@@ -3351,7 +3339,6 @@ function count_user_topics($memID, $board = null)
  * @param int|null $board
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function findMinMaxUserMessage($memID, $board = null)
 {
@@ -3390,7 +3377,6 @@ function findMinMaxUserMessage($memID, $board = null)
  * @param int|null $board
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function findMinMaxUserTopic($memID, $board = null)
 {
@@ -3434,7 +3420,6 @@ function findMinMaxUserTopic($memID, $board = null)
  * @param int|null $board
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function load_user_posts($memID, $start, $count, $range_limit = '', $reverse = false, $board = null)
 {
@@ -3508,7 +3493,6 @@ function load_user_posts($memID, $start, $count, $range_limit = '', $reverse = f
  * @param int|null $board
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function load_user_topics($memID, $start, $count, $range_limit = '', $reverse = false, $board = null)
 {
@@ -3573,7 +3557,6 @@ function load_user_topics($memID, $start, $count, $range_limit = '', $reverse = 
  * @param int[] $curGroups
  *
  * @return array
- * @throws \Exception
  */
 function getMemberGeneralPermissions($curGroups)
 {
@@ -3652,7 +3635,6 @@ function getMemberGeneralPermissions($curGroups)
  * @param int|null $board
  *
  * @return array
- * @throws \Exception
  */
 function getMemberBoardPermissions($memID, $curGroups, $board = null)
 {
@@ -3731,7 +3713,6 @@ function getMemberBoardPermissions($memID, $curGroups, $board = null)
  * @param int $memID the id of the member
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function getMembersIPs($memID)
 {
@@ -3812,7 +3793,6 @@ function getMembersIPs($memID)
  * @param int $memID the id of the "current" member (maybe it could be retrieved with currentMemberID)
  *
  * @return array
- * @throws \Exception
  */
 function getMembersInRange($ips, $memID)
 {
@@ -3878,7 +3858,6 @@ function getMembersInRange($ips, $memID)
  * @param int $member_id the id of a member
  *
  * @return array
- * @throws \Exception
  */
 function getMemberNotificationsProfile($member_id)
 {
@@ -3901,7 +3880,6 @@ function getMemberNotificationsProfile($member_id)
 	foreach ($enabled_mentions as $type)
 	{
 		$type_on = 1;
-		$notif = filterNotificationMethods(array_keys($notifiers), $type);
 		$data = [];
 		foreach ($notifiers as $key => $notifier)
 		{
@@ -3945,7 +3923,7 @@ function getMemberNotificationsProfile($member_id)
 			];
 		}
 
-		// If they enabled a notifications alert, then lets set a enable alerts browser permission
+		// If they enabled a notifications alert, then enable a browser alerts permission
 		// just blows smoke if they already gave it.
 		$push_enabled &= !empty($modSettings['usernotif_desktop_enable']) && !empty($context['profile_updated']);
 		if ($push_enabled)

--- a/sources/subs/ProfileHistory.subs.php
+++ b/sources/subs/ProfileHistory.subs.php
@@ -24,7 +24,6 @@ use ElkArte\Util;
  * @param string $where
  * @param mixed[] $where_vars = array() or values used in the where statement
  * @return string number of user errors
- * @throws \ElkArte\Exceptions\Exception
  */
 function getUserErrorCount($where, $where_vars = array())
 {
@@ -52,7 +51,6 @@ function getUserErrorCount($where, $where_vars = array())
  * @param string $where
  * @param mixed[] $where_vars array of values used in the where statement
  * @return mixed[] error messages array
- * @throws \Exception
  */
 function getUserErrors($start, $items_per_page, $sort, $where, $where_vars = array())
 {
@@ -97,7 +95,6 @@ function getUserErrors($start, $items_per_page, $sort, $where, $where_vars = arr
  * @param string $where
  * @param mixed[] $where_vars array of values used in the where statement
  * @return string count of messages matching the IP
- * @throws \ElkArte\Exceptions\Exception
  */
 function getIPMessageCount($where, $where_vars = array())
 {
@@ -126,7 +123,6 @@ function getIPMessageCount($where, $where_vars = array())
  * @param string $where
  * @param mixed[] $where_vars array of values used in the where statement
  * @return mixed[] an array of basic messages / details
- * @throws \Exception
  */
 function getIPMessages($start, $items_per_page, $sort, $where, $where_vars = array())
 {
@@ -177,7 +173,6 @@ function getIPMessages($start, $items_per_page, $sort, $where, $where_vars = arr
  * @param string $where
  * @param mixed[] $where_vars array of values used in the where statement
  * @return string count of messages matching the IP
- * @throws \ElkArte\Exceptions\Exception
  */
 function getLoginCount($where, $where_vars = array())
 {
@@ -207,7 +202,6 @@ function getLoginCount($where, $where_vars = array())
  * @param mixed[] $where_vars array of values used in the where statement
  *
  * @return mixed[] an array of messages
- * @throws \Exception
  */
 function getLogins($where, $where_vars = array())
 {
@@ -243,7 +237,6 @@ function getLogins($where, $where_vars = array())
  *
  * @param int $memID id_member
  * @return string number of profile edits
- * @throws \ElkArte\Exceptions\Exception
  */
 function getProfileEditCount($memID)
 {
@@ -276,7 +269,6 @@ function getProfileEditCount($memID)
  * @param string $sort A string indicating how to sort the results
  * @param int $memID
  * @return mixed[] array of profile edits
- * @throws \ElkArte\Exceptions\Exception
  */
 function getProfileEdits($start, $items_per_page, $sort, $memID)
 {

--- a/sources/subs/ProfileOptions.subs.php
+++ b/sources/subs/ProfileOptions.subs.php
@@ -26,7 +26,6 @@ use ElkArte\User;
  * @param string[] $buddies
  * @param bool $adding true when adding new buddies
  * @return int[]
- * @throws \Exception
  */
 function getBuddiesID($buddies, $adding = true)
 {
@@ -80,7 +79,6 @@ function getBuddiesID($buddies, $adding = true)
  * @param int $memID
  *
  * @return array
- * @throws \Exception
  */
 function loadMembergroupsJoin($current_groups, $memID)
 {
@@ -150,7 +148,6 @@ function loadMembergroupsJoin($current_groups, $memID)
  *
  * @param int $group_id
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function checkMembergroupChange($group_id)
 {
@@ -183,7 +180,6 @@ function checkMembergroupChange($group_id)
  * @param int $memID
  *
  * @return bool
- * @throws \Exception
  */
 function logMembergroupRequest($group_id, $memID)
 {

--- a/sources/subs/Recent.subs.php
+++ b/sources/subs/Recent.subs.php
@@ -23,7 +23,6 @@ use ElkArte\Util;
  *
  * @param mixed[] $latestPostOptions
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function getLastPosts($latestPostOptions)
 {
@@ -110,7 +109,6 @@ function getLastPosts($latestPostOptions)
  * @param mixed[] $latestPostOptions
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function cache_getLastPosts($latestPostOptions)
 {
@@ -305,7 +303,6 @@ function earliest_msg()
  * @param mixed[] $latestTopicOptions
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function cache_getLastTopics($latestTopicOptions)
 {
@@ -329,7 +326,6 @@ function cache_getLastTopics($latestTopicOptions)
  *
  * @param mixed[] $latestTopicOptions
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function getLastTopics($latestTopicOptions)
 {

--- a/sources/subs/RepairBoards.subs.php
+++ b/sources/subs/RepairBoards.subs.php
@@ -1270,6 +1270,8 @@ function loadForumTests()
 /**
  * Create a salvage area for repair purposes, if one doesn't already exist.
  * Uses the forum's default language, and checks based on that name.
+ *
+ * @throws \ElkArte\Exceptions\Exception salvaged_board_error
  */
 function createSalvageBoard()
 {
@@ -1333,6 +1335,8 @@ function createSalvageBoard()
 /**
  * Create a salvage area for repair purposes, if one doesn't already exist.
  * Uses the forum's default language, and checks based on that name.
+ *
+ * @throws \ElkArte\Exceptions\Exception salvaged_category_error
  */
 function createSalvageCategory()
 {
@@ -1401,7 +1405,6 @@ function createSalvageCategory()
  * @param string $current_step_description
  * @param int $max_substep = none
  * @param bool $force = false
- * @throws \ElkArte\Exceptions\Exception
  */
 function pauseRepairProcess($to_fix, $current_step_description, $max_substep = 0, $force = false)
 {
@@ -1461,7 +1464,6 @@ function pauseRepairProcess($to_fix, $current_step_description, $max_substep = 0
  *
  * @param bool $do_fix
  * @return mixed[]
- * @throws \ElkArte\Exceptions\Exception
  */
 function findForumErrors($do_fix = false)
 {

--- a/sources/subs/Reports.subs.php
+++ b/sources/subs/Reports.subs.php
@@ -56,7 +56,6 @@ function reportsBoardsList()
  * @param int[] $query_groups an array of group ids
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function allMembergroups($group_clause, $query_groups = array())
 {
@@ -100,7 +99,6 @@ function allMembergroups($group_clause, $query_groups = array())
  * @param int[] $query_groups an array of group ids
  *
  * @return array
- * @throws \Exception
  */
 function boardPermissions($profiles, $group_clause, $query_groups)
 {
@@ -183,7 +181,6 @@ function allMembergroupsBoardAccess()
  * @param int[] $query_groups an array of group ids
  *
  * @return array
- * @throws \Exception
  */
 function boardPermissionsByGroup($group_clause, $query_groups)
 {

--- a/sources/subs/ScheduledTasks.subs.php
+++ b/sources/subs/ScheduledTasks.subs.php
@@ -206,7 +206,6 @@ function next_time($regularity, $unit, $offset, $immediate = false)
  *
  * @param int[] $tasks
  * @return array
- * @throws \Exception
  * @package ScheduledTasks
  */
 function loadTasks($tasks)
@@ -239,7 +238,6 @@ function loadTasks($tasks)
  * @param int $task_id the id of the task run (from the table scheduled_tasks)
  * @param int|null $total_time How long the task took to finish. If NULL (default value) -1 will be used
  * @return int the id_log value
- * @throws \ElkArte\Exceptions\Exception
  * @package ScheduledTasks
  */
 function logTask($id_log, $task_id, $total_time = null)
@@ -279,7 +277,6 @@ function logTask($id_log, $task_id, $total_time = null)
  * enabled, while the remaining are disabled
  *
  * @param int[] $enablers array od task IDs
- * @throws \ElkArte\Exceptions\Exception
  * @package ScheduledTasks
  */
 function updateTaskStatus($enablers)
@@ -301,7 +298,6 @@ function updateTaskStatus($enablers)
  *
  * @param string $enabler the name (the function) of a task
  * @param bool $enable is if the tasks should be enabled or disabled
- * @throws \ElkArte\Exceptions\Exception
  * @package ScheduledTasks
  */
 function toggleTaskStatusByName($enabler, $enable = true)
@@ -328,7 +324,6 @@ function toggleTaskStatusByName($enabler, $enable = true)
  * @param int|null $offset
  * @param int|null $interval
  * @param string|null $unit
- * @throws \ElkArte\Exceptions\Exception
  * @package ScheduledTasks
  */
 function updateTask($id_task, $disabled = null, $offset = null, $interval = null, $unit = null)
@@ -424,7 +419,6 @@ function loadTaskDetails($id_task)
  * - Used also by createList() callbacks.
  *
  * @return array
- * @throws \Exception
  * @package ScheduledTasks
  */
 function scheduledTasks()
@@ -471,7 +465,6 @@ function scheduledTasks()
  * @param string $sort A string indicating how to sort the results
  *
  * @return array
- * @throws \Exception
  * @package ScheduledTasks
  */
 function getTaskLogEntries($start, $items_per_page, $sort)
@@ -511,7 +504,6 @@ function getTaskLogEntries($start, $items_per_page, $sort)
  * - Used by createList() callbacks.
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package ScheduledTasks
  */
 function countTaskLogEntries()
@@ -546,7 +538,6 @@ function emptyTaskLog()
  * Process the next tasks, one by one, and update the results.
  *
  * @param int $ts = 0
- * @throws \ElkArte\Exceptions\Exception
  * @package ScheduledTasks
  */
 function processNextTasks($ts = 0)
@@ -631,7 +622,6 @@ function processNextTasks($ts = 0)
  *
  * @param int $id_task specific id of the task to run, used for logging
  * @param string $task_name name of the task, class name, function name, method in ScheduledTask.class
- * @throws \ElkArte\Exceptions\Exception
  * @package ScheduledTasks
  */
 function run_this_task($id_task, $task_name)
@@ -684,7 +674,6 @@ function run_this_task($id_task, $task_name)
  * Retrieve info if there's any next task scheduled and when.
  *
  * @return mixed int|false
- * @throws \ElkArte\Exceptions\Exception
  * @package ScheduledTasks
  */
 function nextTime()

--- a/sources/subs/SearchEngines.subs.php
+++ b/sources/subs/SearchEngines.subs.php
@@ -327,7 +327,6 @@ function recacheSpiderNames()
  * @param string $sort A string indicating how to sort the results
  *
  * @return array
- * @throws \Exception
  * @package SearchEngines
  *
  */
@@ -361,7 +360,6 @@ function getSpiders($start, $items_per_page, $sort)
  *
  * @param int $spider_id id of a spider
  * @return mixed[]
- * @throws \ElkArte\Exceptions\Exception
  * @package SearchEngines
  */
 function getSpiderDetails($spider_id)
@@ -388,7 +386,6 @@ function getSpiderDetails($spider_id)
  * (used by createList() callbacks)
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  * @package SearchEngines
  */
 function getNumSpiders()
@@ -416,7 +413,6 @@ function getNumSpiders()
  * @param int $items_per_page The number of items to show per page
  * @param string $sort A string indicating how to sort the results
  * @return array An array of spider hits
- * @throws \Exception
  * @package SearchEngines
  */
 function getSpiderLogs($start, $items_per_page, $sort)
@@ -439,7 +435,6 @@ function getSpiderLogs($start, $items_per_page, $sort)
  * (used by createList() callbacks)
  *
  * @return int The number of rows in the log_spider_hits table
- * @throws \ElkArte\Exceptions\Exception
  * @package SearchEngines
  */
 function getNumSpiderLogs()
@@ -468,7 +463,6 @@ function getNumSpiderLogs()
  * @param string $sort A string indicating how to sort the results
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  * @package SearchEngines
  *
  */
@@ -493,7 +487,6 @@ function getSpiderStats($start, $items_per_page, $sort)
  *
  * @param int|null $time (optional) if specified counts only the entries before that date
  * @return int The number of rows in the log_spider_stats table
- * @throws \Exception
  * @package SearchEngines
  */
 function getNumSpiderStats($time = null)
@@ -519,7 +512,6 @@ function getNumSpiderStats($time = null)
  * Remove spider logs older than the passed time
  *
  * @param int $time a time value
- * @throws \ElkArte\Exceptions\Exception
  * @package SearchEngines
  */
 function removeSpiderOldLogs($time)
@@ -540,7 +532,6 @@ function removeSpiderOldLogs($time)
  * Remove spider logs older than the passed time
  *
  * @param int $time a time value
- * @throws \ElkArte\Exceptions\Exception
  * @package SearchEngines
  */
 function removeSpiderOldStats($time)
@@ -561,7 +552,6 @@ function removeSpiderOldStats($time)
  * Remove all the entries connected to a certain spider (description, entries, stats)
  *
  * @param int[] $spiders_id an array of spider ids
- * @throws \ElkArte\Exceptions\Exception
  * @package SearchEngines
  */
 function removeSpiders($spiders_id)
@@ -673,7 +663,6 @@ function spidersStatsDates()
  * @param string $name spider name
  * @param string $agent ua of the spider
  * @param string $info_ip
- * @throws \ElkArte\Exceptions\Exception
  * @package SearchEngines
  */
 function updateSpider($id = 0, $name = '', $agent = '', $info_ip = '')

--- a/sources/subs/Smileys.subs.php
+++ b/sources/subs/Smileys.subs.php
@@ -19,7 +19,6 @@
  *
  * @param string[] $smileys
  * @return array
- * @throws \Exception
  */
 function smileyExists($smileys)
 {
@@ -49,7 +48,6 @@ function smileyExists($smileys)
  * @param string $code
  * @param string|null $current
  * @return bool
- * @throws \Exception
  */
 function validateDuplicateSmiley($code, $current = null)
 {
@@ -74,7 +72,6 @@ function validateDuplicateSmiley($code, $current = null)
  * @param string $location
  *
  * @return int
- * @throws \Exception
  */
 function nextSmileyLocation($location)
 {
@@ -100,7 +97,6 @@ function nextSmileyLocation($location)
  * Adds a smiley to the database
  *
  * @param mixed[] $param associative array to use in the insert
- * @throws \Exception
  */
 function addSmiley($param)
 {
@@ -120,7 +116,6 @@ function addSmiley($param)
  * Deletes smileys.
  *
  * @param int[] $smileys
- * @throws \ElkArte\Exceptions\Exception
  */
 function deleteSmileys($smileys)
 {
@@ -140,7 +135,6 @@ function deleteSmileys($smileys)
  *
  * @param int[] $smileys
  * @param int $display_type
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateSmileyDisplayType($smileys, $display_type)
 {
@@ -162,7 +156,6 @@ function updateSmileyDisplayType($smileys, $display_type)
  * Updates a smiley.
  *
  * @param mixed[] $param
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateSmiley($param)
 {
@@ -224,7 +217,6 @@ function getSmiley($id)
  * @param int $id
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function getSmileyPosition($location, $id)
 {
@@ -254,7 +246,6 @@ function getSmileyPosition($location, $id)
  *
  * @param int[] $smiley
  * @param int $source
- * @throws \ElkArte\Exceptions\Exception
  */
 function moveSmileyPosition($smiley, $source)
 {
@@ -296,7 +287,6 @@ function moveSmileyPosition($smiley, $source)
  * @param int $id
  * @param int $row
  * @param int $location
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateSmileyRow($id, $row, $location)
 {
@@ -321,7 +311,6 @@ function updateSmileyRow($id, $row, $location)
  *
  * @param int $id
  * @param int $order
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateSmileyOrder($id, $order)
 {
@@ -387,7 +376,6 @@ function getSmileys()
  *
  * @param string $set name of smiley set to check
  * @return bool
- * @throws \Exception
  */
 function isSmileySetInstalled($set)
 {
@@ -412,7 +400,6 @@ function isSmileySetInstalled($set)
  * Logs the installation of a new smiley set.
  *
  * @param mixed[] $param
- * @throws \Exception
  */
 function logPackageInstall($param)
 {
@@ -440,7 +427,6 @@ function logPackageInstall($param)
  * Get the last smiley_order from the first smileys row.
  *
  * @return string
- * @throws \ElkArte\Exceptions\Exception
  */
 function getMaxSmileyOrder()
 {
@@ -542,7 +528,6 @@ function list_getNumSmileySets()
  * @param string $sort A string indicating how to sort the results
  *
  * @return array
- * @throws \Exception
  */
 function list_getSmileys($start, $items_per_page, $sort)
 {

--- a/sources/subs/Stats.subs.php
+++ b/sources/subs/Stats.subs.php
@@ -26,7 +26,6 @@ use ElkArte\User;
  * Return the number of currently online members.
  *
  * @return double
- * @throws \ElkArte\Exceptions\Exception
  */
 function onlineCount()
 {
@@ -50,7 +49,6 @@ function onlineCount()
  * - Can be used (and is) with days up value to generate averages.
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function getAverages()
 {
@@ -73,7 +71,6 @@ function getAverages()
  * Get the count of categories
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function numCategories()
 {
@@ -96,7 +93,6 @@ function numCategories()
  *
  * @param int $date
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function mostOnline($date)
 {
@@ -125,7 +121,6 @@ function mostOnline($date)
  *
  * @param int|null $limit if empty defaults to 10
  * @return array
- * @throws \Exception
  */
 function topPosters($limit = null)
 {
@@ -195,7 +190,6 @@ function topPosters($limit = null)
  * @param int|null $limit if not supplied, defaults to 10
  * @param bool $read_status
  * @return array
- * @throws \Exception
  */
 function topBoards($limit = null, $read_status = false)
 {
@@ -276,7 +270,6 @@ function topBoards($limit = null, $read_status = false)
  *
  * @param int $limit if not supplied, defaults to 10
  * @return array
- * @throws \Exception
  */
 function topTopicReplies($limit = 10)
 {
@@ -357,7 +350,6 @@ function topTopicReplies($limit = 10)
  *
  * @param int|null $limit if not supplied, defaults to 10
  * @return array
- * @throws \Exception
  */
 function topTopicViews($limit = null)
 {
@@ -462,7 +454,6 @@ function topTopicViews($limit = null)
  * - x is configurable via $modSettings['stats_limit'].
  *
  * @return array
- * @throws \Exception
  */
 function topTopicStarter()
 {
@@ -541,7 +532,6 @@ function topTopicStarter()
  * - x is configurable via $modSettings['stats_limit'], defaults to 10
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function topTimeOnline()
 {
@@ -710,7 +700,6 @@ function monthlyActivity()
  *
  * @param string $condition_string
  * @param mixed[] $condition_parameters = array()
- * @throws \Exception
  */
 function getDailyStats($condition_string, $condition_parameters = array())
 {
@@ -751,7 +740,6 @@ function getDailyStats($condition_string, $condition_parameters = array())
  * @param int $memID
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function UserStatsTopicsStarted($memID)
 {
@@ -786,7 +774,6 @@ function UserStatsTopicsStarted($memID)
  * @param int $memID
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function UserStatsPollsStarted($memID)
 {
@@ -821,7 +808,6 @@ function UserStatsPollsStarted($memID)
  * @param int $memID
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function UserStatsPollsVoted($memID)
 {
@@ -852,7 +838,6 @@ function UserStatsPollsVoted($memID)
  * @param int $limit
  *
  * @return array
- * @throws \Exception
  */
 function UserStatsMostPostedBoard($memID, $limit = 10)
 {
@@ -906,7 +891,6 @@ function UserStatsMostPostedBoard($memID, $limit = 10)
  * @param int $limit
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function UserStatsMostActiveBoard($memID, $limit = 10)
 {
@@ -965,7 +949,6 @@ function UserStatsMostActiveBoard($memID, $limit = 10)
  * @param int $memID
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function UserStatsPostingTime($memID)
 {

--- a/sources/subs/Themes.subs.php
+++ b/sources/subs/Themes.subs.php
@@ -64,7 +64,6 @@ function installedThemes()
  *
  * @param int $id_theme the id of the theme
  * @return string
- * @throws \ElkArte\Exceptions\Exception
  */
 function themeDirectory($id_theme)
 {
@@ -94,7 +93,6 @@ function themeDirectory($id_theme)
  * @param int $id_theme id of the theme
  *
  * @return string
- * @throws \ElkArte\Exceptions\Exception
  */
 function themeUrl($id_theme)
 {
@@ -125,7 +123,6 @@ function themeUrl($id_theme)
  * @param mixed[] $value_data
  *
  * @return array
- * @throws \Exception
  */
 function validateThemeName($indexes, $value_data)
 {
@@ -165,7 +162,6 @@ function validateThemeName($indexes, $value_data)
  *
  * @param int|int[] $themes
  * @return array
- * @throws \Exception
  */
 function getBasicThemeInfos($themes)
 {
@@ -198,7 +194,6 @@ function getBasicThemeInfos($themes)
  * Gets a list of all themes from the database
  *
  * @return array $themes
- * @throws \Exception
  */
 function getCustomThemes()
 {
@@ -242,7 +237,6 @@ function getCustomThemes()
  * @param int[] $theme_list
  *
  * @return array
- * @throws \Exception
  */
 function getThemesPathbyID($theme_list = array())
 {
@@ -291,7 +285,6 @@ function getThemesPathbyID($theme_list = array())
  * @param int[] $knownThemes available themes
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function loadThemes($knownThemes)
 {
@@ -329,7 +322,6 @@ function loadThemes($knownThemes)
  * @param int $id id of the package we are checking
  *
  * @return array
- * @throws \Exception
  */
 function loadThemesAffected($id)
 {
@@ -441,7 +433,6 @@ function get_file_listing($path, $relative)
  * Counts the theme options configured for guests
  *
  * @return array
- * @throws \Exception
  */
 function countConfiguredGuestOptions()
 {
@@ -466,7 +457,6 @@ function countConfiguredGuestOptions()
  * @param int $current_member
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function availableThemes($current_theme, $current_member)
 {
@@ -656,7 +646,6 @@ function availableThemes($current_theme, $current_member)
  * Counts the theme options configured for members
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function countConfiguredMemberOptions()
 {
@@ -689,7 +678,6 @@ function countConfiguredMemberOptions()
  *               - 'non_default' => guests and members with custom settings (i.e. id_member != 0)
  *               - 'all' => any record
  * @param string[]|string $old_settings can be a string or an array of strings. If empty deletes all settings.
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeThemeOptions($theme, $membergroups, $old_settings = '')
 {
@@ -773,7 +761,6 @@ function removeThemeOptions($theme, $membergroups, $old_settings = '')
  * Update the default options for our users.
  *
  * @param mixed[] $setValues in the order: id_theme, id_member, variable name, value
- * @throws \Exception
  */
 function updateThemeOptions($setValues)
 {
@@ -793,7 +780,6 @@ function updateThemeOptions($setValues)
  * @param int $id_theme
  * @param string $options
  * @param string[]|string $value
- * @throws \ElkArte\Exceptions\Exception
  */
 function addThemeOptions($id_theme, $options, $value)
 {
@@ -867,7 +853,6 @@ function deleteTheme($id)
  * Get the next free id for the theme.
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function nextTheme()
 {
@@ -893,7 +878,6 @@ function nextTheme()
  * Adds a new theme to the database.
  *
  * @param mixed[] $details
- * @throws \Exception
  */
 function addTheme($details)
 {
@@ -912,7 +896,6 @@ function addTheme($details)
  *
  * @param int $id
  * @return string
- * @throws \ElkArte\Exceptions\Exception
  */
 function getThemeName($id)
 {
@@ -942,7 +925,6 @@ function getThemeName($id)
  * Deletes all variants from a given theme id.
  *
  * @param int $id
- * @throws \ElkArte\Exceptions\Exception
  */
 function deleteVariants($id)
 {
@@ -969,7 +951,6 @@ function deleteVariants($id)
  * @param string[] $variables
  *
  * @return array|mixed[]
- * @throws \Exception
  */
 function loadThemeOptionsInto($theme, $memID = null, $options = array(), $variables = array())
 {
@@ -1011,7 +992,6 @@ function loadThemeOptionsInto($theme, $memID = null, $options = array(), $variab
  * @param string $based_on name of theme this is based on, will do a LIKE search
  * @param bool $explicit_images Don't worry its not like it sounds !
  * @return mixed[]
- * @throws \ElkArte\Exceptions\Exception
  * @todo may be merged with something else?
  */
 function loadBasedOnTheme($based_on, $explicit_images = false)

--- a/sources/subs/Topic.subs.php
+++ b/sources/subs/Topic.subs.php
@@ -29,7 +29,6 @@ use ElkArte\Util;
  * Removes the passed id_topic's checking for permissions.
  *
  * @param int[]|int $topics The topics to remove (can be an id or an array of ids).
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeTopicsPermissions($topics)
 {
@@ -70,7 +69,6 @@ function removeTopicsPermissions($topics)
  * @param bool $ignoreRecycling if true topics are not moved to the recycle board (if it exists).
  * @param bool $log if true logs the action.
  * @param int[] $removeCacheBoards an array matching topics and boards.
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeTopics($topics, $decreasePostCount = true, $ignoreRecycling = false, $log = false, $removeCacheBoards = array())
 {
@@ -467,7 +465,6 @@ function removeTopics($topics, $decreasePostCount = true, $ignoreRecycling = fal
  * Moves lots of topics to a specific board and checks if the user can move them
  *
  * @param array $moveCache [0] => int[] is the topic, [1] => int[]  is the board to move to.
- * @throws \ElkArte\Exceptions\Exception
  */
 function moveTopicsPermissions($moveCache)
 {
@@ -582,7 +579,6 @@ function moveTopicsPermissions($moveCache)
  * @param int[]|int $topics
  * @param int $toBoard
  * @param bool $log if true logs the action.
- * @throws \ElkArte\Exceptions\Exception
  */
 function moveTopics($topics, $toBoard, $log = false)
 {
@@ -961,6 +957,8 @@ function moveTopicConcurrence($move_from, $id_board, $id_topic)
  * What it does:
  *  - If the topic has been removed and resides in the recycle bin, present confirm dialog
  *  - If recycling is not enabled, or user confirms or topic is not in recycle simply returns
+ *
+ * @throws \ElkArte\Exceptions\Exception post_already_deleted
  */
 function removeDeleteConcurrence()
 {
@@ -992,7 +990,6 @@ function removeDeleteConcurrence()
  * Increase the number of views of this topic.
  *
  * @param int $id_topic the topic being viewed or whatnot.
- * @throws \ElkArte\Exceptions\Exception
  */
 function increaseViewCounter($id_topic)
 {
@@ -1014,7 +1011,6 @@ function increaseViewCounter($id_topic)
  *
  * @param mixed[] $mark_topics array($id_member, $id_topic, $id_msg)
  * @param bool $was_set = false - whether the topic has been previously read by the user
- * @throws \Exception
  */
 function markTopicsRead($mark_topics, $was_set = false)
 {
@@ -1040,7 +1036,6 @@ function markTopicsRead($mark_topics, $was_set = false)
  *
  * @param int $id_topic
  * @param int $id_board
- * @throws \ElkArte\Exceptions\Exception
  * @todo look at board notification...
  *
  */
@@ -1101,7 +1096,6 @@ function updateReadNotificationsFor($id_topic, $id_board)
  * @param int $id_board
  * @param int $id_msg_last_visit
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function getUnreadCountSince($id_board, $id_msg_last_visit)
 {
@@ -1136,7 +1130,6 @@ function getUnreadCountSince($id_board, $id_msg_last_visit)
  * @param int $id_member
  * @param int $id_topic
  * @return bool
- * @throws \Exception
  */
 function hasTopicNotification($id_member, $id_topic)
 {
@@ -1163,7 +1156,6 @@ function hasTopicNotification($id_member, $id_topic)
  * @param int $id_member
  * @param int $id_topic
  * @param bool $on
- * @throws \ElkArte\Exceptions\Exception
  */
 function setTopicNotification($id_member, $id_topic, $on = false)
 {
@@ -1203,7 +1195,6 @@ function setTopicNotification($id_member, $id_topic, $on = false)
  * @param bool $includeUnapproved = false whether to include unapproved topics
  * @param bool $includeStickies = true whether to include sticky topics
  * @return int topic number
- * @throws \ElkArte\Exceptions\Exception
  */
 function previousTopic($id_topic, $id_board, $id_member = 0, $includeUnapproved = false, $includeStickies = true)
 {
@@ -1219,7 +1210,6 @@ function previousTopic($id_topic, $id_board, $id_member = 0, $includeUnapproved 
  * @param bool $includeUnapproved = false whether to include unapproved topics
  * @param bool $includeStickies = true whether to include sticky topics
  * @return int topic number
- * @throws \ElkArte\Exceptions\Exception
  */
 function nextTopic($id_topic, $id_board, $id_member = 0, $includeUnapproved = false, $includeStickies = true)
 {
@@ -1239,7 +1229,6 @@ function nextTopic($id_topic, $id_board, $id_member = 0, $includeUnapproved = fa
  * @param bool $includeUnapproved = false whether to include unapproved topics
  * @param bool $includeStickies = true whether to include sticky topics
  * @return int the topic number
- * @throws \ElkArte\Exceptions\Exception
  */
 function topicPointer($id_topic, $id_board, $next = true, $id_member = 0, $includeUnapproved = false, $includeStickies = true)
 {
@@ -1316,7 +1305,6 @@ function topicPointer($id_topic, $id_board, $next = true, $id_member = 0, $inclu
  * @param int $id_member
  * @param int $topic
  * @param bool $on = false
- * @throws \Exception
  */
 function setTopicWatch($id_member, $topic, $on = false)
 {
@@ -1349,7 +1337,6 @@ function setTopicWatch($id_member, $topic, $on = false)
  * @param string[] $selects (optional from integration)
  * @param string[] $tables (optional from integration)
  * @return mixed[]|bool to topic attributes
- * @throws \Exception
  */
 function getTopicInfo($topic_parameters, $full = '', $selects = array(), $tables = array())
 {
@@ -1417,7 +1404,6 @@ function getTopicInfo($topic_parameters, $full = '', $selects = array(), $tables
  * @param int $topic id of a topic
  * @param int|null $msg the id of a message, if empty, t.id_first_msg is used
  * @return mixed[]|bool to topic attributes
- * @throws \ElkArte\Exceptions\Exception
  */
 function getTopicInfoByMsg($topic, $msg = null)
 {
@@ -1468,7 +1454,6 @@ function getTopicInfoByMsg($topic, $msg = null)
  * @param string $delete_type
  * @param bool $exclude_stickies
  * @param int $older_than
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeOldTopics(array $boards, $delete_type, $exclude_stickies, $older_than)
 {
@@ -1532,7 +1517,6 @@ function removeOldTopics(array $boards, $delete_type, $exclude_stickies, $older_
  * @param int $memberID
  *
  * @return array
- * @throws \Exception
  */
 function topicsStartedBy($memberID)
 {
@@ -1568,7 +1552,6 @@ function topicsStartedBy($memberID)
  * @param bool $only_approved = false
  *
  * @return array message ids
- * @throws \Exception
  */
 function messagesSince($id_topic, $id_msg, $include_current = false, $only_approved = false)
 {
@@ -1607,7 +1590,6 @@ function messagesSince($id_topic, $id_msg, $include_current = false, $only_appro
  * @param bool $only_approved = false
  *
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function countMessagesSince($id_topic, $id_msg, $include_current = false, $only_approved = false)
 {
@@ -1685,7 +1667,6 @@ function countMessagesBefore($id_topic, $id_msg, $include_current = false, $only
  * @param bool $only_approved
  *
  * @return array|mixed[]
- * @throws \Exception
  */
 function selectMessages($topic, $start, $items_per_page, $messages = array(), $only_approved = false)
 {
@@ -1756,7 +1737,6 @@ function selectMessages($topic, $start, $items_per_page, $messages = array(), $o
  * @param string $render defaults to print style rendering for parse_bbc
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function topicMessages($topic, $render = 'print')
 {
@@ -1813,7 +1793,6 @@ function topicMessages($topic, $render = 'print')
  * @param int[] $id_messages
  *
  * @return array
- * @throws \Exception
  */
 function messagesAttachments($id_messages)
 {
@@ -1887,7 +1866,6 @@ function messagesAttachments($id_messages)
  * @param int $id_topic topic id
  * @param int $id_member member id
  * @return array|int empty array if no member supplied, otherwise number of posts
- * @throws \ElkArte\Exceptions\Exception
  */
 function unapprovedPosts($id_topic, $id_member)
 {
@@ -1922,7 +1900,6 @@ function unapprovedPosts($id_topic, $id_member)
  *
  * @param mixed[] $options
  * @param int $id_board
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateSplitTopics($options, $id_board)
 {
@@ -1995,7 +1972,6 @@ function updateSplitTopics($options, $id_board)
  *
  * @param int $topic
  * @return array with id_member_started and locked
- * @throws \ElkArte\Exceptions\Exception
  */
 function topicStatus($topic)
 {
@@ -2015,7 +1991,6 @@ function topicStatus($topic)
  * @param int|int[] $topic
  * @param mixed[] $attributes
  * @return int number of row affected
- * @throws \ElkArte\Exceptions\Exception
  * @todo limited to integer attributes
  */
 function setTopicAttribute($topic, $attributes)
@@ -2052,7 +2027,6 @@ function setTopicAttribute($topic, $attributes)
  * @param int|int[] $id_topic topic to get the status for
  * @param string|string[] $attributes Basically the column names
  * @return array named array based on attributes requested
- * @throws \ElkArte\Exceptions\Exception
  */
 function topicAttribute($id_topic, $attributes)
 {
@@ -2110,7 +2084,6 @@ function topicAttribute($id_topic, $attributes)
  * @param int $id_topic topic to get the status for
  * @param int $user a user id
  * @return mixed[]
- * @throws \ElkArte\Exceptions\Exception
  */
 function topicUserAttributes($id_topic, $user)
 {
@@ -2144,7 +2117,6 @@ function topicUserAttributes($id_topic, $user)
  * @param int[] $topics an array of topic id
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function topicsDetails($topics)
 {
@@ -2157,7 +2129,6 @@ function topicsDetails($topics)
  * @param int[] $topics
  * @param bool $log If true the action is logged
  * @return int Number of topics toggled
- * @throws \ElkArte\Exceptions\Exception
  */
 function toggleTopicSticky($topics, $log = false)
 {
@@ -2204,7 +2175,6 @@ function toggleTopicSticky($topics, $log = false)
  * @param int[] $topics an array of topics
  * @return array an array of topics in the table (key) and its unwatched status (value)
  *
- * @throws \ElkArte\Exceptions\Exception
  * @todo find a better name
  */
 function getLoggedTopics($member, $topics)
@@ -2237,7 +2207,6 @@ function getLoggedTopics($member, $topics)
  * @param int[] $topic_ids
  *
  * @return array
- * @throws \Exception
  */
 function topicsList($topic_ids)
 {
@@ -2288,7 +2257,6 @@ function topicsList($topic_ids)
  * @param mixed[] $limit
  * @param bool $sort set to false for a desc sort
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function getTopicsPostsAndPoster($topic, $limit, $sort)
 {
@@ -2345,7 +2313,6 @@ function getTopicsPostsAndPoster($topic, $limit, $sort)
  * @param int[] $messages
  * @param mixed[] $messageDetails
  * @param string $type = replies
- * @throws \ElkArte\Exceptions\Exception
  */
 function removeMessages($messages, $messageDetails, $type = 'replies')
 {
@@ -2381,7 +2348,6 @@ function removeMessages($messages, $messageDetails, $type = 'replies')
  * @param int[] $messages
  * @param mixed[] $messageDetails
  * @param string $type = replies
- * @throws \ElkArte\Exceptions\Exception
  */
 function approveMessages($messages, $messageDetails, $type = 'replies')
 {
@@ -2410,7 +2376,6 @@ function approveMessages($messages, $messageDetails, $type = 'replies')
  * @param bool $log if true logs the action.
  *
  * @return bool|void
- * @throws \ElkArte\Exceptions\Exception
  */
 function approveTopics($topics, $approve = true, $log = false)
 {
@@ -2489,7 +2454,6 @@ function approveTopics($topics, $approve = true, $log = false)
  * @param string $subject the text that will become the message subject
  * @param mixed[] $board_info some board information (at least id, name, if posts are counted)
  * @param string $new_topic used to build the url for moving to a new topic
- * @throws \ElkArte\Exceptions\Exception
  */
 function postSplitRedirect($reason, $subject, $board_info, $new_topic)
 {
@@ -2545,7 +2509,7 @@ function postSplitRedirect($reason, $subject, $board_info, $new_topic)
  * @param string $new_subject
  *
  * @return int the topic ID of the new split topic.
- * @throws \ElkArte\Exceptions\Exception no_posts_selected
+ * @throws \ElkArte\Exceptions\Exception no_posts_selected, selected_all_posts, cant_find_message
  */
 function splitTopic($split1_ID_TOPIC, $splitMessages, $new_subject)
 {
@@ -2833,7 +2797,6 @@ function splitTopic($split1_ID_TOPIC, $splitMessages, $new_subject)
  *
  * @param mixed[] $boards an array containing basic info of the origin and destination boards (from splitDestinationBoard)
  * @param int $totopic id of the destination topic
- * @throws \ElkArte\Exceptions\Exception
  */
 function splitAttemptMove($boards, $totopic)
 {
@@ -2957,7 +2920,6 @@ function splitDestinationBoard($toboard = 0)
  *
  * @param int $memID id_member
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function topicNotificationCount($memID)
 {
@@ -2994,7 +2956,6 @@ function topicNotificationCount($memID)
  * @param string $sort A string indicating how to sort the results
  * @param int $memID id_member
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function topicNotifications($start, $items_per_page, $sort, $memID)
 {
@@ -3063,7 +3024,6 @@ function topicNotifications($start, $items_per_page, $sort, $memID)
  * @param int $id_topic topic id to work with
  *
  * @return array
- * @throws \ElkArte\Exceptions\Exception
  */
 function postersCount($id_topic)
 {
@@ -3101,7 +3061,6 @@ function postersCount($id_topic)
  * @param int $board
  * @param bool $approved
  * @return int
- * @throws \ElkArte\Exceptions\Exception
  */
 function countTopicsByBoard($board, $approved = false)
 {
@@ -3133,7 +3092,6 @@ function countTopicsByBoard($board, $approved = false)
  * @param bool $approved
  * @param int $offset
  * @return array
- * @throws \Exception
  */
 function mergeableTopics($id_board, $id_topic, $approved, $offset)
 {
@@ -3193,7 +3151,6 @@ function mergeableTopics($id_board, $id_topic, $approved, $offset)
  *
  * @param int[] $topics integer array of topics to work with
  * @return array
- * @throws \Exception
  */
 function messagesInTopics($topics)
 {
@@ -3223,7 +3180,6 @@ function messagesInTopics($topics)
  *
  * @param int[] $topics integer array of topics to work with
  * @return array of topics each member posted in (grouped by members)
- * @throws \Exception
  */
 function topicsPosters($topics)
 {
@@ -3258,7 +3214,6 @@ function topicsPosters($topics)
  * @param string $target_subject subject of the new topic
  * @param string $enforce_subject if not empty all the messages will be set to the same subject
  * @param int[] $notifications array of topics with active notifications
- * @throws \ElkArte\Exceptions\Exception
  */
 function fixMergedTopics($first_msg, $topics, $id_topic, $target_board, $target_subject, $enforce_subject, $notifications)
 {
@@ -3456,7 +3411,6 @@ function getSubject($id_topic)
  * or if parameter $increment is true it simply increments them.
  *
  * @param bool|null $increment = null if true, increment + 1 the total topics, otherwise recount all topics
- * @throws \ElkArte\Exceptions\Exception
  */
 function updateTopicStats($increment = null)
 {
@@ -3493,7 +3447,6 @@ function updateTopicStats($increment = null)
  *
  * @param int[] $topics The topics to lock (can be an id or an array of ids).
  * @param bool $log if true logs the action.
- * @throws \ElkArte\Exceptions\Exception
  */
 function toggleTopicsLock($topics, $log = false)
 {

--- a/sources/subs/Who.subs.php
+++ b/sources/subs/Who.subs.php
@@ -23,7 +23,6 @@ use ElkArte\Util;
  * @param string $session
  * @param string $type
  * @return array
- * @throws \Exception
  */
 function viewers($id, $session, $type = 'topic')
 {
@@ -56,7 +55,6 @@ function viewers($id, $session, $type = 'topic')
  *
  * @param int $id id of the element (topic or board) we're watching
  * @param string $type = 'topic, 'topic' or 'board'
- * @throws \ElkArte\Exceptions\Exception
  */
 function formatViewers($id, $type)
 {
@@ -197,7 +195,6 @@ function addonsCredits()
  * @param mixed[]|string $urls a single url (string) or an array of arrays, each inner array being (serialized request data, id_member)
  * @param string|bool $preferred_prefix = false
  * @return mixed[]|string an array of descriptions if you passed an array, otherwise the string describing their current location.
- * @throws \ElkArte\Exceptions\Exception
  */
 function determineActions($urls, $preferred_prefix = false)
 {


### PR DESCRIPTION
Many doc blocks had expectations documented that were cascade in style.   For example every function that has a DB call would show and exception.  This is simplifies this to, hopefully, only document the throws from the functions that do a ```throw new``` such that you know where a try/catch may make sense.  This only takes care of the subs files.