### PR TITLE
AdBlockPlus like_button fix

### DIFF
--- a/sources/controllers/Display.controller.php
+++ b/sources/controllers/Display.controller.php
@@ -489,7 +489,7 @@ class Display_Controller extends Action_Controller
 						}),
 					});
 
-					$(".like_button, .unlike_button, .likes_button").SiteTooltip({
+					$(".react_button, .unreact_button, .reacts_button").SiteTooltip({
 						hoverIntent: {
 							sensitivity: 10,
 							interval: 150,

--- a/sources/controllers/Recent.controller.php
+++ b/sources/controllers/Recent.controller.php
@@ -270,7 +270,7 @@ class Recent_Controller extends Action_Controller implements Frontpage_Interface
 		{
 			$txt_like_post = '
 				<li class="listlevel1' . (!empty($post['like_counter']) ? ' liked"' : '"') . '>
-					<a class="linklevel1 ' . ($post['can_unlike'] ? 'unlike_button' : 'like_button') . '" href="javascript:void(0)" title="' . (!empty($post['like_counter']) ? $txt['liked_by'] . ' ' . implode(', ', $context['likes'][$post['id']]['member']) : '') . '" onclick="likePosts.prototype.likeUnlikePosts(event,' . $post['id'] . ', ' . $post['topic'] . '); return false;">' .
+					<a class="linklevel1 ' . ($post['can_unlike'] ? 'unreact_button' : 'react_button') . '" href="javascript:void(0)" title="' . (!empty($post['like_counter']) ? $txt['liked_by'] . ' ' . implode(', ', $context['likes'][$post['id']]['member']) : '') . '" onclick="likePosts.prototype.likeUnlikePosts(event,' . $post['id'] . ', ' . $post['topic'] . '); return false;">' .
 						(!empty($post['like_counter']) ? '<span class="likes_indicator">' . $post['like_counter'] . '</span>&nbsp;' . $txt['likes'] : $txt['like_post']) . '
 					</a>
 				</li>';
@@ -280,7 +280,7 @@ class Recent_Controller extends Action_Controller implements Frontpage_Interface
 		{
 			$txt_like_post = '
 				<li class="listlevel1 liked">
-					<a href="javascript:void(0)" title="' . $txt['liked_by'] . ' ' . implode(', ', $context['likes'][$post['id']]['member']) . '" class="linklevel1 likes_button">
+					<a href="javascript:void(0)" title="' . $txt['liked_by'] . ' ' . implode(', ', $context['likes'][$post['id']]['member']) . '" class="linklevel1 reacts_button">
 						<span class="likes_indicator">' . $post['like_counter'] . '</span>&nbsp;' . $txt['likes'] . '
 					</a>
 				</li>';
@@ -483,7 +483,7 @@ class Recent_Controller extends Action_Controller implements Frontpage_Interface
 					}),
 				});
 
-				$(".like_button, .unlike_button, .likes_button").SiteTooltip({
+				$(".react_button, .unreact_button, .reacts_button").SiteTooltip({
 					hoverIntent: {
 						sensitivity: 10,
 						interval: 150,

--- a/themes/default/Display.template.php
+++ b/themes/default/Display.template.php
@@ -304,7 +304,7 @@ function template_messages()
 			if ($message['can_like'] || $message['can_unlike'])
 				echo '
 							<li class="listlevel1', !empty($message['like_counter']) ? ' liked"' : '"', '>
-								<a class="linklevel1 ', $message['can_unlike'] ? 'unlike_button' : 'like_button', '" href="javascript:void(0)"', !empty($message['like_counter']) ? ' title="' . $txt['liked_by'] . ' ' . implode(', ', $context['likes'][$message['id']]['member']) . '"' : '', ' onclick="likePosts.prototype.likeUnlikePosts(event,', $message['id'], ', ', $context['current_topic'], '); return false;">',
+								<a class="linklevel1 ', $message['can_unlike'] ? 'unreact_button' : 'react_button', '" href="javascript:void(0)"', !empty($message['like_counter']) ? ' title="' . $txt['liked_by'] . ' ' . implode(', ', $context['likes'][$message['id']]['member']) . '"' : '', ' onclick="likePosts.prototype.likeUnlikePosts(event,', $message['id'], ', ', $context['current_topic'], '); return false;">',
 									!empty($message['like_counter']) ? '<span class="likes_indicator">' . $message['like_counter'] . '</span>&nbsp;' . $txt['likes'] : $txt['like_post'], '
 								</a>
 							</li>';
@@ -313,7 +313,7 @@ function template_messages()
 			else
 				echo '
 							<li class="listlevel1', !empty($message['like_counter']) ? ' liked"' : '"', '>
-								<a href="javascript:void(0)" role="button" title="', !empty($message['like_counter']) ? $txt['liked_by'] . ' ' . implode(', ', $context['likes'][$message['id']]['member']) : '', '" class="linklevel1 likes_button">',
+								<a href="javascript:void(0)" role="button" title="', !empty($message['like_counter']) ? $txt['liked_by'] . ' ' . implode(', ', $context['likes'][$message['id']]['member']) : '', '" class="linklevel1 reacts_button">',
 									!empty($message['like_counter']) ? '<span class="likes_indicator">' . $message['like_counter'] . '</span>&nbsp;' . $txt['likes'] : '&nbsp;', '
 								</a>
 							</li>';

--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -1772,11 +1772,11 @@ nav > .quickbuttons {
 .report_button:before     {background-position: 0 -312px;}
 .warn_button:before       {background-position: 0 -336px;}
 .quotetonew_button:before {background-position: 0 -360px;}
-.like_button:before       {background-position: 0 -384px;}
-.unlike_button:before     {background-position: 0 -408px;}
+.react_button:before       {background-position: 0 -384px;}
+.unreact_button:before     {background-position: 0 -408px;}
 .star_button:before       {background-position: 0 -432px;}
 .quick_edit:before        {background-position: 0 -456px;}
-.likes_button:before      {background-position: 0 -480px;}
+.reacts_button:before      {background-position: 0 -480px;}
 
 /* Radius left end of the first (Quote) button. */
 .linklevel1.quote_button {
@@ -1821,15 +1821,15 @@ nav > .quickbuttons {
 }
 
 /* Show appropriate like/unlike action */
-.like_button:before, .likes_button:before, .unlike_button:before {
+.react_button:before, .reacts_button:before, .unreact_button:before {
 	background-position: 0 -480px;
 }
 
-.unlike_button:before {
+.unreact_button:before {
 	background-position: 0 -408px;
 }
 
-.like_button:hover:before {
+.react_button:hover:before {
 	background-position: 0 -384px;
 }
 

--- a/themes/default/scripts/like_posts.js
+++ b/themes/default/scripts/like_posts.js
@@ -44,7 +44,7 @@
 					return false;
 
 				// Set the subAction to what they are doing
-				if (check.indexOf('unlike_button') >= 0) {
+				if (check.indexOf('unreact_button') >= 0) {
 					if (!confirm(likemsg_are_you_sure))
 						return;
 
@@ -97,8 +97,8 @@
 			 * @param {object} params object of new values from the ajax request
 			 */
 			updateUi = function (params) {
-				var currentClass = (params.action === 'unlikepost') ? 'unlike_button' : 'like_button',
-					nextClass = (params.action === 'unlikepost') ? 'like_button' : 'unlike_button';
+				var currentClass = (params.action === 'unlikepost') ? 'unreact_button' : 'react_button',
+					nextClass = (params.action === 'unlikepost') ? 'react_button' : 'unreact_button';
 
 				// Swap the button class as needed, update the text for the hover
 				$(params.elem).removeClass(currentClass).addClass(nextClass);


### PR DESCRIPTION
Changed like_button to react_button, likes_button to reacts_button, so that AdBlockPlus doesn't remove the likes button when Social Media Blocking is enabled

Fixes #3564 