### PR TITLE
Test updates

### DIFF
--- a/.github/bootstrap.php
+++ b/.github/bootstrap.php
@@ -43,7 +43,7 @@ if (!defined('ELK'))
 	define('BOARDDIR', $boarddir);
 	define('CACHEDIR', $cachedir);
 	define('EXTDIR', $extdir);
-	define('LANGUAGEDIR', $boarddir . '/themes/default/languages');
+	define('LANGUAGEDIR', $sourcedir . '/ElkArte/Languages');
 	define('SOURCEDIR', $sourcedir);
 	define('ADMINDIR', $sourcedir . '/admin');
 	define('CONTROLLERDIR', $sourcedir . '/controllers');
@@ -88,7 +88,7 @@ loadBoard();
 loadPermissions();
 new ElkArte\Themes\ThemeLoader();
 
-// It should be added to the install and upgrade scripts.
+// It should be added to the installation and upgrade scripts.
 // But since the converters need to be updated also. This is easier.
 updateSettings(array(
 	'attachmentUploadDir' => serialize(array(1 => $modSettings['attachmentUploadDir'])),
@@ -104,6 +104,6 @@ updateSettings(array(
 removeSettings('mentions_member_check');
 
 // Basic language is good to have for functional tests
-\ElkArte\Themes\ThemeLoader::loadLanguageFile('index+Errors');
+\ElkArte\Themes\ThemeLoader::loadLanguageFile('Index+Errors');
 
 file_put_contents('bootstrapcompleted.lock', '1');

--- a/.github/phpunit-mysql.xml
+++ b/.github/phpunit-mysql.xml
@@ -20,7 +20,7 @@
           <directory suffix="Basic.php">../tests/sources</directory>
       </testsuite>
       <testsuite name="Bootstrap Tests">
-          <directory suffix="BootstrapRunTestExt.php">../tests/travis-ci</directory>
+          <directory suffix="BootstrapRunTestExt.php">../tests</directory>
       </testsuite>
   </testsuites>
 

--- a/.github/phpunit-webtest.xml
+++ b/.github/phpunit-webtest.xml
@@ -22,7 +22,7 @@
           <directory suffix=".php">../themes/default</directory>
           <exclude>
               <directory suffix=".php">../sources/ext</directory>
-              <directory suffix=".php">../themes/default/languages/english</directory>
+              <directory suffix=".php">../themes/ElkArte/Languages</directory>
           </exclude>
       </whitelist>
   </filter>

--- a/.github/setup-elkarte.sh
+++ b/.github/setup-elkarte.sh
@@ -23,4 +23,10 @@ then
 fi
 
 # Phpunit and support
+# composer config --file=composer2.json && composer install --no-interaction --quiet
 composer install --no-interaction --quiet
+if [[ "$PHP_VERSION" =~ ^8 ]]
+then
+	composer remove phpunit/phpunit phpunit/phpunit-selenium --dev --update-with-dependencies
+	composer require phpunit/phpunit:^9.0 --dev --update-with-all-dependencies --ignore-platform-reqs
+fi

--- a/.github/setup-results.sh
+++ b/.github/setup-results.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Setup xdebug filter list, run PHPUNIT tests, send to codecov
+# run PHPUNIT tests, send to codecov
 
 set -e
 set +x
@@ -10,14 +10,10 @@ DB=$1
 PHP_VERSION=$2
 
 # Build a config string for PHPUnit
-COVER="--prepend /tmp/xdebug-filter.php"
-CONFIG="--stderr --verbose --debug --configuration .github/phpunit-${DB}.xml"
-
-# Create xdebug filter list
-vendor/bin/phpunit --dump-xdebug-filter /tmp/xdebug-filter.php ${CONFIG}
+CONFIG="--verbose --configuration .github/phpunit-${DB}.xml"
 
 # Running PHPUnit tests
-vendor/bin/phpunit ${CONFIG} ${COVER}
+vendor/bin/phpunit ${CONFIG}
 
 # Agents will merge all coverage data...
 if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]

--- a/.github/setup-selenium.sh
+++ b/.github/setup-selenium.sh
@@ -23,8 +23,8 @@ CHROMEDRIVER_ZIP=/tmp/chromedriver_linux64.zip
 
 # Download Selenium
 echo "Downloading Selenium"
-mkdir -p $(dirname "$SELENIUM_JAR")
-wget -nv -O "$SELENIUM_JAR" "$SELENIUM_DOWNLOAD_URL"
+sudo mkdir -p $(dirname "$SELENIUM_JAR")
+sudo wget -nv -O "$SELENIUM_JAR" "$SELENIUM_DOWNLOAD_URL"
 
 # Install Fx or Chrome
 echo "Installing Browser"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,11 +16,11 @@ env:
 jobs:
   # Selenium headless browser testing
   Selenium-checks:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
-          - db: 'mysql:5.7'
+          - db: "mysql:5.7"
             php: '7.2'
 
     name: WebTest (PHP ${{ matrix.php }} - DB ${{ matrix.db_alias != '' && matrix.db_alias || matrix.db }})
@@ -98,7 +98,7 @@ jobs:
 
   # Static checks, e.g. syntax errors, lint, etc
   static-checks:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
@@ -155,7 +155,7 @@ jobs:
 
   # START MySQL / MariaDB Tests
   mysql-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
@@ -234,14 +234,14 @@ jobs:
 
   # START Postgres Tests
   postgres-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
           - php: '7.2'
-            db: "postgres:9.5"
+            db: "postgres:9"
           - php: '7.4'
-            db: "postgres:11.10"
+            db: "postgres:12"
 
     name: Postgre (${{ matrix.php }} - DB ${{ matrix.db_alias != '' && matrix.db_alias || matrix.db }})
 

--- a/Settings.sample.php
+++ b/Settings.sample.php
@@ -176,4 +176,4 @@ $extdir = __DIR__ . '/sources/ext';
  * Path to the languages directory.
  * @var string
  */
-$languagedir = __DIR__ . '/themes/default/languages';
+$languagedir = __DIR__ . '/sources/ElkArte/Languages';

--- a/Settings_bak.sample.php
+++ b/Settings_bak.sample.php
@@ -176,4 +176,4 @@ $extdir = __DIR__ . '/sources/ext';
  * Path to the languages directory.
  * @var string
  */
-$languagedir = __DIR__ . '/themes/default/languages';
+$languagedir = __DIR__ . '/sources/ElkArte/Languages';

--- a/composer.json
+++ b/composer.json
@@ -35,14 +35,9 @@
 		"ext-exif": "*"
 	},
 	"suggest": {
-		"ext-recode": "*",
-		"ext-openssl": "*",
-		"ext-ctype": "*",
 		"ext-memcache": "*",
-		"ext-bcmath": "*",
 		"ext-zlib": "*",
 		"ext-pgsql": "*",
-		"ext-pspell": "*",
 		"ext-imap": "*",
 		"ext-memcached": "*",
 		"ext-zend-opcache": "*",
@@ -50,7 +45,6 @@
 		"ext-apcu": "*",
 		"ext-libxml": "*",
 		"ext-dom": "*",
-		"ext-mcrypt": "*",
 		"ext-apache": "*",
 		"ext-iconv": "*",
 		"ext-imagick": "*"

--- a/sources/subs/Members.subs.php
+++ b/sources/subs/Members.subs.php
@@ -627,7 +627,7 @@ function registerMember(&$regOptions, $ErrorContext = 'register')
 		'member_name' => $regOptions['username'],
 		'email_address' => $regOptions['email'],
 		'passwd' => validateLoginPassword($password, '', $regOptions['username'], true),
-		'password_salt' => $tokenizer->generate_hash(4),
+		'password_salt' => $tokenizer->generate_hash(10),
 		'posts' => 0,
 		'date_registered' => !empty($regOptions['time']) ? $regOptions['time'] : time(),
 		'member_ip' => $regOptions['interface'] == 'admin' ? '127.0.0.1' : $regOptions['ip'],

--- a/tests/sources/LanguageStringsTest.Basic.php
+++ b/tests/sources/LanguageStringsTest.Basic.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 class TestLanguageStrings extends TestCase
 {
 	protected $backupGlobalsBlacklist = ['user_info'];
+
 	/**
 	 * Prepare what is necessary to use in these tests.
 	 *
@@ -40,6 +41,7 @@ class TestLanguageStrings extends TestCase
 			foreach ($content as $string)
 			{
 				$string = trim($string);
+
 				// A string begins with $txt['
 				if (substr($string, 0, 6) == '$txt[\'')
 				{
@@ -47,7 +49,9 @@ class TestLanguageStrings extends TestCase
 					$multiline = true;
 				}
 				elseif ($multiline)
+				{
 					$full_string .= $string;
+				}
 
 				// This is the end of the string and not some odd stuff
 				if ((substr($string, -2) == '\';' && substr($string, -3) != '\\\';') || (substr($string, -2) == '";' && substr($string, -3) != '\\";'))
@@ -56,14 +60,15 @@ class TestLanguageStrings extends TestCase
 					if (!empty($match[1]))
 					{
 						$m = preg_replace('~([^\w:])~', '-->$1<--', $match[1]);
-
 						$this->assertTrue($m === $match[1], 'The index of the string \'' . $match[1] . '\' contains invalid characters: \'' . $m . '\'');
 					}
+
 					if (!empty($match[2]))
 					{
 						$contains_concat = (strpos($match[2], '\' . \'') !== false || strpos($match[2], '" . "') !== false);
 						$this->assertFalse($contains_concat, 'The string \'' . $match[1] . '\' seems to contain some kind of PHP string concatenation, please fix it (or fix the test).');
 					}
+
 					$full_string = '';
 					$multiline = false;
 				}


### PR DESCRIPTION
Some minor improvements to the testbed
- use 20.04
- user phpunit9 for php8 tests (only to allow test coverage)
- update language file locations
- cleanup some composer dependency's
- drop xdebug filer list (its was removed or depreciated in 9.0)
- Can't convert to 9.0 due to selenium test coverage not working on it.  I could do what I did with the php8.0 test but not worth the effort at this time.