### PR TITLE
Update html2md so it does not break links

### DIFF
--- a/themes/default/Display.template.php
+++ b/themes/default/Display.template.php
@@ -9,7 +9,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:  	BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1.7
+ * @version 1.1.9
  *
  */
 


### PR DESCRIPTION
Also pulled in many processing enhancements from 2.0.  

For anyone having the broken link issue, just replace the 1.1.8 version with this new file.