### PR TITLE
[WIP] Attachments

### DIFF
--- a/sources/ElkArte/Attachments/Attachment.php
+++ b/sources/ElkArte/Attachments/Attachment.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This is file part of the handling of attachments
+ *
+ * @package   ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ *
+ * This file contains code covered by:
+ * copyright: 2011 Simple Machines (http://www.simplemachines.org)
+ *
+ * @version 2.0 dev
+ *
+ */
+
+namespace ElkArte\Attachments;
+
+/**
+ * Right now just a shell to wrap some constants I'm not sure where to put.
+ */
+class Attachment
+{
+	const DL_TYPE_AVATAR = 'avatar';
+	const DL_TYPE_THUMB = 'thumb';
+
+	const DB_TYPE_ATTACH = 0;
+	const DB_TYPE_AVATAR = 1;
+	const DB_TYPE_THUMB = 3;
+}

--- a/sources/ElkArte/Attachments/Download.php
+++ b/sources/ElkArte/Attachments/Download.php
@@ -42,12 +42,15 @@ class Download
 	 * Starts up the download process
 	 *
 	 * @param string $id_attach String version of the attachment id
-	 * @param int $id
 	 */
-	public function __construct($id_attach, $id)
+	public function __construct($id_attach)
 	{
 		$this->string_attach = $id_attach;
-		$this->id_attach = $id;
+		// Non-temporary attachments shall have integer ids
+		if (!$this->isTemporary())
+		{
+			$this->id_attach = (int) $id;
+		}
 		$this->db = database();
 	}
 

--- a/sources/ElkArte/Attachments/Download.php
+++ b/sources/ElkArte/Attachments/Download.php
@@ -170,7 +170,6 @@ class Download
 		elseif (empty($this->data['mime_type']) || $inline === false && getValidMimeImageType($this->data['file_ext']) !== '')
 		{
 			$this->data['mime_type'] = '';
-			$inline = false;
 		}
 		$this->prepare_headers($this->file_path, $eTag, $this->data['mime_type'], $disposition, $this->data['real_filename'], $do_cache);
 

--- a/sources/ElkArte/Attachments/Download.php
+++ b/sources/ElkArte/Attachments/Download.php
@@ -38,6 +38,12 @@ class Download
 	protected $db = null;
 	protected $thumb_suffix = '';
 
+	/**
+	 * Starts up the download process
+	 *
+	 * @param string $id_attach String version of the attachment id
+	 * @param int $id
+	 */
 	public function __construct($id_attach, $id)
 	{
 		$this->string_attach = $id_attach;
@@ -45,12 +51,22 @@ class Download
 		$this->db = database();
 	}
 
+	/**
+	 * Temporary attachments have special names, so need slightly special handling
+	 */
 	public function isTemporary()
 	{
 		// Temporary attachment, special case...
 		return strpos($this->string_attach, 'post_tmp_' . User::$info->id . '_') !== false;
 	}
 
+	/**
+	 * Fetches data from the db and determine if the attachment actually exists
+	 *
+	 * @param null|string $text
+	 * @param null|int $id_topic
+	 * @throws \ElkArte\Exceptions\Exception
+	 */
 	public function validate($type, $id_topic = null)
 	{
 		if (empty($this->id_attach))
@@ -82,6 +98,9 @@ class Download
 		return !empty($this->data['real_filename']);
 	}
 
+	/**
+	 * Same as validate, but for temporary attachments
+	 */
 	protected function validateTemporary()
 	{
 		global $modSettings;
@@ -117,6 +136,12 @@ class Download
 		return !empty($this->data['real_filename']);
 	}
 
+	/**
+	 * Reads and returns the data of the image
+	 *
+	 * @param bool $inline
+	 * @param bool $use_compression
+	 */
 	public function send($inline, $use_compression)
 	{
 		if (empty($this->id_attach) || empty($this->data['real_filename']))
@@ -158,16 +183,25 @@ class Download
 		return $this->send_file($use_compression && $this->isCompressible());
 	}
 
+	/**
+	 * Is the atachment is approved or not
+	 */
 	public function isApproved()
 	{
 		return !empty($this->data['is_approved']);
 	}
 
+	/**
+	 * If the user requesting the attachment is its owner
+	 */
 	public function isOwner()
 	{
 		return (int) $this->data['id_member'] !== 0 && User::$info->id === (int) $this->data['id_member'];
 	}
 
+	/**
+	 * If the attachment is an avatar
+	 */
 	public function isAvatar()
 	{
 		return $this->data['attachment_type'] == Attachment::DB_TYPE_AVATAR;
@@ -359,6 +393,9 @@ class Download
 		detectServer()->setTimeLimit(600);
 	}
 
+	/**
+	 * Some magic in case data are not available immediately
+	 */
 	protected function rebuildData($id_topic)
 	{
 		global $modSettings;

--- a/sources/ElkArte/Attachments/Download.php
+++ b/sources/ElkArte/Attachments/Download.php
@@ -1,0 +1,518 @@
+<?php
+
+/**
+ * This is the file that takes care of sending the bits to the browser
+ *
+ * @package   ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ *
+ * This file contains code covered by:
+ * copyright: 2011 Simple Machines (http://www.simplemachines.org)
+ *
+ * @version 2.0 dev
+ *
+ */
+
+namespace ElkArte\Attachments;
+
+use ElkArte\Graphics\TextImage;
+use ElkArte\Graphics\Image;
+use ElkArte\Exceptions\Exception;
+use ElkArte\AttachmentsDirectory;
+use ElkArte\TemporaryAttachmentsList;
+use ElkArte\Http\Headers;
+use ElkArte\Languages\Txt;
+use ElkArte\User;
+use ElkArte\HttpReq;
+
+/**
+ * This class takes one file and if it exists it sends it back to the browser that requesetd it
+ */
+class Download
+{
+	protected $string_attach = '';
+	protected $id_attach = 0;
+	protected $file_path = null;
+	protected $data = [];
+	protected $db = null;
+	protected $thumb_suffix = '';
+
+	public function __construct($id_attach, $id)
+	{
+		$this->string_attach = $id_attach;
+		$this->id_attach = $id;
+		$this->db = database();
+	}
+
+	public function isTemporary()
+	{
+		// Temporary attachment, special case...
+		return strpos($this->string_attach, 'post_tmp_' . User::$info->id . '_') !== false;
+	}
+
+	public function validate($type, $id_topic = null)
+	{
+		if (empty($this->id_attach))
+		{
+			return false;
+		}
+
+		if ($this->isTemporary())
+		{
+			return $this->validateTemporary();
+		}
+		$this->data = $this->getFromTopic($id_topic);
+
+		$this->data['id_folder'] = $this->data['id_folder'] ?? '';
+		$this->data['real_filename'] = $this->data['filename'] ?? '';
+		$this->data['file_hash'] = $this->data['file_hash'] ?? '';
+		$this->data['file_ext'] = $this->data['fileext'] ?? '';
+		$this->data['id_attach'] = $this->data['id_attach'] ?? '';
+		$this->data['attachment_type'] = $this->data['attachment_type'] ?? '';
+		$this->data['mime_type'] = $this->data['mime_type'] ?? '';
+		$this->data['is_approved'] = $this->data['approved'] ?? '';
+		$this->data['id_member'] = $this->data['id_member'] ?? '';
+
+		if ($type === Attachment::DL_TYPE_THUMB)
+		{
+			$this->thumb_suffix = '_' . Attachment::DL_TYPE_THUMB;
+		}
+
+		return !empty($this->data['real_filename']);
+	}
+
+	protected function validateTemporary()
+	{
+		global $modSettings;
+
+		$tmp_attachments = new TemporaryAttachmentsList();
+		$attachmentsDir = new AttachmentsDirectory($modSettings, $this->db);
+
+		try
+		{
+			$this->data = $tmp_attachments->getTempAttachById($this->_req->query->attach, $attachmentsDir, User::$info->id);
+			$this->data['file_ext'] = pathinfo($this->data['name'], PATHINFO_EXTENSION);
+			$this->file_path = $this->data['tmp_name'];
+			$this->data['id_attach'] = $this->data['attachid'];
+			$this->data['real_filename'] = $this->data['name'];
+			$this->data['mime_type'] = $this->data['type'];
+		}
+		catch (\Exception $e)
+		{
+			throw new Exception($e->getMessage(), false);
+		}
+
+		$this->data['resize'] = true;
+
+		// Return mime type ala mimetype extension
+		if (substr(getMimeType($this->file_path), 0, 5) !== 'image')
+		{
+			$checkMime = returnMimeThumb($file_ext);
+			$mime_type = 'image/png';
+			$this->data['resize'] = false;
+			$this->file_path = $checkMime;
+		}
+
+		return !empty($this->data['real_filename']);
+	}
+
+	public function send($inline, $use_compression)
+	{
+		if (empty($this->id_attach) || empty($this->data['real_filename']))
+		{
+			return $this->noAttach();
+		}
+
+		if ($this->file_path === null)
+		{
+			$this->file_path = getAttachmentFilename($this->data['real_filename'], $this->id_attach, $this->data['id_folder'], false, $this->data['file_hash']) . $this->thumb_suffix;
+		}
+
+		$eTag = '"' . substr($this->id_attach . $this->data['real_filename'] . @filemtime($this->file_path), 0, 64) . '"';
+		$disposition = $inline ? 'inline' : 'attachment';
+		$do_cache = !($inline === false && getValidMimeImageType($this->data['file_ext']) !== '');
+
+		// Make sure the mime type warrants an inline display.
+		if ($inline && !empty($this->data['mime_type']) && strpos($this->data['mime_type'], 'image/') !== 0)
+		{
+			$this->data['mime_type'] = '';
+		}
+		// Does this have a mime type?
+		elseif (empty($this->data['mime_type']) || $inline === false && getValidMimeImageType($this->data['file_ext']) !== '')
+		{
+			$this->data['mime_type'] = '';
+			$inline = false;
+		}
+		$this->prepare_headers($this->file_path, $eTag, $this->data['mime_type'], $disposition, $this->data['real_filename'], $do_cache);
+
+		if (!empty($this->data['resize']))
+		{
+			// Create a thumbnail image
+			$image = new Image($this->file_path);
+
+			$this->file_path = $this->file_path . '_thumb';
+			$image->createThumbnail(100, 100, $this->file_path, '',false);
+		}
+
+		return $this->send_file($use_compression && $this->isCompressible());
+	}
+
+	public function isApproved()
+	{
+		return !empty($this->data['is_approved']);
+	}
+
+	public function isOwner()
+	{
+		return (int) $this->data['id_member'] !== 0 && User::$info->id === (int) $this->data['id_member'];
+	}
+
+	public function isAvatar()
+	{
+		return $this->data['attachment_type'] == Attachment::DB_TYPE_AVATAR;
+	}
+
+	/**
+	 * Generates a language image based on text for display, outputs image and exits
+	 *
+	 * @param null|string $text
+	 * @throws \ElkArte\Exceptions\Exception
+	 */
+	public function noAttach($text = null)
+	{
+		global $txt;
+
+		if ($text === null)
+		{
+			Txt::load('Errors');
+			$text = $txt['attachment_not_found'];
+		}
+
+		try
+		{
+			$img = new TextImage($text);
+			$img = $img->generate(200);
+		}
+		catch (\Exception $e)
+		{
+			throw new Exception('no_access', false);
+		}
+
+		$this->prepare_headers('no_image', 'no_image', 'image/png', 'inline', 'no_image.png', true, false);
+
+		Headers::instance()->sendHeaders();
+
+		return $img;
+	}
+
+	/**
+	 * Increase download counter for id_attach.
+	 *
+	 * What it does:
+	 *
+	 * - Does not check if it's a thumbnail.
+	 *
+	 * @param int $id_attach
+	 * @package Attachments
+	 */
+	public function increaseDownloadCounter()
+	{
+		if (empty($this->id_attach) || $this->isAvatar())
+		{
+			return;
+		}
+
+		$this->db->fetchQuery('
+			UPDATE {db_prefix}attachments
+			SET downloads = downloads + 1
+			WHERE id_attach = {int:id_attach}',
+			array(
+				'id_attach' => $this->id_attach,
+			)
+		);
+	}
+
+	/**
+	 * Sends the requested file to the user.  If the file is compressible e.g.
+	 * has a mine type of text/??? may compress the file prior to sending.
+	 */
+	protected function send_file($use_compression)
+	{
+		$headers = Headers::instance();
+		$body = file_get_contents($this->file_path);
+
+		// If we can/should compress this file
+		if ($use_compression && strlen($body) > 250)
+		{
+			$body = gzencode($body, 2);
+			$headers
+				->header('Content-Encoding', 'gzip')
+				->header('Vary', 'Accept-Encoding');
+		}
+
+		// Someone is getting a present
+		$headers->header('Content-Length', strlen($body));
+		$headers->send();
+		return $body;
+	}
+
+	/**
+	 * If the mime type benefits from compression e.g. text/xyz and gzencode is
+	 * available and the user agent accepts gzip, then return true, else false
+	 *
+	 * @return bool if we should compress the file
+	 */
+	protected function isCompressible()
+	{
+		// Not compressible, or not supported / requested by client
+		return (bool) preg_match('~^(?:text/|application/(?:json|xml|rss\+xml)$)~i', $this->data['mime_type']);
+	}
+
+	/**
+	 * Takes care of sending out the most common headers.
+	 *
+	 * @param string $filename Full path+file name of the file in the filesystem
+	 * @param string $eTag ETag cache validator
+	 * @param string $mime_type The mime-type of the file
+	 * @param string $disposition The value of the Content-Disposition header
+	 * @param string $real_filename The original name of the file
+	 * @param bool $do_cache If send the a max-age header or not
+	 * @param bool $check_filename When false, any check on $filename is skipped
+	 */
+	protected function prepare_headers($filename, $eTag, $mime_type, $disposition, $real_filename, $do_cache, $check_filename = true)
+	{
+		global $txt;
+
+		$headers = Headers::instance();
+		$request = HttpReq::instance();
+
+		// No point in a nicer message, because this is supposed to be an attachment anyway...
+		if ($check_filename && !file_exists($filename))
+		{
+			Txt::load('Errors');
+
+			$protocol = preg_match('~HTTP/1\.[01]~i', $request->server->SERVER_PROTOCOL) ? $request->server->SERVER_PROTOCOL : 'HTTP/1.0';
+			$headers
+				->removeHeader('all')
+				->headerSpecial($protocol . ' 404 Not Found')
+				->sendHeaders();
+
+			// We need to die like this *before* we send any anti-caching headers as below.
+			die('404 - ' . $txt['attachment_not_found']);
+		}
+
+		// If it hasn't been modified since the last time this attachment was retrieved, there's no need to display it again.
+		if (!empty($request->server->HTTP_IF_MODIFIED_SINCE))
+		{
+			list ($modified_since) = explode(';', $request->server->HTTP_IF_MODIFIED_SINCE);
+			if (!$check_filename || strtotime($modified_since) >= filemtime($filename))
+			{
+				@ob_end_clean();
+
+				// Answer the question - no, it hasn't been modified ;).
+				$headers
+					->removeHeader('all')
+					->headerSpecial('HTTP/1.1 304 Not Modified')
+					->sendHeaders();
+				exit;
+			}
+		}
+
+		// Check whether the ETag was sent back, and cache based on that...
+		if (!empty($request->server->HTTP_IF_NONE_MATCH) && strpos($request->server->HTTP_IF_NONE_MATCH, $eTag) !== false)
+		{
+			@ob_end_clean();
+
+			$headers
+				->removeHeader('all')
+				->headerSpecial('HTTP/1.1 304 Not Modified')
+				->sendHeaders();
+			exit;
+		}
+
+		// Send the attachment headers.
+		$headers
+			->header('Expires', gmdate('D, d M Y H:i:s', time() + 525600 * 60) . ' GMT')
+			->header('Last-Modified', gmdate('D, d M Y H:i:s', $check_filename ? filemtime($filename) : time() - 525600 * 60) . ' GMT')
+			->header('Accept-Ranges', 'bytes')
+			->header('Connection', 'close')
+			->header('ETag', $eTag);
+
+		// Different browsers like different standards...
+		$headers->setAttachmentFileParams($mime_type, $real_filename, $disposition);
+
+		// If this has an "image extension" - but isn't actually an image - then ensure it isn't cached cause of silly IE.
+		if ($do_cache)
+		{
+			$headers
+				->header('Cache-Control', 'max-age=' . (525600 * 60) . ', private');
+		}
+		else
+		{
+			$headers
+				->header('Pragma', 'no-cache')
+				->header('Cache-Control', 'no-cache');
+		}
+
+		// Try to buy some time...
+		detectServer()->setTimeLimit(600);
+	}
+
+	protected function rebuildData($id_topic)
+	{
+		global $modSettings;
+
+		$full_attach = $this->getFromTopic($id_topic);
+		$attachment = [
+			'filename' => !empty($full_attach['filename']) ? $full_attach['filename'] : '',
+			'id_attach' => 0,
+			'attachment_type' => 0,
+			'approved' => $full_attach['approved'],
+			'id_member' => $full_attach['id_member']
+		];
+
+		// If it is a known extension, show a mimetype extension image
+		$check = returnMimeThumb(!empty($full_attach['fileext']) ? $full_attach['fileext'] : 'default');
+		if ($check !== false)
+		{
+			$attachment['fileext'] = 'png';
+			$attachment['mime_type'] = 'image/png';
+			$this->file_path = $check;
+		}
+		else
+		{
+			$attachmentsDir = new AttachmentsDirectory($modSettings, $this->db);
+			$this->file_path = $attachmentsDir->getCurrent() . '/' . $attachment['filename'];
+		}
+
+		if (substr(getMimeType($this->file_path), 0, 5) !== 'image')
+		{
+			$attachment['fileext'] = 'png';
+			$attachment['mime_type'] = 'image/png';
+			$this->file_path = $settings['theme_dir'] . '/images/mime_images/default.png';
+		}
+		return $attachment;
+	}
+
+	/**
+	 * Get the specified attachment.
+	 *
+	 * What it does:
+	 *
+	 * - This includes a check of the topic
+	 * - it only returns the attachment if it's indeed attached to a message in the topic given as parameter, and
+	 * query_see_board...
+	 * - Must return the same array keys as getThumbFromTopic()
+	 *
+	 * @param int $id_topic
+	 *
+	 * @return array
+	 * @package Attachments
+	 */
+	protected function getFromTopic($id_topic)
+	{
+		// Make sure this attachment is on this board.
+		$attachmentData = array();
+		$request = $this->db->fetchQuery('
+			SELECT 
+				a.id_folder, a.filename, a.file_hash, a.fileext, a.id_attach, a.attachment_type, 
+				a.mime_type, a.approved, m.id_member
+			FROM {db_prefix}attachments AS a
+				INNER JOIN {db_prefix}messages AS m ON (m.id_msg = a.id_msg AND m.id_topic = {int:current_topic})
+				INNER JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board AND 1=1)
+			WHERE a.id_attach = {int:attach}
+			LIMIT 1',
+			array(
+				'attach' => $this->id_attach,
+				'current_topic' => $id_topic,
+			)
+		);
+		if ($request->num_rows() != 0)
+		{
+			$attachmentData = $request->fetch_assoc();
+		}
+		$request->free_result();
+
+		return $attachmentData;
+	}
+
+	/**
+	 * Get the thumbnail of specified attachment.
+	 *
+	 * What it does:
+	 *
+	 * - This includes a check of the topic
+	 * - it only returns the attachment if it's indeed attached to a message in the topic given as parameter, and
+	 * query_see_board...
+	 * - Must return the same array keys as getFromTopic()
+	 *
+	 * @param int $id_topic
+	 *
+	 * @return array
+	 * @package Attachments
+	 */
+	function getThumbFromTopic($id_topic)
+	{
+		// Make sure this attachment is on this board.
+		$request = $this->db->fetchQuery('
+			SELECT 
+				th.id_folder, th.filename, th.file_hash, th.fileext, th.id_attach, 
+				th.attachment_type, th.mime_type,
+				a.id_folder AS attach_id_folder, a.filename AS attach_filename,
+				a.file_hash AS attach_file_hash, a.fileext AS attach_fileext,
+				a.id_attach AS attach_id_attach, a.attachment_type AS attach_attachment_type,
+				a.mime_type AS attach_mime_type,
+				a.approved, m.id_member
+			FROM {db_prefix}attachments AS a
+				INNER JOIN {db_prefix}messages AS m ON (m.id_msg = a.id_msg AND m.id_topic = {int:current_topic})
+				INNER JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board AND {query_see_board})
+				LEFT JOIN {db_prefix}attachments AS th ON (th.id_attach = a.id_thumb)
+			WHERE a.id_attach = {int:attach}',
+			array(
+				'attach' => $this->id_attach,
+				'current_topic' => $id_topic,
+			)
+		);
+		$attachmentData = [
+			'id_folder' => '', 'filename' => '', 'file_hash' => '', 'fileext' => '', 'id_attach' => '',
+			'attachment_type' => '', 'mime_type' => '', 'approved' => '', 'id_member' => ''];
+		if ($request->num_rows() != 0)
+		{
+			$row = $request->fetch_assoc();
+
+			// If there is a hash then the thumbnail exists
+			if (!empty($row['file_hash']))
+			{
+				$attachmentData = array(
+					'id_folder' => $row['id_folder'],
+					'filename' => $row['filename'],
+					'file_hash' => $row['file_hash'],
+					'fileext' => $row['fileext'],
+					'id_attach' => $row['id_attach'],
+					'attachment_type' => $row['attachment_type'],
+					'mime_type' => $row['mime_type'],
+					'approved' => $row['approved'],
+					'id_member' => $row['id_member'],
+				);
+			}
+			// otherwise $modSettings['attachmentThumbnails'] may be (or was) off, so original file
+			elseif (getValidMimeImageType($row['attach_mime_type']) !== '')
+			{
+				$attachmentData = array(
+					'id_folder' => $row['attach_id_folder'],
+					'filename' => $row['attach_filename'],
+					'file_hash' => $row['attach_file_hash'],
+					'fileext' => $row['attach_fileext'],
+					'id_attach' => $row['attach_id_attach'],
+					'attachment_type' => $row['attach_attachment_type'],
+					'mime_type' => $row['attach_mime_type'],
+					'approved' => $row['approved'],
+					'id_member' => $row['id_member'],
+				);
+			}
+		}
+
+		return $attachmentData;
+	}
+}

--- a/sources/ElkArte/Controller/Attachment.php
+++ b/sources/ElkArte/Controller/Attachment.php
@@ -286,8 +286,7 @@ class Attachment extends AbstractController
 		// We need to do some work on attachments and avatars.
 		require_once(SUBSDIR . '/Attachments.subs.php');
 
-		$id_attach = $this->_req->query->attach ?? '';
-		$attachment_class = new Download($id_attach, $this->_req->getQuery('attach', 'intval', 0));
+		$attachment_class = new Download($this->_req->query->attach ?? '');
 
 		$inline = $attachment_class->isTemporary();
 

--- a/sources/ElkArte/Controller/Attachment.php
+++ b/sources/ElkArte/Controller/Attachment.php
@@ -287,7 +287,7 @@ class Attachment extends AbstractController
 		require_once(SUBSDIR . '/Attachments.subs.php');
 
 		$id_attach = $this->_req->query->attach ?? '';
-		$attachment_class = new Download($id_attach, $this->_req->getQuery('attach', 'intval', $this->_req->getQuery('id', 'intval', 0)));
+		$attachment_class = new Download($id_attach, $this->_req->getQuery('attach', 'intval', 0));
 
 		$inline = $attachment_class->isTemporary();
 

--- a/sources/ElkArte/Controller/Attachment.php
+++ b/sources/ElkArte/Controller/Attachment.php
@@ -20,15 +20,11 @@ use ElkArte\AbstractController;
 use ElkArte\Action;
 use ElkArte\Errors\AttachmentErrorContext;
 use ElkArte\Exceptions\Exception;
-use ElkArte\FileFunctions;
-use ElkArte\Graphics\TextImage;
-use ElkArte\Graphics\Image;
 use ElkArte\AttachmentsDirectory;
+use ElkArte\Attachments\Download;
 use ElkArte\Http\Headers;
 use ElkArte\TemporaryAttachmentsList;
-use ElkArte\Themes\ThemeLoader;
 use ElkArte\Languages\Txt;
-use ElkArte\User;
 
 /**
  * Everything to do with attachment handling / processing
@@ -238,7 +234,7 @@ class Attachment extends AbstractController
 			{
 				require_once(SUBSDIR . '/ManageAttachments.subs.php');
 				$attachId = $this->_req->getPost('attachid', 'intval');
-				if (canRemoveAttachment($attachId, User::$info->id))
+				if (canRemoveAttachment($attachId, $this->user->id))
 				{
 					$result_tmp = removeAttachments(array('id_attach' => $attachId), '', true);
 					if (!empty($result_tmp))
@@ -281,28 +277,19 @@ class Attachment extends AbstractController
 	 */
 	public function action_dlattach()
 	{
-		global $modSettings, $context, $topic, $board, $settings;
+		global $modSettings, $context, $topic, $board;
 
 		// Some defaults that we need.
 		$context['no_last_modified'] = true;
 		$filename = null;
 
-		// Make sure some attachment was requested!
-		if (!isset($this->_req->query->attach) && !isset($this->_req->query->id))
-		{
-			// Give them the old can't find it image
-			$this->action_no_attach();
-		}
-
 		// We need to do some work on attachments and avatars.
 		require_once(SUBSDIR . '/Attachments.subs.php');
 
-		// Temporary attachment, special case...
-		if (isset($this->_req->query->attach) && strpos($this->_req->query->attach, 'post_tmp_' . $this->user->id . '_') !== false)
-		{
-			// Return via tmpattach, back presumably to the post form
-			$this->action_tmpattach();
-		}
+		$id_attach = $this->_req->query->attach ?? '';
+		$attachment_class = new Download($id_attach, $this->_req->getQuery('attach', 'intval', $this->_req->getQuery('id', 'intval', 0)));
+
+		$inline = $attachment_class->isTemporary();
 
 		$id_attach = $this->_req->getQuery('attach', 'intval', $this->_req->getQuery('id', 'intval', 0));
 
@@ -325,379 +312,20 @@ class Attachment extends AbstractController
 
 		isAllowedTo('view_attachments', $id_board);
 
-		if ($this->_req->getQuery('thumb') === null)
+		$type = $this->_req->getQuery('thumb') !== null ? 'thumb' : $this->_req->getQuery('type');
+		if ($attachment_class->validate($type, $id_topic))
 		{
-			$attachment = getAttachmentFromTopic($id_attach, $id_topic);
-		}
-		else
-		{
-			$this->_req->query->image = true;
-			$attachment = getAttachmentThumbFromTopic($id_attach, $id_topic);
-
-			// No file name, no thumbnail, no image.
-			if (empty($attachment['filename']))
+			// If it isn't yet approved (and is an attachment), do they have permission to view it?
+			if ($attachment_class->isApproved() == false && $attachment_class->isOwner() == false && $attachment_class->isAvatar() == false)
 			{
-				$full_attach = getAttachmentFromTopic($id_attach, $id_topic);
-				$attachment['filename'] = !empty($full_attach['filename']) ? $full_attach['filename'] : '';
-				$attachment['id_attach'] = 0;
-				$attachment['attachment_type'] = 0;
-				$attachment['approved'] = $full_attach['approved'];
-				$attachment['id_member'] = $full_attach['id_member'];
-
-				// If it is a known extension, show a mimetype extension image
-				$check = returnMimeThumb(!empty($full_attach['fileext']) ? $full_attach['fileext'] : 'default');
-				if ($check !== false)
-				{
-					$attachment['fileext'] = 'png';
-					$attachment['mime_type'] = 'image/png';
-					$filename = $check;
-				}
-				else
-				{
-					$attachmentsDir = new AttachmentsDirectory($modSettings, database());
-					$filename = $attachmentsDir->getCurrent() . '/' . $attachment['filename'];
-				}
-
-				if (substr(getMimeType($filename), 0, 5) !== 'image')
-				{
-					$attachment['fileext'] = 'png';
-					$attachment['mime_type'] = 'image/png';
-					$filename = $settings['theme_dir'] . '/images/mime_images/default.png';
-				}
+				isAllowedTo('approve_posts', $id_board ?? $board);
 			}
+
+			$attachment_class->increaseDownloadCounter();
 		}
 
-		if (empty($attachment))
-		{
-			// Exit via no_attach
-			$this->action_no_attach();
-		}
-
-		$id_folder = $attachment['id_folder'] ?? '';
-		$real_filename = $attachment['filename'] ?? '';
-		$file_hash = $attachment['file_hash'] ?? '';
-		$file_ext = $attachment['fileext'] ?? '';
-		$id_attach = $attachment['id_attach'] ?? '';
-		$attachment_type = $attachment['attachment_type'] ?? '';
-		$mime_type = $attachment['mime_type'] ?? '';
-		$is_approved = $attachment['approved'] ?? '';
-		$id_member = $attachment['id_member'] ?? '';
-
-		// If it isn't yet approved, do they have permission to view it?
-		if (!$is_approved && ($id_member == 0 || $this->user->id !== $id_member) && ($attachment_type == 0 || $attachment_type == 3))
-		{
-			isAllowedTo('approve_posts', $id_board ?? $board);
-		}
-
-		// Update the download counter (unless it's a thumbnail or an avatar).
-		if (!empty($id_attach) && empty($is_avatar) || $attachment_type != 3)
-		{
-			increaseDownloadCounter($id_attach);
-		}
-
-		if ($filename === null)
-		{
-			$filename = getAttachmentFilename($real_filename, $id_attach, $id_folder, false, $file_hash);
-		}
-
-		$eTag = '"' . substr($id_attach . $real_filename . @filemtime($filename), 0, 64) . '"';
-		$disposition = !isset($this->_req->query->image) ? 'attachment' : 'inline';
-		$do_cache = !(!isset($this->_req->query->image) && getValidMimeImageType($file_ext) !== '');
-
-		// Make sure the mime type warrants an inline display.
-		if (isset($this->_req->query->image) && !empty($mime_type) && strpos($mime_type, 'image/') !== 0)
-		{
-			unset($this->_req->query->image);
-			$mime_type = '';
-		}
-		// Does this have a mime type?
-		elseif (empty($mime_type) || !isset($this->_req->query->image) && getValidMimeImageType($file_ext) !== '')
-		{
-			$mime_type = '';
-			if (isset($this->_req->query->image))
-			{
-				unset($this->_req->query->image);
-			}
-		}
-
-		$this->prepare_headers($filename, $eTag, $mime_type, $disposition, $real_filename, $do_cache);
-		$this->send_file($filename, $mime_type);
-
-		obExit(false);
-	}
-
-	/**
-	 * Generates a language image based on text for display, outputs image and exits
-	 *
-	 * @param null|string $text
-	 * @throws \ElkArte\Exceptions\Exception
-	 */
-	public function action_no_attach($text = null)
-	{
-		global $txt;
-
-		if ($text === null)
-		{
-			new ThemeLoader();
-			Txt::load('Errors');
-			$text = $txt['attachment_not_found'];
-		}
-
-		try
-		{
-			$img = new TextImage($text);
-			$img = $img->generate(200);
-		}
-		catch (\Exception $e)
-		{
-			throw new Exception('no_access', false);
-		}
-
-		$this->prepare_headers('no_image', 'no_image', 'image/png', 'inline', 'no_image.png', true, false);
-		Headers::instance()->sendHeaders();
-		echo $img;
-
-		obExit(false);
-	}
-
-	/**
-	 * If the mime type benefits from compression e.g. text/xyz and gzencode is
-	 * available and the user agent accepts gzip, then return true, else false
-	 *
-	 * @param string $mime_type
-	 * @return bool if we should compress the file
-	 */
-	public function useCompression($mime_type)
-	{
-		global $modSettings;
-
-		// Not compressible, or not supported / requested by client
-		if (!preg_match('~^(?:text/|application/(?:json|xml|rss\+xml)$)~i', $mime_type)
-			|| (!isset($_SERVER['HTTP_ACCEPT_ENCODING']) || strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') === false))
-		{
-			return false;
-		}
-
-		// Support is available on the server
-		if (!function_exists('gzencode') && !empty($modSettings['enableCompressedOutput']))
-		{
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Takes care of sending out the most common headers.
-	 *
-	 * @param string $filename Full path+file name of the file in the filesystem
-	 * @param string $eTag ETag cache validator
-	 * @param string $mime_type The mime-type of the file
-	 * @param string $disposition The value of the Content-Disposition header
-	 * @param string $real_filename The original name of the file
-	 * @param bool $do_cache Send a max-age header or not
-	 * @param bool $check_filename When false, any check on $filename is skipped
-	 */
-	public function prepare_headers($filename, $eTag, $mime_type, $disposition, $real_filename, $do_cache, $check_filename = true)
-	{
-		global $txt;
-
-		$headers = Headers::instance();
-
-		// No point in a nicer message, because this is supposed to be an attachment anyway...
-		if ($check_filename && !FileFunctions::instance()->fileExists($filename))
-		{
-			Txt::load('Errors');
-
-			$protocol = preg_match('~HTTP/1\.[01]~i', $this->_req->server->SERVER_PROTOCOL) ? $this->_req->server->SERVER_PROTOCOL : 'HTTP/1.0';
-			$headers
-				->removeHeader('all')
-				->headerSpecial($protocol . ' 404 Not Found')
-				->sendHeaders();
-
-			// We need to die like this *before* we send any anti-caching headers as below.
-			die('404 - ' . $txt['attachment_not_found']);
-		}
-
-		// If it hasn't been modified since the last time this attachment was retrieved, there's no need to display it again.
-		if (!empty($this->_req->server->HTTP_IF_MODIFIED_SINCE))
-		{
-			list ($modified_since) = explode(';', $this->_req->server->HTTP_IF_MODIFIED_SINCE);
-			if (!$check_filename || strtotime($modified_since) >= filemtime($filename))
-			{
-				@ob_end_clean();
-
-				// Answer the question - no, it hasn't been modified ;).
-				$headers
-					->removeHeader('all')
-					->headerSpecial('HTTP/1.1 304 Not Modified')
-					->sendHeaders();
-				exit;
-			}
-		}
-
-		// Check whether the ETag was sent back, and cache based on that...
-		if (!empty($this->_req->server->HTTP_IF_NONE_MATCH) && strpos($this->_req->server->HTTP_IF_NONE_MATCH, $eTag) !== false)
-		{
-			@ob_end_clean();
-
-			$headers
-				->removeHeader('all')
-				->headerSpecial('HTTP/1.1 304 Not Modified')
-				->sendHeaders();
-			exit;
-		}
-
-		// Send the attachment headers.
-		$headers
-			->header('Expires', gmdate('D, d M Y H:i:s', time() + 525600 * 60) . ' GMT')
-			->header('Last-Modified', gmdate('D, d M Y H:i:s', $check_filename ? filemtime($filename) : time() - 525600 * 60) . ' GMT')
-			->header('Accept-Ranges', 'bytes')
-			->header('Connection', 'close')
-			->header('ETag', $eTag);
-
-		// Different browsers like different standards...
-		$headers->setAttachmentFileParams($mime_type, $real_filename, $disposition);
-
-		// If this has an "image extension" - but isn't actually an image - then ensure it isn't cached cause of silly IE.
-		if ($do_cache)
-		{
-			$headers
-				->header('Cache-Control', 'max-age=' . (525600 * 60) . ', private');
-		}
-		else
-		{
-			$headers
-				->header('Pragma', 'no-cache')
-				->header('Cache-Control', 'no-cache');
-		}
-
-		// Try to buy some time...
-		detectServer()->setTimeLimit(600);
-	}
-
-	/**
-	 * Sends the requested file to the user.  If the file is compressible e.g.
-	 * has a mine type of text/??? may compress the file prior to sending.
-	 *
-	 * @param string $filename
-	 * @param string $mime_type
-	 */
-	public function send_file($filename, $mime_type)
-	{
-		$headers = Headers::instance();
-		$body = file_get_contents($filename);
-		$use_compression = $this->useCompression($mime_type);
-
-		// If we can/should compress this file
-		if ($use_compression && strlen($body) > 250)
-		{
-			$body = gzencode($body, 2);
-			$headers
-				->header('Content-Encoding', 'gzip')
-				->header('Vary', 'Accept-Encoding');
-		}
-
-		// Someone is getting a present
-		$headers->header('Content-Length', strlen($body));
-		$headers->send();
-		echo $body;
-	}
-
-	/**
-	 * "Simplified", cough, version of action_dlattach to send out thumbnails while creating
-	 * or editing a message.
-	 */
-	public function action_tmpattach()
-	{
-		global $modSettings, $topic;
-
-		// Make sure some attachment was requested!
-		if (!isset($this->_req->query->attach))
-		{
-			$this->action_no_attach();
-		}
-
-		// We will need some help
-		require_once(SUBSDIR . '/Attachments.subs.php');
-		$tmp_attachments = new TemporaryAttachmentsList();
-		$attachmentsDir = new AttachmentsDirectory($modSettings, database());
-
-		try
-		{
-			if (empty($topic) || (string) (int) $this->_req->query->attach !== (string) $this->_req->query->attach)
-			{
-				$attach_data = $tmp_attachments->getTempAttachById($this->_req->query->attach, $attachmentsDir, User::$info->id);
-				$file_ext = pathinfo($attach_data['name'], PATHINFO_EXTENSION);
-				$filename = $attach_data['tmp_name'];
-				$id_attach = $attach_data['attachid'];
-				$real_filename = $attach_data['name'];
-				$mime_type = $attach_data['type'];
-			}
-			else
-			{
-				$id_attach = $this->_req->getQuery('attach', 'intval', -1);
-
-				isAllowedTo('view_attachments');
-				$attachment = getAttachmentFromTopic($id_attach, $topic);
-				if (empty($attachment))
-				{
-					// Exit via no_attach
-					$this->action_no_attach();
-				}
-
-				// Save some typing
-				$id_folder = $attachment['id_folder'];
-				$real_filename = $attachment['filename'];
-				$file_hash = $attachment['file_hash'];
-				$file_ext = $attachment['fileext'];
-				$id_attach = $attachment['id_attach'];
-				$attachment_type = $attachment['attachment_type'];
-				$mime_type = $attachment['mime_type'];
-				$is_approved = $attachment['approved'];
-				$id_member = $attachment['id_member'];
-
-				// If it isn't yet approved, do they have permission to view it?
-				if (!$is_approved && ($id_member == 0 || $this->user->id !== $id_member) && ($attachment_type == 0 || $attachment_type == 3))
-				{
-					isAllowedTo('approve_posts');
-				}
-
-				$filename = getAttachmentFilename($real_filename, $id_attach, $id_folder, false, $file_hash);
-			}
-		}
-		catch (\Exception $e)
-		{
-			throw new Exception($e->getMessage(), false);
-		}
-
-		$resize = true;
-
-		// Return mime type ala mimetype extension
-		if (substr(getMimeType($filename), 0, 5) !== 'image')
-		{
-			$checkMime = returnMimeThumb($file_ext);
-			$mime_type = 'image/png';
-			$resize = false;
-			$filename = $checkMime;
-		}
-
-		$eTag = '"' . substr($id_attach . $real_filename . filemtime($filename), 0, 64) . '"';
-		$do_cache = !(!isset($this->_req->query->image) && getValidMimeImageType($file_ext) !== '');
-
-		$this->prepare_headers($filename, $eTag, $mime_type, 'inline', $real_filename, $do_cache);
-
-		if ($resize)
-		{
-			// Create a thumbnail image
-			$image = new Image($filename);
-
-			$filename = $filename . '_thumb';
-			$image->createThumbnail(100, 100, $filename, null,false);
-		}
-
-		// With the headers complete, send the file data
-		$this->send_file($filename, $mime_type);
+		$use_compression = !empty($modSettings['enableCompressedOutput']) && isset($_SERVER['HTTP_ACCEPT_ENCODING']) && strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== false && function_exists('gzencode');
+		echo $attachment_class->send($inline, $use_compression);
 
 		obExit(false);
 	}

--- a/themes/default/Display.template.php
+++ b/themes/default/Display.template.php
@@ -971,11 +971,11 @@ function template_display_attachments($message, $ignoring)
 
 		if ($attachment['is_image'])
 		{
-			if ($attachment['thumbnail']['has_thumb'])
+			if ($attachment['has_thumb'])
 			{
 				echo '
-											<a href="', $attachment['href'], ';image" id="link_', $attachment['id'], '" ', $attachment['thumbnail']['lightbox'], '>
-												<img class="attachment_image" src="', $attachment['thumbnail']['href'], '" alt="" id="thumb_', $attachment['id'], '" />
+											<a href="', $attachment['href'], ';image" id="link_', $attachment['id'], '" ', 'data-lightboxmessage="' . $message['id'] . '" data-lightboximage="' . $attachment['id'] . '"', '>
+												<img class="attachment_image" src="', $attachment['thumbnail_href'], '" alt="" id="thumb_', $attachment['id'], '" />
 											</a>';
 			}
 			else


### PR DESCRIPTION
It was a while I wanted to kill again the attachments.
That's really just a bit of makeup to warm me up. The Attachment class is a placeholder, I just wanted to put these constants somewhere because it always bothered me I could never find what the heck the numbers were. It could hold much more, worst case a good chunk of Attachments.subs.php in a static way.

I was thinking of a couple of things:
1. drop the storing of the thumbnails in the db (just rely on a prefix to the file name and GTFO),
2. *maybe* move the uploaded avatars out of the way (that as far as I remember is a good chunk of annoying code to deal with),
3. if not too messy, maybe go back to when there was one way to store attachments, just not a single directory, I'd say by months is usually good enough and easy to deal with?

What do you think @Spuds ?