### PR TITLE
Mail

### DIFF
--- a/sources/ElkArte/Controller/ScheduledTasks.php
+++ b/sources/ElkArte/Controller/ScheduledTasks.php
@@ -14,6 +14,7 @@
 namespace ElkArte\Controller;
 
 use ElkArte\AbstractController;
+use ElkArte\Mail\QueueMail;
 
 /**
  * This controllers action handlers are automatically called.
@@ -87,14 +88,7 @@ class ScheduledTasks extends AbstractController
 	 */
 	public function action_reducemailqueue()
 	{
-		global $modSettings;
-
-		// Lets not waste our time or resources.
-		if (empty($modSettings['mail_queue_use_cron']))
-		{
-			// This does the hard work, it does.
-			require_once(SUBSDIR . '/Mail.subs.php');
-			reduceMailQueue();
-		}
+		// This does the hard work, it does.
+		(new QueueMail())->reduceMailQueue();
 	}
 }

--- a/sources/ElkArte/Mail/BaseMail.php
+++ b/sources/ElkArte/Mail/BaseMail.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * Base abstract class for mail functions
  *
  * @package   ElkArte Forum
  * @copyright ElkArte Forum contributors
@@ -12,6 +13,9 @@
 
 namespace ElkArte\Mail;
 
+/**
+ * BaseMail class provides constructor and common code for other mail functions
+ */
 abstract class BaseMail
 {
 	/** @var bool If to use PBE/Mailist processing */

--- a/sources/ElkArte/Mail/BaseMail.php
+++ b/sources/ElkArte/Mail/BaseMail.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ *
+ * @package   ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ *
+ * @version 2.0 dev
+ *
+ */
+
+namespace ElkArte\Mail;
+
+abstract class BaseMail
+{
+	/** @var bool If to use PBE/Mailist processing */
+	public $mailList = false;
+
+	/** @var bool If to use mail or SMTP to send */
+	public $useSendmail = true;
+
+	/** @var string \r\n or \n based on transport and OS */
+	public $lineBreak = "\n";
+
+	/** @var m, p or t */
+	public $messageType;
+
+	/** @var array collection of data for saving in DB to allow reply to email */
+	public $unqPBEHead = [];
+
+	/** @var string Used to help bounce detection */
+	public $returnPath;
+
+	/**
+	 * Constructor, use to set the transport and linebreak
+	 */
+	public function __construct()
+	{
+		$this->setMailTransport();
+		$this->setLineBreak();
+
+		require_once(SUBSDIR . '/Mail.subs.php');
+	}
+
+	/**
+	 * Sets if we use php mail or smtp mail transport
+	 */
+	public function setMailTransport()
+	{
+		global $modSettings;
+
+		$this->useSendmail = empty($modSettings['mail_type']) || $modSettings['smtp_host'] === '';
+	}
+
+	/**
+	 * Based on OS or mail transport, sets the needed linebreak value
+	 */
+	public function setLineBreak()
+	{
+		// Line breaks need to be \r\n only in windows or for SMTP.
+		$this->lineBreak = detectServer()->is('windows') || !$this->useSendmail ? "\r\n" : "\n";
+	}
+
+	/**
+	 * Sets flag if we are using maillist functionality
+	 *
+	 * @param string $from_wrapper
+	 * @param string $message_id
+	 * @param int $priority
+	 */
+	public function setMailList($from_wrapper, $message_id, $priority)
+	{
+		global $modSettings;
+
+		// Using maillist styles and this message qualifies (priority 3 and below only (4 = digest, 5 = newsletter))
+		$this->mailList = !empty($modSettings['maillist_enabled'])
+			&& $from_wrapper !== null
+			&& $message_id !== null
+			&& $priority < 4
+			&& empty($modSettings['mail_no_message_id']);
+	}
+
+	/**
+	 * Message type is one of m = message, t = topic, p = private
+	 *
+	 * @param string $message_id
+	 * @return string cleaned message id
+	 */
+	public function setMessageType($message_id)
+	{
+		$this->messageType = 'm';
+		if ($message_id !== null && isset($message_id[0]) && in_array($message_id[0], ['m', 'p', 't']))
+		{
+			$this->messageType = $message_id[0];
+			$message_id = substr($message_id, 1);
+		}
+
+		return $message_id;
+	}
+
+	/**
+	 * Sets the unique ID for the message id header and PBE emails
+	 *
+	 * If using maillist functions it will also insert the ID into the message body's as
+	 * some email clients strip, or do not return, proper headers to show what they are in replying to.
+	 * PBE functions depend on finding this key to match up reply's to a message and ensure the reply
+	 * was from a valid recipient.
+	 *
+	 * @param $message_id
+	 * @return string
+	 */
+	public function getUniqueMessageID($message_id)
+	{
+		global $boardurl, $modSettings;
+
+		$unq_head = '';
+
+		// If we are using the post by email functions, then we generate "reply to mail" security keys
+		if ($this->mailList)
+		{
+			$this->unqPBEHead[0] = md5($boardurl . microtime() . mt_rand());
+			$this->unqPBEHead[1] = $this->messageType;
+			$this->unqPBEHead[2] = $message_id;
+
+			$unq_head = $this->unqPBEHead[0] . '-' . $this->unqPBEHead[1] . $this->unqPBEHead[2];
+		}
+		elseif (empty($modSettings['mail_no_message_id']))
+		{
+			$unq_head = md5($boardurl . microtime()) . '-' . $message_id;
+		}
+
+		return $unq_head;
+	}
+
+	/**
+	 * Sets a return path, mainly used in PHP mail() function to help in bounce detection
+	 *
+	 * @return void
+	 */
+	public function setReturnPath()
+	{
+		global $modSettings, $webmaster_email;
+
+		$this->returnPath = !empty($modSettings['maillist_sitename_address']) ? $modSettings['maillist_sitename_address'] : '';
+
+		if ($this->returnPath === '')
+		{
+			$this->returnPath = empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'];
+		}
+	}
+}

--- a/sources/ElkArte/Mail/BaseMail.php
+++ b/sources/ElkArte/Mail/BaseMail.php
@@ -23,7 +23,7 @@ abstract class BaseMail
 	/** @var string \r\n or \n based on transport and OS */
 	public $lineBreak = "\n";
 
-	/** @var m, p or t */
+	/** @var string m, p or t */
 	public $messageType;
 
 	/** @var array collection of data for saving in DB to allow reply to email */

--- a/sources/ElkArte/Mail/BuildMail.php
+++ b/sources/ElkArte/Mail/BuildMail.php
@@ -17,6 +17,7 @@ class BuildMail extends BaseMail
 {
 	/** @var array All the required headers to send */
 	public $headers = [];
+
 	/** @var string Mime message composed of various sections/boundaries */
 	public $message;
 
@@ -45,9 +46,6 @@ class BuildMail extends BaseMail
 		global $modSettings;
 
 		$priority = (int) $priority;
-
-		// Use sendmail or SMTP ?
-		$this->setMailTransport();
 
 		// Use maillist styles ?
 		$this->setMailList($from_wrapper, $message_id, $priority);
@@ -300,7 +298,10 @@ class BuildMail extends BaseMail
 		{
 			// Standard ElkArte headers
 			$this->headers[] = 'From: ' . $from_name . ' <' . (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from']) . '>';
-			$this->headers[] = ($from !== null && strpos($from, '@') !== false) ? 'Reply-To: <' . $from . '>' : '';
+			if ($from !== null && strpos($from, '@') !== false)
+			{
+				$this->headers[] = 'Reply-To: <' . $from . '>';
+			}
 		}
 	}
 

--- a/sources/ElkArte/Mail/BuildMail.php
+++ b/sources/ElkArte/Mail/BuildMail.php
@@ -1,0 +1,500 @@
+<?php
+
+/**
+ * This class deals with the creation of email headers and email message encodings
+ *
+ * @package   ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ *
+ * @version 2.0 dev
+ *
+ */
+
+namespace ElkArte\Mail;
+
+class BuildMail extends BaseMail
+{
+	/** @var array All the required headers to send */
+	public $headers = [];
+	/** @var string Mime message composed of various sections/boundaries */
+	public $message;
+
+	/**
+	 * This function builds an email and its headers.
+	 *
+	 * It uses the mail_type settings and webmaster_email variable.
+	 *
+	 * @param string[]|string $to - the email(s) to send to
+	 * @param string $subject - email subject, expected to have entities, and slashes, but not be parsed
+	 * @param string $message - email body, expected to have slashes, no htmlentities
+	 * @param string|null $from = null - the address to use for replies
+	 * @param string|null $message_id = null - if specified, it will be used as local part of the Message-ID header.
+	 * @param bool $send_html = false, if the message is HTML vs. plain text
+	 * @param int $priority = 3 Primarily used when the queue is enabled.  0 will bypass any queue and send now,
+	 * 4 (digest), 5 (newsletter) will bypass any PBE settings.  3 normal email, 1/2 registrations etc.
+	 * @param bool $is_private redacts names from appearing in the mail queue
+	 * @param string|null $from_wrapper - used to provide envelope from wrapper based on if we share a
+	 * users display name
+	 * @param int|null $reference - The parent topic id for use in a References header
+	 * @return bool If the email was accepted properly.
+	 * @package Mail
+	 */
+	public function buildEmail($to, $subject, $message, $from = null, $message_id = null, $send_html = false, $priority = 3, $is_private = false, $from_wrapper = null, $reference = null)
+	{
+		global $modSettings;
+
+		$priority = (int) $priority;
+
+		// Use sendmail or SMTP ?
+		$this->setMailTransport();
+
+		// Use maillist styles ?
+		$this->setMailList($from_wrapper, $message_id, $priority);
+
+		// Set line breaks as required by OS and Transport
+		$message = $this->setMessageLineBreak($message);
+
+		// Set Message type and clean message_id
+		$message_id = $this->setMessageType($message_id);
+
+		// If the recipient list isn't an array, make it one.
+		$to_array = is_array($to) ? $to : array($to);
+
+		// Get rid of entities in the subject line
+		$subject = un_htmlspecialchars($subject);
+
+		// Make the message use the proper line breaks.
+		$message = str_replace(array("\r", "\n"), array('', $this->lineBreak), $message);
+
+		// Support Basic DMARC Compliance when in MLM mode
+		$from = $this->setDMARCFrom($from, $from_wrapper);
+
+		// Take care of from / subject encodings
+		$from_name = $this->setFromName($from);
+		list ($subject) = $this->mimeSpecialChars($subject);
+
+		// Construct from / replyTo mail headers, based on if we show a users name
+		$this->setFromHeaders($from, $from_name, $from_wrapper, $reference);
+
+		// We'll need this later for the envelope fix, too, so keep it
+		$this->setReturnPath();
+
+		// Return path, date, mailer
+		$headers[] = 'Return-Path: ' . $this->returnPath;
+		$headers[] = 'Date: ' . gmdate('D, d M Y H:i:s') . ' -0000';
+		$headers[] = 'X-Mailer: ELK';
+
+		// For maillist, digests or newsletters we include a few more headers for compliance
+		$this->setDigestHeaders($priority);
+
+		// Pass this to the integration before we start modifying the output -- it'll make it easier later.
+		if (in_array(false, call_integration_hook('integrate_outgoing_email', array(&$subject, &$message, &$headers)), true))
+		{
+			return false;
+		}
+
+		// The mime boundary separates the different alternative versions, like plain text, base64, html
+		// For strict compliance we keep this line to 78 charters, (one could flow the headers too)
+		$mime_boundary = 'ELK-' . substr(md5(uniqid(mt_rand(), true) . microtime()), 0, 28);
+
+		// Using mime, as it allows to send a plain unencoded alternative.
+		$this->headers[] = 'Mime-Version: 1.0';
+		$this->headers[] = 'Content-Type: multipart/alternative; boundary="' . $mime_boundary . '"';
+		$this->headers[] = 'Content-Transfer-Encoding: 7bit';
+
+		// Generate our completed `standard` header string
+		$headers = implode($this->lineBreak, $this->headers) . $this->lineBreak;
+
+		// Now build our message with various encodings
+		$message = $this->getMessage($send_html, $mime_boundary, $message);
+
+		// Are we using the mail queue, if so this is where we butt in...
+		if (!empty($modSettings['mail_queue']) && $priority !== 0)
+		{
+			return AddMailQueue(false, $to_array, $subject, $message, $headers, $send_html, $priority, $is_private, $this->messageType . $message_id);
+		}
+
+		// If it's a priority mail, send it now - note though that this should NOT be used for sending many at once.
+		if (!empty($modSettings['mail_queue']) && !empty($modSettings['mail_period_limit']))
+		{
+			list ($last_mail_time, $mails_this_minute) = @explode('|', $modSettings['mail_recent']);
+			if (empty($mails_this_minute) || time() > $last_mail_time + 60)
+			{
+				$new_queue_stat = time() . '|' . 1;
+			}
+			else
+			{
+				$new_queue_stat = $last_mail_time . '|' . ((int) $mails_this_minute + 1);
+			}
+
+			updateSettings(array('mail_recent' => $new_queue_stat));
+		}
+
+		// SMTP or sendmail?
+		$mail = new Mail();
+		$mail_result = $mail->sendMail($to_array, $subject, $headers, $message, $message_id, $priority, $from_wrapper);
+
+		// Clear out the stat cache.
+		trackStats();
+
+		// Everything go smoothly?
+		return $mail_result;
+	}
+
+	/**
+	 * Sets the message line break to what is reuqied for the transport in use
+	 *
+	 * @param string $message
+	 * @return string
+	 */
+	public function setMessageLineBreak($message)
+	{
+		// Make the message use the proper line breaks.
+		return str_replace(array("\r", "\n"), array('', $this->lineBreak), $message);
+	}
+
+	/**
+	 * Cleans the header when using PBE/Maillist functions to prevent message from field
+	 * failing DMARC checking.
+	 *
+	 * @param string $from
+	 * @param string $from_wrapper
+	 * @return string
+	 */
+	public function setDMARCFrom($from, $from_wrapper)
+	{
+		global $modSettings;
+
+		$dmarc_from = $from;
+
+		// Requirements (draft) for Mail List Message (MLM) to Support Basic DMARC Compliance
+		// http://www.dmarc.org/supplemental/mailman-project-mlm-dmarc-reqs.html
+		if ($this->mailList && $from !== null && $from_wrapper !== null)
+		{
+			// Be sure there is never an email in the from name when using maillist styles
+			if (filter_var($dmarc_from, FILTER_VALIDATE_EMAIL))
+			{
+				$dmarc_from = str_replace(strstr($dmarc_from, '@'), '', $dmarc_from);
+			}
+
+			// Add in the 'via' if desired, helps prevent email clients from learning/replacing legit names/emails
+			if (!empty($modSettings['maillist_sitename']) && empty($modSettings['dmarc_spec_standard']))
+			{
+				// @memo (2014) "via" is still a draft, and it's not yet clear if it will be localized or not.
+				// To play safe, we are keeping it hard-coded, but the string is available for translation.
+				return $dmarc_from . ' ' . /* $txt['via'] */ 'via' . ' ' . $modSettings['maillist_sitename'];
+			}
+
+			return $dmarc_from;
+		}
+
+		return $dmarc_from;
+	}
+
+	/**
+	 * Set a from name for an email.  Adjusts this to use PBE settings if enabled.
+	 *
+	 * @param string $from
+	 * @return string
+	 */
+	public function setFromName($from)
+	{
+		global $modSettings, $mbname;
+
+		$from_name = !empty($from) ? $from : (!empty($modSettings['maillist_sitename']) ? $modSettings['maillist_sitename'] : $mbname);
+		$from_name = addcslashes($from_name, '<>()\'\\"');
+
+		list($from_name, $from_encoding) = $this->mimeSpecialChars($from_name);
+		if ($from_encoding !== 'base64')
+		{
+			$from_name = '"' . $from_name . '"';
+		}
+
+		return $from_name;
+	}
+
+	/**
+	 * Prepare text strings for sending as email body or header.
+	 *
+	 * What it does:
+	 *
+	 * - In case there are higher ASCII characters in the given string, this
+	 * function will attempt the transport method 'quoted-printable'.
+	 * - Otherwise the transport method '7bit' is used.
+	 *
+	 * @param string $string
+	 * @return string[] an array containing the converted string and the transport method.
+	 * @package Mail
+	 */
+	public function mimeSpecialChars($string)
+	{
+		// Ensure any HTML entities are in a valid range
+		$string = $this->getValidUTF8String($string);
+
+		// We don't need to mess with the line if no special characters were in it..
+		if (preg_match('~([^\x09\x0A\x0D\x20-\x7F])~', $string) === 1)
+		{
+			// Base64 encode.
+			$string = base64_encode($string);
+			$string = '=?UTF-8?B?' . $string . '?=';
+
+			return array($string, 'base64');
+		}
+
+		return array($string, '7bit');
+	}
+
+	/**
+	 * Replaces any valid &#123; entities with their UTF-8 chr() equivalent
+	 *
+	 * @param $string
+	 * @return string
+	 */
+	public function getValidUTF8String($string)
+	{
+		$string = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $string);
+
+		// Replace any HTML entities, in a valid utf-8 range, with their character
+		if (preg_match('~&#(\d{3,7});~', $string) !== 0)
+		{
+			return preg_replace_callback('~&#(\d{3,7});~', 'fixchar__callback', $string);
+		}
+
+		return $string;
+	}
+
+	/**
+	 * Sets both From: and Reply-To: headers
+	 *
+	 * - If passed $reference then a References: header will also be set
+	 *
+	 * @param string $from an email address
+	 * @param string $from_name a more common name for the address
+	 * @param string $from_wrapper email address of the $from_name, irrespective of the envelope name
+	 * @param string $reference
+	 * @return void
+	 */
+	public function setFromHeaders($from, $from_name, $from_wrapper, $reference = null)
+	{
+		global $webmaster_email, $context, $modSettings;
+
+		if ($from_wrapper !== null)
+		{
+			$this->headers[] = 'From: ' . $from_name . ' <' . $from_wrapper . '>';
+
+			// If they reply where is it going to be sent?
+			$this->headers[] = 'Reply-To: "' . (!empty($modSettings['maillist_sitename']) ? $modSettings['maillist_sitename'] : $context['forum_name']) . '" <' . (!empty($modSettings['maillist_sitename_address']) ? $modSettings['maillist_sitename_address'] : (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'])) . '>';
+			if ($reference !== null)
+			{
+				$this->headers[] = 'References: <' . $reference .
+					strstr(empty($modSettings['maillist_mail_from'])
+						? $webmaster_email
+						: $modSettings['maillist_mail_from'], '@')
+					. '>';
+			}
+		}
+		else
+		{
+			// Standard ElkArte headers
+			$this->headers[] = 'From: ' . $from_name . ' <' . (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from']) . '>';
+			$this->headers[] = ($from !== null && strpos($from, '@') !== false) ? 'Reply-To: <' . $from . '>' : '';
+		}
+	}
+
+	/**
+	 * Sets a few specialized digest headers to
+	 *
+	 * - Prevent auto replying to notifications
+	 * - Identify as a list server to help with anti-spam measures
+	 *
+	 * @param int $priority
+	 */
+	public function setDigestHeaders($priority)
+	{
+		global $modSettings, $boardurl, $webmaster_email, $mbname;
+
+		// For maillist, digests or newsletters we include a few more headers for compliance
+		if ($this->mailList || $priority > 3)
+		{
+			// Try to avoid auto replies
+			$this->headers[] = 'X-Auto-Response-Suppress: All';
+			$this->headers[] = 'Auto-Submitted: auto-replied';
+
+			// Indicate it is a list server to avoid spam tagging and to help client filters
+			// http://www.ietf.org/rfc/rfc2369.txt
+			// List-Id: Notifications <listname.forumsite.tld>
+			$listId = (!empty($modSettings['maillist_sitename_address'])
+				? $modSettings['maillist_sitename_address']
+				: (empty($modSettings['maillist_mail_from'])
+					? $webmaster_email
+					: $modSettings['maillist_mail_from']));
+			$listId = str_replace('@', '.', $listId);
+			$this->headers[] = 'List-Id: Notifications <' . $listId . '>';
+
+			// List-Unsubscribe: <https://www.forumsite.tld/index.php?action=profile;area=notification>
+			$this->headers[] = 'List-Unsubscribe: <' . $boardurl . '/index.php?action=profile;area=notification>';
+
+			// List-Owner: <mailto:help@forumsite.tld> (Site Name)
+			$this->headers[] = 'List-Owner: <mailto:' . (!empty($modSettings['maillist_sitename_help'])
+					? $modSettings['maillist_sitename_help']
+					: (empty($modSettings['maillist_mail_from'])
+						? $webmaster_email
+						: $modSettings['maillist_mail_from'])) . '> (' . (!empty($modSettings['maillist_sitename'])
+					? $modSettings['maillist_sitename']
+					: $mbname) . ')';
+		}
+	}
+
+	/**
+	 * Creates 3 complete message sections
+	 *
+	 * - Plain Ascii text.  Characters >127 are converted to entities &#123; All control characters removed. Any
+	 * html tags are stripped.
+	 * - Base64 encoded.  Control characters (<31) are dropped.  Entities are converted to utf-8 characters.
+	 * The result is base64-encoded and chunk split for email compliance.
+	 * - Quoted-Printable encoded.  Control characters (<31) are dropped.  Entities are converted
+	 * to utf-8 characters.  The result is then encoded with quoted printable which does the needed line
+	 * flowing.  This will be marked as text/plain or text/html based on $send_html flag
+	 *
+	 * @param $send_html
+	 * @param $mime_boundary
+	 * @param $orig_message
+	 * @return string
+	 */
+	public function getMessage($send_html, $mime_boundary, $orig_message)
+	{
+		if ($send_html)
+		{
+			$ascii_message = $this->get7bitVersion($this->getPlainFromHTML($orig_message));
+		}
+		else
+		{
+			$ascii_message = $this->get7bitVersion($orig_message);
+		}
+
+		// This is the plain text version.  Even if no one sees it, we need it for spam checkers.
+		$message = $ascii_message . $this->lineBreak . '--' . $mime_boundary . $this->lineBreak;
+
+		// This is base64 message, more accurate than plain as it true UTF-8
+		$mine_message = $this->getBase64Version($orig_message);
+		$message .= 'Content-Type: text/plain; charset=UTF-8' . $this->lineBreak;
+		$message .= 'Content-Transfer-Encoding: base64' . $this->lineBreak . $this->lineBreak;
+		$message .= $mine_message . $this->lineBreak . '--' . $mime_boundary . $this->lineBreak;
+
+		// This is the actual HTML message, prim and proper.  If we wanted images, they could be
+		// inlined here (with multipart/related, etc.)
+		$html_message = $this->getQuotedPrintableVersion($orig_message);
+		$message .= 'Content-Type: text/' . ($send_html ? 'html' : 'plain') . '; charset=UTF-8' . $this->lineBreak;
+		$message .= 'Content-Transfer-Encoding: Quoted-Printable' . $this->lineBreak . $this->lineBreak;
+		$message .= $html_message . $this->lineBreak . '--' . $mime_boundary . '--';
+
+		return $message;
+	}
+
+	/**
+	 * All characters will be represented with 7 bits (ASCII characters 0-127) and thus don’t need to
+	 * be encoded. This is fine for the simplest of emails.
+	 *
+	 * @param string $string
+	 * @return string
+	 */
+	public function get7bitVersion($string)
+	{
+		// Drop any control characters other than tab, lf and cr
+		$string = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $string);
+
+		// Convert all 'special' characters (anything above 127) into HTML entities to maintain 7bit compliance
+		return preg_replace_callback('~([\x80-\x{10FFFF}])~u', 'entityConvert', $string);
+	}
+
+	/**
+	 * When supplied an HTML message, this 'converts' it to plain text for the ascii section of the
+	 * mime email
+	 *
+	 * @param string $string
+	 * @return string
+	 */
+	public function getPlainFromHTML($string)
+	{
+		// Remove any basic control characters, allowing for tab, LF and CR
+		$string = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $string);
+
+		// No html in plain text, but insert some block level line breaks
+		$trans = [
+			'</title>' => $this->lineBreak,
+			'</div>' => $this->lineBreak,
+			'</p>' => $this->lineBreak,
+			'</br>' => $this->lineBreak,
+			'</br />' => $this->lineBreak,
+			'</blockquote>' => $this->lineBreak];
+
+		return un_htmlspecialchars(strip_tags(strtr($string, $trans)));
+	}
+
+	/**
+	 * Base64 is a safe encoding that takes an entire string and transforms to a six-bit ASCII alphabet
+	 * (consisting of uppercase letters, lowercase letters, numerals, and the “+” and “/” characters).
+	 * This allows all contents to be safely sent and consumed by modern email software.
+	 *
+	 * @param string $string
+	 * @return string
+	 */
+	public function getBase64Version($string)
+	{
+		// Convert valid &#12345; HTML entities into UTF8 characters
+		$string = $this->getValidUTF8String($string);
+
+		// Base64 encode.
+		$string = base64_encode($string);
+
+		return chunk_split($string, 76, $this->lineBreak);
+	}
+
+	/**
+	 * Quoted-Printable is an alternative encoding to Base64 which only encodes high-byte characters,
+	 * which can be detected by an equals sign followed by the hexadecimal representation of the
+	 * byte (e.g., “=D0”). This allows most of the text to remain human-readable, with clear
+	 * exceptions wherever equal signs are encountered.
+	 *
+	 * @param string $string
+	 * @return string
+	 */
+	public function getQuotedPrintableVersion($string)
+	{
+		// Get a pure UTF8 character string
+		$string = $this->getValidUTF8String($string);
+
+		// Base64 encode.
+		return quoted_printable_encode($string);
+	}
+
+	/**
+	 * Callback for the preg_replace in mimespecialchars
+	 *
+	 * @param array $match
+	 *
+	 * @return string
+	 * @package Mail
+	 *
+	 */
+	public function mimespecialchars_callback($match)
+	{
+		return chr($match[1]);
+	}
+
+	/**
+	 * Makes a basic HTML email from plain text
+	 *
+	 * @param $string
+	 * @return array|string|string[]|null
+	 */
+	public function getBasicHTMLVersion($string)
+	{
+		global $scripturl;
+
+		$string = strtr($string, array($this->lineBreak => '<br />' . $this->lineBreak));
+
+		return preg_replace('~\b(' . preg_quote($scripturl, '~') . '(?:[?/][\w-%.,?@!:&;=#]+)?)~', '<a href="$1" target="_blank" rel="noopener">$1</a>', $string);
+	}
+}

--- a/sources/ElkArte/Mail/BuildMail.php
+++ b/sources/ElkArte/Mail/BuildMail.php
@@ -77,11 +77,13 @@ class BuildMail extends BaseMail
 		// Construct from / replyTo mail headers, based on if we show a users name
 		$this->setFromHeaders($from, $from_name, $from_wrapper, $reference);
 
-		// We'll need this later for the envelope fix, too, so keep it
-		$this->setReturnPath();
-
 		// Return path, date, mailer
-		$this->headers[] = 'Return-Path: ' . $this->returnPath;
+		if ($this->useSendmail)
+		{
+			// The final destination SMTP server should be setting this value, not us.
+			$this->setReturnPath();
+			$this->headers[] = 'Return-Path: <' . $this->returnPath . '>';
+		}
 		$this->headers[] = 'Date: ' . gmdate('D, d M Y H:i:s') . ' -0000';
 		$this->headers[] = 'X-Mailer: ELK';
 
@@ -89,7 +91,7 @@ class BuildMail extends BaseMail
 		$this->setDigestHeaders($priority);
 
 		// Pass this to the integration before we start modifying the output -- it'll make it easier later.
-		if (in_array(false, call_integration_hook('integrate_outgoing_email', array(&$subject, &$message, &$headers)), true))
+		if (in_array(false, call_integration_hook('integrate_outgoing_email', array(&$subject, &$message, &$this->headers)), true))
 		{
 			return false;
 		}

--- a/sources/ElkArte/Mail/BuildMail.php
+++ b/sources/ElkArte/Mail/BuildMail.php
@@ -143,7 +143,7 @@ class BuildMail extends BaseMail
 	}
 
 	/**
-	 * Sets the message line break to what is reuqied for the transport in use
+	 * Sets the message line break to what is required for the transport in use
 	 *
 	 * @param string $message
 	 * @return string
@@ -367,14 +367,8 @@ class BuildMail extends BaseMail
 	 */
 	public function getMessage($send_html, $mime_boundary, $orig_message)
 	{
-		if ($send_html)
-		{
-			$ascii_message = $this->get7bitVersion($this->getPlainFromHTML($orig_message));
-		}
-		else
-		{
-			$ascii_message = $this->get7bitVersion($orig_message);
-		}
+		$ascii_message = $send_html ? $this->getPlainFromHTML($orig_message) : $orig_message;
+		$ascii_message = $this->get7bitVersion($ascii_message);
 
 		// This is the plain text version.  Even if no one sees it, we need it for spam checkers.
 		$message = $ascii_message . $this->lineBreak . '--' . $mime_boundary . $this->lineBreak;

--- a/sources/ElkArte/Mail/BuildMail.php
+++ b/sources/ElkArte/Mail/BuildMail.php
@@ -81,9 +81,9 @@ class BuildMail extends BaseMail
 		$this->setReturnPath();
 
 		// Return path, date, mailer
-		$headers[] = 'Return-Path: ' . $this->returnPath;
-		$headers[] = 'Date: ' . gmdate('D, d M Y H:i:s') . ' -0000';
-		$headers[] = 'X-Mailer: ELK';
+		$this->headers[] = 'Return-Path: ' . $this->returnPath;
+		$this->headers[] = 'Date: ' . gmdate('D, d M Y H:i:s') . ' -0000';
+		$this->headers[] = 'X-Mailer: ELK';
 
 		// For maillist, digests or newsletters we include a few more headers for compliance
 		$this->setDigestHeaders($priority);
@@ -104,7 +104,7 @@ class BuildMail extends BaseMail
 		$this->headers[] = 'Content-Transfer-Encoding: 7bit';
 
 		// Generate our completed `standard` header string
-		$headers = implode($this->lineBreak, $this->headers) . $this->lineBreak;
+		$headers = implode($this->lineBreak, $this->headers);
 
 		// Now build our message with various encodings
 		$message = $this->getMessage($send_html, $mime_boundary, $message);
@@ -133,7 +133,7 @@ class BuildMail extends BaseMail
 
 		// SMTP or sendmail?
 		$mail = new Mail();
-		$mail_result = $mail->sendMail($to_array, $subject, $headers, $message, $message_id, $priority, $from_wrapper);
+		$mail_result = $mail->sendMail($to_array, $subject, $headers, $message, $message_id);
 
 		// Clear out the stat cache.
 		trackStats();
@@ -271,11 +271,11 @@ class BuildMail extends BaseMail
 	 *
 	 * @param string $from an email address
 	 * @param string $from_name a more common name for the address
-	 * @param string $from_wrapper email address of the $from_name, irrespective of the envelope name
-	 * @param string $reference
+	 * @param string|null $from_wrapper email address of the $from_name, irrespective of the envelope name
+	 * @param string|null $reference
 	 * @return void
 	 */
-	public function setFromHeaders($from, $from_name, $from_wrapper, $reference = null)
+	public function setFromHeaders($from, $from_name, $from_wrapper = null, $reference = null)
 	{
 		global $webmaster_email, $context, $modSettings;
 

--- a/sources/ElkArte/Mail/Mail.php
+++ b/sources/ElkArte/Mail/Mail.php
@@ -15,6 +15,9 @@ namespace ElkArte\Mail;
 
 use ElkArte\Errors\Errors;
 
+/**
+ * Deals with the sending of email via mail() or SMTP functions
+ */
 class Mail extends BaseMail
 {
 	/**

--- a/sources/ElkArte/Mail/Mail.php
+++ b/sources/ElkArte/Mail/Mail.php
@@ -1,0 +1,415 @@
+<?php
+
+/**
+ * This class deals with the actual sending of your sites emails
+ *
+ * @package   ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ *
+ * @version 2.0 dev
+ *
+ */
+
+namespace ElkArte\Mail;
+
+use ElkArte\Errors\Errors;
+
+class Mail extends BaseMail
+{
+	/**
+	 * This function dispatches to PHP mail or SMTP mail to send email to the specified recipient(s).
+	 *
+	 * It uses the mail_type settings and webmaster_email variable.
+	 *
+	 * @param string[]|string $to - the email(s) to send to
+	 * @param string $subject - email subject as prepared by buildEmail()
+	 * @param string $message - email body as processed by buildEmail()
+	 * @param string|null $message_id = null - if specified, it will be used as local part of the Message-ID header.
+	 * @return bool whether the email was accepted properly.
+	 * @package Mail
+	 */
+	public function sendMail($to, $subject, $headers, $message, $message_id = null)
+	{
+		$message_id = $this->setMessageType($message_id);
+
+		$to = is_array($to) ? $to : array($to);
+
+		if ($this->useSendmail)
+		{
+			return $this->sendPHP($to, $subject, $message, $headers, $message_id);
+		}
+
+		return $this->SMTP($to, $subject, $message, $headers, $message_id);
+	}
+
+	/**
+	 * Sends an email using PHP mail() function
+	 *
+	 * @param string[] $mail_to_array
+	 * @param string $subject
+	 * @param string $message
+	 * @param string $headers
+	 * @param string $message_id
+	 * @return bool if the mail was accepted by the system
+	 */
+	public function sendPHP($mail_to_array, $subject, $message, $headers, $message_id)
+	{
+		global $webmaster_email, $modSettings, $txt;
+
+		$mail_result = true;
+		$subject = strtr($subject, array("\r" => '', "\n" => ''));
+
+		// Looks like another hidden beauty here
+		if (!empty($modSettings['mail_strip_carriage']))
+		{
+			$message = strtr($message, array("\r" => ''));
+			$headers = strtr($headers, array("\r" => ''));
+		}
+
+		$mid = strstr(empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'], '@');
+		$this->setReturnPath();
+		$sent = [];
+		foreach ($mail_to_array as $key => $sendTo)
+		{
+			// Every message sent gets a unique Message-ID header
+			$unq_head = $this->getUniqueMessageID($message_id);
+			$messageHeader = 'Message-ID: <' . $unq_head . $mid . '>';
+
+			// Using PBE, we also insert keys in the message as a safety net or sorts
+			if ($this->mailList)
+			{
+				$message = mail_insert_key($message, $unq_head, $this->lineBreak);
+			}
+
+			// This is frequently not set, or not set according to the needs of PBE and bounce detection
+			// We have to use ini_set, since "-f <address>" doesn't work on Windows systems, so we need both
+			$old_return = ini_set('sendmail_from', $this->returnPath);
+			$sendTo = strtr($sendTo, ["\r" => '', "\n" => '']);
+			if (!mail($sendTo, $subject, $message, $headers . $messageHeader, '-f ' . $this->returnPath))
+			{
+				Errors::instance()->log_error(sprintf($txt['mail_send_unable'], $sendTo));
+				$mail_result = false;
+			}
+			else
+			{
+				// Keep our post via email log
+				if (!empty($unq_head))
+				{
+					$this->unqPBEHead[] = time();
+					$this->unqPBEHead[] = $sendTo;
+					$sent[] = $this->unqPBEHead;
+				}
+
+				// Track total emails sent
+				if (!empty($modSettings['trackStats']))
+				{
+					trackStats(array('email' => '+'));
+				}
+			}
+
+			// Put it back
+			ini_set('sendmail_from', $old_return);
+
+			// Wait, wait, I'm still sending here!
+			detectServer()->setTimeLimit(300);
+		}
+
+		// Log each email that we sent, such that they can be replied to
+		if (!empty($sent))
+		{
+			require_once(SUBSDIR . '/Maillist.subs.php');
+			log_email($sent);
+		}
+
+		return $mail_result;
+	}
+
+	/**
+	 * Sends mail, like mail() but using Simple Mail Transfer Protocol (SMTP).
+	 *
+	 * - It expects no slashes or entities.
+	 *
+	 * @param string[] $mail_to_array - array of strings (email addresses)
+	 * @param string $subject email subject
+	 * @param string $message email message
+	 * @param string $headers
+	 * @param string|null $message_id
+	 * @return bool whether it sent or not.
+	 * @package Mail
+	 */
+	public function SMTP($mail_to_array, $subject, $message, $headers, $message_id = null)
+	{
+		global $modSettings, $webmaster_email;
+
+		// This should already be set in the ACP
+		if (empty($modSettings['smtp_client']))
+		{
+			$modSettings['smtp_client'] = detectServer()->getFQDN(empty($modSettings['smtp_host']) ? '' : $modSettings['smtp_host']);
+			updateSettings(array('smtp_client' => $modSettings['smtp_client']));
+		}
+
+		// Shortcuts
+		$smtp_client = $modSettings['smtp_client'];
+		$smtp_port = empty($modSettings['smtp_port']) ? 25 : (int) $modSettings['smtp_port'];
+		$smtp_host = trim($modSettings['smtp_host']);
+
+		// Try to connect to the SMTP server...
+		$socket = $this->_getSMTPSocket($smtp_host, $smtp_port);
+		if ($socket === false)
+		{
+			return false;
+		}
+
+		// The server responded, now login our client
+		$login = $this->_loginSMTPClient($socket, $smtp_client);
+		if ($login === false)
+		{
+			return false;
+		}
+
+		// Fix the message for any lines beginning with a period! (the first is ignored, you see.)
+		$message = strtr($message, array("\r\n" . '.' => "\r\n" . '..'));
+
+		$mid = strstr(empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'], '@');
+		$mail_to_array = array_values($mail_to_array);
+		$sent = [];
+
+		// Time to send these, so they can be trapped in a SPAM filter :P
+		foreach ($mail_to_array as $i => $mail_to)
+		{
+			$this_message = $message;
+			$unq_head = $this->getUniqueMessageID($message_id);
+			$messageHeader = 'Message-ID: <' . $unq_head . $mid . '>';
+
+			// Using PBE, we also insert keys in the message to overcome clients that act badly
+			if ($this->mailList)
+			{
+				$this_message = mail_insert_key($this_message, $unq_head, $this->lineBreak);
+			}
+
+			// Reset the connection to send another email.
+			if (($i !== 0) && !$this->_server_parse('RSET', $socket, '250'))
+			{
+				return false;
+			}
+
+			// From, to, and then start the data...
+			if (!$this->_server_parse('MAIL FROM: <' . (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from']) . '>', $socket, '250'))
+			{
+				return false;
+			}
+
+			if (!$this->_server_parse('RCPT TO: <' . $mail_to . '>', $socket, '250'))
+			{
+				return false;
+			}
+
+			if (!$this->_server_parse('DATA', $socket, '354'))
+			{
+				return false;
+			}
+
+			fwrite($socket, 'Subject: ' . $subject . $this->lineBreak);
+			if ($mail_to !== '')
+			{
+				fwrite($socket, 'To: <' . $mail_to . '>' . $this->lineBreak);
+			}
+			fwrite($socket, $headers . $messageHeader . $this->lineBreak . $this->lineBreak);
+			fwrite($socket, $this_message . $this->lineBreak);
+
+			// Send a ., or in other words "end of data".
+			if (!$this->_server_parse('.', $socket, '250'))
+			{
+				return false;
+			}
+
+			// track the number of emails sent
+			if (!empty($modSettings['trackStats']))
+			{
+				trackStats(array('email' => '+'));
+			}
+
+			// Keep our post via email log
+			if (!empty($this->unqPBEHead))
+			{
+				$this->unqPBEHead[] = time();
+				$this->unqPBEHead[] = $mail_to;
+				$sent[] = $this->unqPBEHead;
+			}
+
+			// Almost done, almost done... don't stop me just yet!
+			detectServer()->setTimeLimit(300);
+		}
+
+		// say our goodbyes
+		fwrite($socket, 'QUIT' . $this->lineBreak);
+		fclose($socket);
+
+		// Log each email if using PBE
+		if (!empty($sent))
+		{
+			require_once(SUBSDIR . '/Maillist.subs.php');
+			log_email($sent);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Make a connection to the SMTP server
+	 *
+	 * @param string $smtp_host
+	 * @param int $smtp_port
+	 * @return false|resource
+	 */
+	private function _getSMTPSocket($smtp_host, $smtp_port)
+	{
+		global $txt;
+
+		// Try to connect to the SMTP server... if it doesn't exist, only wait three seconds.
+		$socket = fsockopen($smtp_host, $smtp_port, $errno, $errstr, 3);
+		if (!$socket)
+		{
+			// Maybe we can still save this?  The port might be wrong.
+			if ($smtp_port === 25 && substr($smtp_host, 0, 4) === 'ssl:')
+			{
+				$socket = fsockopen($smtp_host, 465, $errno, $errstr, 3);
+				if ($socket)
+				{
+					updateSettings(array('smtp_port' => 465));
+					Errors::instance()->log_error($txt['smtp_port_ssl']);
+				}
+			}
+
+			// Unable to connect!
+			if (!$socket)
+			{
+				Errors::instance()->log_error($txt['smtp_no_connect'] . ': ' . $errno . ' : ' . $errstr);
+			}
+		}
+
+		// Wait for a response of 220, without "-" continue.
+		if (!$socket || !$this->_server_parse(null, $socket, '220'))
+		{
+			return false;
+		}
+
+		return $socket;
+	}
+
+	/**
+	 * Parse a message to the SMTP server.
+	 *
+	 * - Sends the specified message to the server, and checks for the expected response.
+	 *
+	 * @param string $message - the message to send
+	 * @param resource $socket - socket to send on
+	 * @param string $response - the expected response code
+	 * @return string|bool it responded as such.
+	 * @package Mail
+	 */
+	private function _server_parse($message, $socket, $response)
+	{
+		global $txt;
+
+		if ($message !== null)
+		{
+			fwrite($socket, $message . "\r\n");
+		}
+
+		// No response yet.
+		$server_response = '';
+
+		while (substr($server_response, 3, 1) !== ' ')
+		{
+			if (!($server_response = fgets($socket, 256)))
+			{
+				// @todo Change this message to reflect that it may mean bad user/password/server issues/etc.
+				Errors::instance()->log_error($txt['smtp_bad_response']);
+
+				return false;
+			}
+		}
+
+		if ($response === null)
+		{
+			return substr($server_response, 0, 3);
+		}
+
+		if (strpos($server_response, $response) !== 0)
+		{
+			Errors::instance()->log_error($txt['smtp_error'] . $server_response);
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Logs a 'user' on to the SMTP server
+	 *
+	 * If it fails and suspects TLS is required, will attempt that as well.
+	 *
+	 * @param resource $socket
+	 * @param string $smtp_client
+	 * @return bool
+	 */
+	private function _loginSMTPClient($socket, $smtp_client)
+	{
+		global $modSettings;
+
+		$smtp_username = trim($modSettings['smtp_username']);
+		$smtp_password = trim($modSettings['smtp_password']);
+		$smtp_starttls = !empty($modSettings['smtp_starttls']);
+
+		if ($smtp_username !== '' && $smtp_password !== '')
+		{
+			// EHLO could be understood to mean encrypted hello...
+			if ($this->_server_parse('EHLO ' . $smtp_client, $socket, null) === '250')
+			{
+				if ($smtp_starttls)
+				{
+					$this->_server_parse('STARTTLS', $socket, null);
+					stream_socket_enable_crypto($socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+					$this->_server_parse('EHLO ' . $smtp_client, $socket, null);
+				}
+
+				if (!$this->_server_parse('AUTH LOGIN', $socket, '334'))
+				{
+					return false;
+				}
+
+				// Send the username and password, encoded.
+				if (!$this->_server_parse(base64_encode($smtp_username), $socket, '334'))
+				{
+					return false;
+				}
+
+				// The password is already encoded ;)
+				if (!$this->_server_parse($smtp_password, $socket, '235'))
+				{
+					return false;
+				}
+
+				return true;
+			}
+
+			if ($this->_server_parse('HELO ' . $smtp_client, $socket, '250'))
+			{
+				return true;
+			}
+
+			return false;
+		}
+
+		// Just say "helo".
+		if ($this->_server_parse('HELO ' . $smtp_client, $socket, '250'))
+		{
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/sources/ElkArte/Mail/QueueMail.php
+++ b/sources/ElkArte/Mail/QueueMail.php
@@ -132,7 +132,7 @@ class QueueMail
 	 * was set
 	 *
 	 * @param $batch_size
-	 * @return int|mixed
+	 * @return int
 	 */
 	public function setBatchSize($batch_size)
 	{
@@ -162,10 +162,10 @@ class QueueMail
 
 			// Size is number per minute / number of times we will be called per minute
 			$batch_size = (int) ceil($modSettings['mail_period_limit'] / ceil(60 / $delay));
-			$batch_size = $batch_size === 1 && $modSettings['mail_period_limit'] > 1 ? 2 : $batch_size;
+			return ($batch_size === 1 && $modSettings['mail_period_limit'] > 1) ? 2 : $batch_size;
 		}
 
-		return $batch_size;
+		return 0;
 	}
 
 	/**

--- a/sources/ElkArte/Mail/QueueMail.php
+++ b/sources/ElkArte/Mail/QueueMail.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * Class used to release email from the queue
  *
  * @package   ElkArte Forum
  * @copyright ElkArte Forum contributors
@@ -12,6 +13,9 @@
 
 namespace ElkArte\Mail;
 
+/**
+ * Sends emails from the mail queue in to the wild
+ */
 class QueueMail
 {
 	/**

--- a/sources/ElkArte/Mail/QueueMail.php
+++ b/sources/ElkArte/Mail/QueueMail.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ *
+ * @package   ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ *
+ * @version 2.0 dev
+ *
+ */
+
+namespace ElkArte\Mail;
+
+class QueueMail
+{
+	/**
+	 * Sends a group of emails from the mail queue.
+	 *
+	 * - Allows a batch of emails to be released every 5 to 10 seconds (based on per period limits)
+	 * - If batch size is not set, will determine a size such that it sends in 1/2 the period (buffer)
+	 * - Handles using a cron job and another script to send the emails ("mail_queue_use_cron" setting)
+	 *
+	 * @param int|bool $batch_size = false the number to send each loop
+	 * @param bool $override_limit = false bypassing our limit flaf
+	 * @param bool $force_send = false
+	 * @return bool
+	 * @package Mail
+	 */
+	public function reduceMailQueue($batch_size = false, $override_limit = false, $force_send = false)
+	{
+		global $modSettings;
+
+		// Do we have another script to send out the queue?
+		if (!empty($modSettings['mail_queue_use_cron']) && empty($force_send))
+		{
+			return false;
+		}
+
+		// If we came with a timestamp, and that doesn't match the next event, then someone else has beaten us.
+		if (isset($_GET['ts']) && $_GET['ts'] != $modSettings['mail_next_send'] && empty($force_send))
+		{
+			return false;
+		}
+
+		// How many emails can we send each time we are called in a period
+		$batch_size = $this->setBatchSize($batch_size);
+
+		// Set the delay / pause until the next sending
+		$delay = $this->setDelay($override_limit);
+		if ($delay === false)
+		{
+			return false;
+		}
+
+		// Make any needed adjustments based on quota remaining in this time period.
+		$batch_size = $this->adjustBatchSize($override_limit, $batch_size, $delay);
+
+		// Now we know how many we're sending, let's send them.
+		list ($ids, $emails) = emailsInfo($batch_size);
+
+		// Remove these from the queue .... Delete, delete, delete!!!
+		if (!empty($ids))
+		{
+			deleteMailQueueItems($ids);
+		}
+
+		// Don't believe we have any left after this batch?
+		if (count($ids) < $batch_size)
+		{
+			resetNextSendTime();
+		}
+
+		// Nothing to send?
+		if (empty($ids))
+		{
+			return false;
+		}
+
+		// Prepare to send each email, and log that for future-proof.
+		require_once(SUBSDIR . '/Maillist.subs.php');
+
+		// We have some to send, lets send them!
+		$failed_emails = array();
+		$mail = new Mail();
+		foreach ($emails as $email)
+		{
+			// Enable PBE processing if this is a maillist mailing
+			if (!empty($modSettings['maillist_enabled'])
+				&& $email['message_id'] !== null
+				&& strpos($email['headers'], 'List-Id:') !== false)
+			{
+				$mail->mailList = true;
+			}
+
+			// Send it with mail() or SMTP
+			$result = $mail->sendMail($email['to'], $email['subject'], $email['headers'], $email['body'], $email['message_id']);
+
+			// Hopefully it sent?
+			if (!$result)
+			{
+				$failed_emails[] = array(time(), $email['to'], $email['body'], $email['subject'], $email['headers'], $email['send_html'], $email['priority'], $email['private'], $email['message_id']);
+			}
+		}
+
+		// Clear out the stat cache.
+		trackStats();
+
+		// Any emails that didn't send get added back to the queue
+		if (!empty($failed_emails))
+		{
+			updateFailedQueue($failed_emails);
+
+			return false;
+		}
+
+		// We were able to send the email, clear our failed attempts.
+		if (!empty($modSettings['mail_failed_attempts']))
+		{
+			updateSuccessQueue();
+		}
+
+		// Had something to send...
+		return true;
+	}
+
+	/**
+	 * Sets the number of emails that we can release in the next pass
+	 *
+	 * - Uses value if set in the ACP
+	 * - Determines best value based on number per min allowed and no batch size
+	 * was set
+	 *
+	 * @param $batch_size
+	 * @return int|mixed
+	 */
+	public function setBatchSize($batch_size)
+	{
+		global $modSettings;
+
+		// How many emails can we send each time we are called in a period
+		if (!$batch_size)
+		{
+			// Batch size has been set in the ACP, use it
+			if (!empty($modSettings['mail_batch_size']))
+			{
+				return (int) $modSettings['mail_batch_size'];
+			}
+
+			// No per period setting or batch size, set to send 5 every 5 seconds, or 60 per minute
+			if (empty($modSettings['mail_period_limit']))
+			{
+				return 5;
+			}
+
+			// A per period limit but no defined batch size?  Determine a batch size
+			// based on the number of times we will potentially be called each minute
+			// as set in updateNextSendTime()
+			$delay = !empty($modSettings['mail_queue_delay'])
+				? $modSettings['mail_queue_delay']
+				: ($modSettings['mail_period_limit'] <= 5 ? 10 : 5);
+
+			// Size is number per minute / number of times we will be called per minute
+			$batch_size = (int) ceil($modSettings['mail_period_limit'] / ceil(60 / $delay));
+			$batch_size = $batch_size === 1 && $modSettings['mail_period_limit'] > 1 ? 2 : $batch_size;
+		}
+
+		return $batch_size;
+	}
+
+	/**
+	 * Set the delay wait time until the next batch of emails can be sent
+	 *
+	 * @param $override_limit
+	 * @return bool|int
+	 */
+	public function setDelay($override_limit)
+	{
+		global $modSettings;
+
+		// Set the delay for the next sending
+		$delay = 0;
+		if (!$override_limit)
+		{
+			// Update next send time for our mail queue. If there was nothing to update, bail out :P
+			$delay = updateNextSendTime();
+			if ($delay === false)
+			{
+				return false;
+			}
+
+			$modSettings['mail_next_send'] = time() + $delay;
+		}
+
+		return $delay;
+	}
+
+	/**
+	 * Tracks what we have sent in this time period, ensuring we do not go over our
+	 * per minute quota.  If time limit is running out will adjust batch limit up
+	 * to fill the allowed quota.  This is necessary as we can not rely on the scheduled
+	 * task trigger period, it is based on traffic, not traffic, no trigger
+	 *
+	 * @param bool $override_limit
+	 * @param int $batch_size
+	 * @param int $delay
+	 * @return int
+	 */
+	public function adjustBatchSize($override_limit, $batch_size, $delay)
+	{
+		global $modSettings;
+
+		if (!$override_limit && !empty($modSettings['mail_period_limit']))
+		{
+			// See if we have quota left to send another batch_size this minute or if we have to wait
+			list ($mail_time, $mail_number) = isset($modSettings['mail_recent']) ? explode('|', $modSettings['mail_recent']) : [0, 0];
+
+			// Nothing worth noting...
+			if (empty($mail_number) || $mail_time < time() - 60)
+			{
+				$mail_time = time();
+				$mail_number = $batch_size;
+			}
+			// Otherwise, we may still have quota to send a few more?
+			elseif ($mail_number < $modSettings['mail_period_limit'])
+			{
+				// If this is likely one of the last cycles for this period, then send any remaining quota
+				if (($mail_time - (time() - 60)) < $delay * 2)
+				{
+					$batch_size = $modSettings['mail_period_limit'] - $mail_number;
+				}
+				// Some batch sizes may need to be adjusted to fit as we approach the end
+				elseif ($mail_number + $batch_size > $modSettings['mail_period_limit'])
+				{
+					$batch_size = $modSettings['mail_period_limit'] - $mail_number;
+				}
+
+				$mail_number += $batch_size;
+			}
+			// No more I'm afraid, return!
+			else
+			{
+				return 0;
+			}
+
+			// Reflect that we're about to send some, do it now to be safe.
+			updateSettings(array('mail_recent' => $mail_time . '|' . $mail_number));
+		}
+
+		return $batch_size;
+	}
+}

--- a/sources/subs/Mail.subs.php
+++ b/sources/subs/Mail.subs.php
@@ -225,6 +225,7 @@ function entityConvert($match)
  */
 function mail_insert_key($message, $unq_head, $line_break)
 {
+	$regex = [];
 	$regex['plain'] = '~^(.*?)(' . $line_break . '--ELK-[a-z0-9]{28})~s';
 	$regex['qp'] = '~(Content-Transfer-Encoding: Quoted-Printable' . $line_break . $line_break . ')(.*?)(' . $line_break . '--ELK-[a-z0-9]{28})~s';
 	$regex['base64'] = '~(Content-Transfer-Encoding: base64' . $line_break . $line_break . ')(.*?)(' . $line_break . '--ELK-[a-z0-9]{28})~s';

--- a/sources/subs/Mail.subs.php
+++ b/sources/subs/Mail.subs.php
@@ -16,9 +16,11 @@
  */
 
 use BBC\ParserWrapper;
-use ElkArte\Languages\Txt;
-use ElkArte\User;
 use ElkArte\Languages\Loader as LangLoader;
+use ElkArte\Languages\Txt;
+use ElkArte\Mail\BuildMail;
+use ElkArte\Mail\QueueMail;
+use ElkArte\User;
 
 /**
  * This function sends an email to the specified recipient(s).
@@ -30,321 +32,19 @@ use ElkArte\Languages\Loader as LangLoader;
  * @param string $message - email body, expected to have slashes, no htmlentities
  * @param string|null $from = null - the address to use for replies
  * @param string|null $message_id = null - if specified, it will be used as local part of the Message-ID header.
- * @param bool $send_html = false, whether or not the message is HTML vs. plain text
- * @param int $priority = 3
- * @param bool|null $hotmail_fix = null
- * @param bool $is_private
- * @param string|null $from_wrapper - used to provide envelope from wrapper based on if we sharing a users display name
+ * @param bool $send_html = false, whether the message is HTML vs. plain text
+ * @param int $priority = 3 Primarily used for queue priority.  0 = send now, >3 = no PBE
+ * @param bool|null $hotmail_fix = null  No longer used, left for old function calls
+ * @param bool $is_private Hides to/from names when viewing the mail queue
+ * @param string|null $from_wrapper - used to provide envelope from wrapper based on if we share users display name
  * @param int|null $reference - The parent topic id for use in a References header
- * @return bool whether or not the email was accepted properly.
+ * @return bool whether the email was accepted properly.
  * @package Mail
  */
 function sendmail($to, $subject, $message, $from = null, $message_id = null, $send_html = false, $priority = 3, $hotmail_fix = null, $is_private = false, $from_wrapper = null, $reference = null)
 {
-	global $webmaster_email, $context, $modSettings, $txt, $scripturl, $boardurl;
-
-	// Use sendmail if it's set or if no SMTP server is set.
-	$use_sendmail = empty($modSettings['mail_type']) || $modSettings['smtp_host'] == '';
-
-	// Using maillist styles and this message qualifies (priority 3 and below only (4 = digest, 5 = newsletter))
-	$maillist = !empty($modSettings['maillist_enabled']) && $from_wrapper !== null && $message_id !== null && $priority < 4 && empty($modSettings['mail_no_message_id']);
-
-	// Line breaks need to be \r\n only in windows or for SMTP.
-	$line_break = detectServer()->is('windows') || !$use_sendmail ? "\r\n" : "\n";
-
-	if ($message_id !== null && isset($message_id[0]) && in_array($message_id[0], array('m', 'p', 't')))
-	{
-		$message_type = $message_id[0];
-		$message_id = substr($message_id, 1);
-	}
-	else
-	{
-		$message_type = 'm';
-	}
-
-	// So far so good.
-	$mail_result = true;
-
-	// If the recipient list isn't an array, make it one.
-	$to_array = is_array($to) ? $to : array($to);
-
-	// Once upon a time, Hotmail could not interpret non-ASCII mails.
-	// In honour of those days, it's still called the 'hotmail fix'.
-	if ($hotmail_fix === null)
-	{
-		$hotmail_to = array();
-		foreach ($to_array as $i => $to_address)
-		{
-			if (preg_match('~@(att|comcast|bellsouth)\.[a-zA-Z\.]{2,6}$~i', $to_address) === 1)
-			{
-				$hotmail_to[] = $to_address;
-				$to_array = array_diff($to_array, array($to_address));
-			}
-		}
-
-		// Call this function recursively for the hotmail addresses.
-		if (!empty($hotmail_to))
-		{
-			$mail_result = sendmail($hotmail_to, $subject, $message, $from, $message_type . $message_id, $send_html, $priority, true, $is_private, $from_wrapper, $reference);
-		}
-
-		// The remaining addresses no longer need the fix.
-		$hotmail_fix = false;
-
-		// No other addresses left? Return instantly.
-		if (empty($to_array))
-		{
-			return $mail_result;
-		}
-	}
-
-	// Get rid of entities.
-	$subject = un_htmlspecialchars($subject);
-
-	// Make the message use the proper line breaks.
-	$message = str_replace(array("\r", "\n"), array('', $line_break), $message);
-
-	// Make sure hotmail mails are sent as HTML so that HTML entities work.
-	if ($hotmail_fix && !$send_html)
-	{
-		$send_html = true;
-		$message = strtr($message, array($line_break => '<br />' . $line_break));
-		$message = preg_replace('~(' . preg_quote($scripturl, '~') . '(?:[?/][\w\-_%\.,\?&;=#]+)?)~', '<a href="$1">$1</a>', $message);
-	}
-
-	// Requirements (draft) for MLM to Support Basic DMARC Compliance
-	// http://www.dmarc.org/supplemental/mailman-project-mlm-dmarc-reqs.html
-	if ($maillist && $from !== null && $from_wrapper !== null)
-	{
-		// Be sure there is never an email in the from name if using maillist styles
-		$dmarc_from = $from;
-		if (filter_var($dmarc_from, FILTER_VALIDATE_EMAIL))
-		{
-			$dmarc_from = str_replace(strstr($dmarc_from, '@'), '', $dmarc_from);
-		}
-
-		// Add in the 'via' if desired, helps prevent email clients from learning/replacing legit names/emails
-		if (!empty($modSettings['maillist_sitename']) && empty($modSettings['dmarc_spec_standard']))
-			// @memo (2014) "via" is still a draft, and it's not yet clear if it will be localized or not.
-			// To play safe, we are keeping it hard-coded, but the string is available for translation.
-		{
-			$from = $dmarc_from . ' ' . /* $txt['via'] */
-				'via' . ' ' . $modSettings['maillist_sitename'];
-		}
-		else
-		{
-			$from = $dmarc_from;
-		}
-	}
-
-	// Take care of from / subject encodings
-	list (, $from_name, $from_encoding) = mimespecialchars(addcslashes($from !== null ? $from : (!empty($modSettings['maillist_sitename']) ? $modSettings['maillist_sitename'] : $context['forum_name']), '<>()\'\\"'), true, $hotmail_fix, $line_break);
-	list (, $subject) = mimespecialchars($subject, true, $hotmail_fix, $line_break);
-	if ($from_encoding !== 'base64')
-	{
-		$from_name = '"' . $from_name . '"';
-	}
-
-	// Construct the from / replyTo mail headers, based on if we showing a users name
-	if ($from_wrapper !== null)
-	{
-		$headers = 'From: ' . $from_name . ' <' . $from_wrapper . '>' . $line_break;
-
-		// If they reply where is it going to be sent?
-		$headers .= 'Reply-To: "' . (!empty($modSettings['maillist_sitename']) ? $modSettings['maillist_sitename'] : $context['forum_name']) . '" <' . (!empty($modSettings['maillist_sitename_address']) ? $modSettings['maillist_sitename_address'] : (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'])) . '>' . $line_break;
-		if ($reference !== null)
-		{
-			$headers .= 'References: <' . $reference . strstr(empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'], '@') . '>' . $line_break;
-		}
-	}
-	else
-	{
-		// Standard ElkArte headers
-		$headers = 'From: ' . $from_name . ' <' . (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from']) . '>' . $line_break;
-		$headers .= ($from !== null && strpos($from, '@') !== false) ? 'Reply-To: <' . $from . '>' . $line_break : '';
-	}
-
-	// We'll need this later for the envelope fix, too, so keep it
-	$return_path = (!empty($modSettings['maillist_sitename_address']) ? $modSettings['maillist_sitename_address'] : (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from']));
-
-	// Return path, date, mailer
-	$headers .= 'Return-Path: ' . $return_path . $line_break;
-	$headers .= 'Date: ' . gmdate('D, d M Y H:i:s') . ' -0000' . $line_break;
-	$headers .= 'X-Mailer: ELK' . $line_break;
-
-	// For maillist, digests or newsletters we include a few more headers for compliance
-	if ($maillist || $priority > 3)
-	{
-		// Lets try to avoid auto replies
-		$headers .= 'X-Auto-Response-Suppress: All' . $line_break;
-		$headers .= 'Auto-Submitted: auto-generated' . $line_break;
-
-		// Indicate its a list server to avoid spam tagging and to help client filters
-		// http://www.ietf.org/rfc/rfc2369.txt
-		$headers .= 'List-Id: <' . (!empty($modSettings['maillist_sitename_address']) ? $modSettings['maillist_sitename_address'] : (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'])) . '>' . $line_break;
-		$headers .= 'List-Unsubscribe: <' . $boardurl . '/index.php?action=profile;area=notification>' . $line_break;
-		$headers .= 'List-Owner: <mailto:' . (!empty($modSettings['maillist_sitename_help']) ? $modSettings['maillist_sitename_help'] : (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'])) . '> (' . (!empty($modSettings['maillist_sitename']) ? $modSettings['maillist_sitename'] : $context['forum_name']) . ')' . $line_break;
-	}
-
-	// Pass this to the integration before we start modifying the output -- it'll make it easier later.
-	if (in_array(false, call_integration_hook('integrate_outgoing_email', array(&$subject, &$message, &$headers)), true))
-	{
-		return false;
-	}
-
-	// Save the original message...
-	$orig_message = $message;
-
-	// The mime boundary separates the different alternative versions.
-	$mime_boundary = 'ELK-' . md5($message . time());
-
-	// Using mime, as it allows to send a plain unencoded alternative.
-	$headers .= 'Mime-Version: 1.0' . $line_break;
-	$headers .= 'Content-Type: multipart/alternative; boundary="' . $mime_boundary . '"' . $line_break;
-	$headers .= 'Content-Transfer-Encoding: 7bit' . $line_break;
-
-	// Sending HTML?  Let's plop in some basic stuff, then.
-	if ($send_html)
-	{
-		$no_html_message = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $orig_message);
-		$no_html_message = un_htmlspecialchars(strip_tags(strtr($no_html_message, array('</title>' => $line_break))));
-
-		// But, then, dump it and use a plain one for dinosaur clients.
-		list (, $plain_message) = mimespecialchars($no_html_message, false, true, $line_break);
-		$message = $plain_message . $line_break . '--' . $mime_boundary . $line_break;
-
-		// This is the plain text version.  Even if no one sees it, we need it for spam checkers.
-		list ($charset, $plain_charset_message, $encoding) = mimespecialchars($no_html_message, false, false, $line_break);
-		$message .= 'Content-Type: text/plain; charset=' . $charset . $line_break;
-		$message .= 'Content-Transfer-Encoding: ' . $encoding . $line_break . $line_break;
-		$message .= $plain_charset_message . $line_break . '--' . $mime_boundary . $line_break;
-
-		// This is the actual HTML message, prim and proper.  If we wanted images, they could be inlined here (with multipart/related, etc.)
-		list ($charset, $html_message, $encoding) = mimespecialchars($orig_message, false, $hotmail_fix, $line_break);
-		$message .= 'Content-Type: text/html; charset=' . $charset . $line_break;
-		$message .= 'Content-Transfer-Encoding: ' . ($encoding == '' ? '7bit' : $encoding) . $line_break . $line_break;
-		$message .= $html_message . $line_break . '--' . $mime_boundary . '--';
-	}
-	// Text is good too.
-	else
-	{
-		// Send a plain message first, for the older web clients.
-		$plain_message = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $orig_message);
-		list (, $plain_message) = mimespecialchars($plain_message, false, true, $line_break);
-
-		$message = $plain_message . $line_break . '--' . $mime_boundary . $line_break;
-
-		// Now add an encoded message using the forum's character set.
-		list ($charset, $encoded_message, $encoding) = mimespecialchars($orig_message, false, false, $line_break);
-		$message .= 'Content-Type: text/plain; charset=' . $charset . $line_break;
-		$message .= 'Content-Transfer-Encoding: ' . $encoding . $line_break . $line_break;
-		$message .= $encoded_message . $line_break . '--' . $mime_boundary . '--';
-	}
-
-	// Are we using the mail queue, if so this is where we butt in...
-	if (!empty($modSettings['mail_queue']) && $priority != 0)
-	{
-		return AddMailQueue(false, $to_array, $subject, $message, $headers, $send_html, $priority, $is_private, $message_type . $message_id);
-	}
-	// If it's a priority mail, send it now - note though that this should NOT be used for sending many at once.
-	elseif (!empty($modSettings['mail_queue']) && !empty($modSettings['mail_period_limit']))
-	{
-		list ($last_mail_time, $mails_this_minute) = @explode('|', $modSettings['mail_recent']);
-		if (empty($mails_this_minute) || time() > $last_mail_time + 60)
-		{
-			$new_queue_stat = time() . '|' . 1;
-		}
-		else
-		{
-			$new_queue_stat = $last_mail_time . '|' . ((int) $mails_this_minute + 1);
-		}
-
-		updateSettings(array('mail_recent' => $new_queue_stat));
-	}
-
-	// SMTP or sendmail?
-	if ($use_sendmail)
-	{
-		$subject = strtr($subject, array("\r" => '', "\n" => ''));
-		if (!empty($modSettings['mail_strip_carriage']))
-		{
-			$message = strtr($message, array("\r" => ''));
-			$headers = strtr($headers, array("\r" => ''));
-		}
-		$sent = array();
-		$need_break = substr($headers, -1) === "\n" || substr($headers, -1) === "\r" ? false : true;
-
-		foreach ($to_array as $key => $to)
-		{
-			$unq_id = '';
-			$unq_head = '';
-			$unq_head_array = array();
-
-			// If we are using the post by email functions, then we generate "reply to mail" security keys
-			if ($maillist && !empty($message_id) && $priority != 4)
-			{
-				$unq_head_array[0] = md5($boardurl . microtime() . rand());
-				$unq_head_array[1] = $message_type;
-				$unq_head_array[2] = $message_id;
-				$unq_head = $unq_head_array[0] . '-' . $unq_head_array[1] . $unq_head_array[2];
-				$unq_id = ($need_break ? $line_break : '') . 'Message-ID: <' . $unq_head . strstr(empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'], '@') . '>';
-				$message = mail_insert_key($message, $unq_head, $line_break);
-			}
-			elseif (empty($modSettings['mail_no_message_id']))
-			{
-				$unq_id = ($need_break ? $line_break : '') . 'Message-ID: <' . md5($boardurl . microtime()) . '-' . $message_id . strstr(empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'], '@') . '>';
-			}
-
-			// This is frequently not set, or not set according to the needs of PBE and bounce detection
-			// We have to use ini_set, since "-f <address>" doesn't work on windows systems, so we need both
-			$old_return = ini_set('sendmail_from', $return_path);
-			if (!mail(strtr($to, array("\r" => '', "\n" => '')), $subject, $message, $headers . $unq_id, '-f ' . $return_path))
-			{
-				\ElkArte\Errors\Errors::instance()->log_error(sprintf($txt['mail_send_unable'], $to));
-				$mail_result = false;
-			}
-			else
-			{
-				// Keep our post via email log
-				if (!empty($unq_head))
-				{
-					$unq_head_array[] = time();
-					$unq_head_array[] = $to;
-					$sent[] = $unq_head_array;
-				}
-
-				// Track total emails sent
-				if (!empty($modSettings['trackStats']))
-				{
-					trackStats(array('email' => '+'));
-				}
-			}
-
-			// Put it back
-			ini_set('sendmail_from', $old_return);
-
-			// Wait, wait, I'm still sending here!
-			detectServer()->setTimeLimit(300);
-		}
-
-		// Log each email that we sent so they can be replied to
-		if (!empty($sent))
-		{
-			require_once(SUBSDIR . '/Maillist.subs.php');
-			log_email($sent);
-		}
-	}
-	else
-		// SMTP protocol it is
-	{
-		$mail_result = $mail_result && smtp_mail($to_array, $subject, $message, $headers, $priority, $message_type . $message_id);
-	}
-
-	// Clear out the stat cache.
-	trackStats();
-
-	// Everything go smoothly?
-	return $mail_result;
+	// Pass this on to the buildEmail and sendMail functions
+	return (new BuildMail())->buildEmail($to, $subject, $message, $from, $message_id, $send_html, $priority, $is_private, $from_wrapper, $reference);
 }
 
 /**
@@ -460,89 +160,16 @@ function AddMailQueue($flush = false, $to_array = array(), $subject = '', $messa
 }
 
 /**
- * Prepare text strings for sending as email body or header.
- *
- * What it does:
- *
- * - In case there are higher ASCII characters in the given string, this
- * function will attempt the transport method 'quoted-printable'.
- * - Otherwise the transport method '7bit' is used.
- *
- * @param string $string
- * @param bool $with_charset = true
- * @param bool $hotmail_fix = false, with hotmail_fix set all higher ASCII
- * characters are converted to HTML entities to assure proper display of the mail
- * @param string $line_break
- * @param string|null $custom_charset = null, if set, it uses this character set
- * @return string[] an array containing the character set, the converted string and the transport method.
- * @package Mail
- */
-function mimespecialchars($string, $with_charset = true, $hotmail_fix = false, $line_break = "\r\n", $custom_charset = null)
-{
-	$charset = $custom_charset !== null ? $custom_charset : 'UTF-8';
-
-	// This is the fun part....
-	if (preg_match_all('~&#(\d{3,8});~', $string, $matches) !== 0 && !$hotmail_fix)
-	{
-		// Let's, for now, assume there are only &#021;'ish characters.
-		$simple = true;
-
-		foreach ($matches[1] as $entity)
-		{
-			if ($entity > 128)
-			{
-				$simple = false;
-			}
-		}
-		unset($matches);
-
-		if ($simple)
-		{
-			$string = preg_replace_callback('~&#(\d{3,7});~', 'mimespecialchars_callback', $string);
-		}
-		else
-		{
-			$string = preg_replace_callback('~&#(\d{3,7});~', 'fixchar__callback', $string);
-
-			// Unicode, baby.
-			$charset = 'UTF-8';
-		}
-	}
-
-	// Convert all special characters to HTML entities...just for Hotmail :-\
-	if ($hotmail_fix)
-	{
-		// Convert all 'special' characters to HTML entities.
-		return array($charset, preg_replace_callback('~([\x80-\x{10FFFF}])~u', 'entityConvert', $string), '7bit');
-	}
-	// We don't need to mess with the line if no special characters were in it..
-	elseif (!$hotmail_fix && preg_match('~([^\x09\x0A\x0D\x20-\x7F])~', $string) === 1)
-	{
-		// Base64 encode.
-		$string = str_replace("\x00", '', $string);
-		$string = base64_encode($string);
-
-		$string = $with_charset
-			? '=?' . $charset . '?B?' . $string . '?='
-			: chunk_split($string, 76, $line_break);
-
-		return array($charset, $string, 'base64');
-	}
-	else
-	{
-		return array($charset, $string, '7bit');
-	}
-}
-
-/**
- * Converts out of ascii range characters in to HTML entities
+ * Converts out of ascii range utf-8 characters in to HTML entities.  Primarily used
+ * to maintain 7bit compliance for plain emails
  *
  * - Character codes <= 128 are left as is
- * - Callback function of preg_replace_callback, used just for hotmail address
+ * - Character codes U+0080 <> U+00A0 range (control) are dropped
+ * - Callback function of preg_replace_callback
  *
  * @param mixed[] $match
  *
- * @return mixed|string
+ * @return string
  * @package Mail
  *
  */
@@ -552,9 +179,16 @@ function entityConvert($match)
 	$c_strlen = strlen($c);
 	$c_ord = ord($c[0]);
 
+	// <= 127 are standard ASCII characters
 	if ($c_strlen === 1 && $c_ord <= 0x7F)
 	{
 		return $c;
+	}
+
+	// Drop 2 byte control characters in the  U+0080 <> U+00A0 range
+	if ($c_strlen === 2 && $c_ord === 0xC2 && ord($c[1]) <= 0xA0)
+	{
+		return '';
 	}
 
 	if ($c_strlen === 2 && $c_ord >= 0xC0 && $c_ord <= 0xDF)
@@ -576,302 +210,6 @@ function entityConvert($match)
 }
 
 /**
- * Callback for the preg_replace in mimespecialchars
- *
- * @param mixed[] $match
- *
- * @return string
- * @package Mail
- *
- */
-function mimespecialchars_callback($match)
-{
-	return chr($match[1]);
-}
-
-/**
- * Sends mail, like mail() but over SMTP.
- *
- * - It expects no slashes or entities.
- *
- * @param string[] $mail_to_array - array of strings (email addresses)
- * @param string $subject email subject
- * @param string $message email message
- * @param string $headers
- * @param int $priority
- * @param string|null $message_id
- * @return bool whether it sent or not.
- * @internal
- * @package Mail
- */
-function smtp_mail($mail_to_array, $subject, $message, $headers, $priority, $message_id = null)
-{
-	global $modSettings, $webmaster_email, $txt, $scripturl;
-
-	$modSettings['smtp_host'] = trim($modSettings['smtp_host']);
-
-	if ($message_id !== null && isset($message_id[0]) && in_array($message_id[0], array('m', 'p', 't')))
-	{
-		$message_type = $message_id[0];
-		$message_id = substr($message_id, 1);
-	}
-	else
-	{
-		$message_type = 'm';
-	}
-
-	// Try POP3 before SMTP?
-	// @todo There's no interface for this yet.
-	if ($modSettings['mail_type'] == 2 && $modSettings['smtp_username'] != '' && $modSettings['smtp_password'] != '')
-	{
-		$socket = fsockopen($modSettings['smtp_host'], 110, $errno, $errstr, 2);
-		if (!$socket && (substr($modSettings['smtp_host'], 0, 5) === 'smtp.' || substr($modSettings['smtp_host'], 0, 11) === 'ssl://smtp.'))
-		{
-			$socket = fsockopen(strtr($modSettings['smtp_host'], array('smtp.' => 'pop.')), 110, $errno, $errstr, 2);
-		}
-
-		if ($socket)
-		{
-			fgets($socket, 256);
-			fputs($socket, 'USER ' . $modSettings['smtp_username'] . "\r\n");
-			fgets($socket, 256);
-			fputs($socket, 'PASS ' . base64_decode($modSettings['smtp_password']) . "\r\n");
-			fgets($socket, 256);
-			fputs($socket, 'QUIT' . "\r\n");
-
-			fclose($socket);
-		}
-	}
-
-	// Try to connect to the SMTP server... if it doesn't exist, only wait three seconds.
-	if (!$socket = fsockopen($modSettings['smtp_host'], empty($modSettings['smtp_port']) ? 25 : $modSettings['smtp_port'], $errno, $errstr, 3))
-	{
-		// Maybe we can still save this?  The port might be wrong.
-		if (substr($modSettings['smtp_host'], 0, 4) === 'ssl:' && (empty($modSettings['smtp_port']) || $modSettings['smtp_port'] == 25))
-		{
-			if (($socket = fsockopen($modSettings['smtp_host'], 465, $errno, $errstr, 3)))
-			{
-				\ElkArte\Errors\Errors::instance()->log_error($txt['smtp_port_ssl']);
-			}
-		}
-
-		// Unable to connect!  Don't show any error message, but just log one and try to continue anyway.
-		if (!$socket)
-		{
-			\ElkArte\Errors\Errors::instance()->log_error($txt['smtp_no_connect'] . ': ' . $errno . ' : ' . $errstr);
-
-			return false;
-		}
-	}
-
-	// Wait for a response of 220, without "-" continue.
-	if (!server_parse(null, $socket, '220'))
-	{
-		return false;
-	}
-
-	// This should be set in the ACP
-	if (empty($modSettings['smtp_client']))
-	{
-		$modSettings['smtp_client'] = detectServer()->getFQDN(empty($modSettings['smtp_host']) ? '' : $modSettings['smtp_host']);
-		updateSettings(array('smtp_client' => $modSettings['smtp_client']));
-	}
-
-	if ($modSettings['mail_type'] == 1 && $modSettings['smtp_username'] != '' && $modSettings['smtp_password'] != '')
-	{
-		// EHLO could be understood to mean encrypted hello...
-		if (server_parse('EHLO ' . $modSettings['smtp_client'], $socket, null) == '250')
-		{
-			if (!empty($modSettings['smtp_starttls']))
-			{
-				server_parse('STARTTLS', $socket, null);
-				stream_socket_enable_crypto($socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
-				server_parse('EHLO ' . $modSettings['smtp_client'], $socket, null);
-			}
-
-			if (!server_parse('AUTH LOGIN', $socket, '334'))
-			{
-				return false;
-			}
-			// Send the username and password, encoded.
-			if (!server_parse(base64_encode($modSettings['smtp_username']), $socket, '334'))
-			{
-				return false;
-			}
-			// The password is already encoded ;)
-			if (!server_parse($modSettings['smtp_password'], $socket, '235'))
-			{
-				return false;
-			}
-		}
-		elseif (!server_parse('HELO ' . $modSettings['smtp_client'], $socket, '250'))
-		{
-			return false;
-		}
-	}
-	else
-	{
-		// Just say "helo".
-		if (!server_parse('HELO ' . $modSettings['smtp_client'], $socket, '250'))
-		{
-			return false;
-		}
-	}
-
-	// Fix the message for any lines beginning with a period! (the first is ignored, you see.)
-	$message = strtr($message, array("\r\n" . '.' => "\r\n" . '..'));
-
-	$sent = array();
-	$need_break = substr($headers, -1) === "\n" || substr($headers, -1) === "\r" ? false : true;
-	$real_headers = $headers;
-	$line_break = "\r\n";
-
-	// !! Theoretically, we should be able to just loop the RCPT TO.
-	$mail_to_array = array_values($mail_to_array);
-	foreach ($mail_to_array as $i => $mail_to)
-	{
-		// the keys are must unique for every mail you see
-		$unq_id = '';
-		$unq_head = '';
-		$unq_head_array = array();
-
-		// Using the post by email functions, and not a digest (priority 4)
-		// then generate "reply to mail" keys and place them in the message
-		if (!empty($modSettings['maillist_enabled']) && !empty($message_id) && $priority != 4)
-		{
-			$unq_head_array[0] = md5($scripturl . microtime() . rand());
-			$unq_head_array[1] = $message_type;
-			$unq_head_array[2] = $message_id;
-			$unq_head = $unq_head_array[0] . '-' . $unq_head_array[1] . $unq_head_array[2];
-			$unq_id = ($need_break ? $line_break : '') . 'Message-ID: <' . $unq_head . strstr(empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'], '@') . '>';
-			$message = mail_insert_key($message, $unq_head, $line_break);
-		}
-
-		// Fix up the headers for this email!
-		$headers = $real_headers . $unq_id;
-
-		// Reset the connection to send another email.
-		if ($i !== 0)
-		{
-			if (!server_parse('RSET', $socket, '250'))
-			{
-				return false;
-			}
-		}
-
-		// From, to, and then start the data...
-		if (!server_parse('MAIL FROM: <' . (empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from']) . '>', $socket, '250'))
-		{
-			return false;
-		}
-
-		if (!server_parse('RCPT TO: <' . $mail_to . '>', $socket, '250'))
-		{
-			return false;
-		}
-
-		if (!server_parse('DATA', $socket, '354'))
-		{
-			return false;
-		}
-
-		fputs($socket, 'Subject: ' . $subject . $line_break);
-		if (strlen($mail_to) > 0)
-		{
-			fputs($socket, 'To: <' . $mail_to . '>' . $line_break);
-		}
-		fputs($socket, $headers . $line_break . $line_break);
-		fputs($socket, $message . $line_break);
-
-		// Send a ., or in other words "end of data".
-		if (!server_parse('.', $socket, '250'))
-		{
-			return false;
-		}
-
-		// track the number of emails sent
-		if (!empty($modSettings['trackStats']))
-		{
-			trackStats(array('email' => '+'));
-		}
-
-		// Keep our post via email log
-		if (!empty($unq_head))
-		{
-			$unq_head_array[] = time();
-			$unq_head_array[] = $mail_to;
-			$sent[] = $unq_head_array;
-		}
-
-		// Almost done, almost done... don't stop me just yet!
-		detectServer()->setTimeLimit(300);
-	}
-
-	// say our goodbyes
-	fputs($socket, 'QUIT' . $line_break);
-	fclose($socket);
-
-	// Log each email
-	if (!empty($sent))
-	{
-		require_once(SUBSDIR . '/Maillist.subs.php');
-		log_email($sent);
-	}
-
-	return true;
-}
-
-/**
- * Parse a message to the SMTP server.
- *
- * - Sends the specified message to the server, and checks for the expected response.
- *
- * @param string $message - the message to send
- * @param resource $socket - socket to send on
- * @param string $response - the expected response code
- * @return string|bool it responded as such.
- * @internal
- * @package Mail
- */
-function server_parse($message, $socket, $response)
-{
-	global $txt;
-
-	if ($message !== null)
-	{
-		fputs($socket, $message . "\r\n");
-	}
-
-	// No response yet.
-	$server_response = '';
-
-	while (substr($server_response, 3, 1) !== ' ')
-	{
-		if (!($server_response = fgets($socket, 256)))
-		{
-			// @todo Change this message to reflect that it may mean bad user/password/server issues/etc.
-			\ElkArte\Errors\Errors::instance()->log_error($txt['smtp_bad_response']);
-
-			return false;
-		}
-	}
-
-	if ($response === null)
-	{
-		return substr($server_response, 0, 3);
-	}
-
-	if (substr($server_response, 0, 3) !== $response)
-	{
-		\ElkArte\Errors\Errors::instance()->log_error($txt['smtp_error'] . $server_response);
-
-		return false;
-	}
-
-	return true;
-}
-
-/**
  * Adds the unique security key in to an email
  *
  * - adds the key in to (each) message body section
@@ -881,20 +219,25 @@ function server_parse($message, $socket, $response)
  * @param string $unq_head
  * @param string $line_break
  *
- * @return mixed|null|string|string[]
+ * @return string
  * @package Mail
  *
  */
 function mail_insert_key($message, $unq_head, $line_break)
 {
-	// Append the key to the bottom of each message section, plain, html, encoded, etc
-	$message = preg_replace('~^(.*?)(' . $line_break . '--ELK-[a-z0-9]{32})~s', "$1{$line_break}{$line_break}[{$unq_head}]{$line_break}$2", $message);
-	$message = preg_replace('~(Content-Type: text/plain;.*?Content-Transfer-Encoding: 7bit' . $line_break . $line_break . ')(.*?)(' . $line_break . '--ELK-[a-z0-9]{32})~s', "$1$2{$line_break}{$line_break}[{$unq_head}]{$line_break}$3", $message);
-	$message = preg_replace('~(Content-Type: text/html;.*?Content-Transfer-Encoding: 7bit' . $line_break . $line_break . ')(.*?)(' . $line_break . '--ELK-[a-z0-9]{32})~s', "$1$2<br /><br />[{$unq_head}]<br />$3", $message);
+	$regex['plain'] = '~^(.*?)(' . $line_break . '--ELK-[a-z0-9]{28})~s';
+	$regex['qp'] = '~(Content-Transfer-Encoding: Quoted-Printable' . $line_break . $line_break . ')(.*?)(' . $line_break . '--ELK-[a-z0-9]{28})~s';
+	$regex['base64'] = '~(Content-Transfer-Encoding: base64' . $line_break . $line_break . ')(.*?)(' . $line_break . '--ELK-[a-z0-9]{28})~s';
 
-	// base64 the harder one to insert our key
-	// Find the sections, un-do the chunk_split, add in the new key, and re chunky it
-	if (preg_match('~(Content-Transfer-Encoding: base64' . $line_break . $line_break . ')(.*?)(' . $line_break . '--ELK-[a-z0-9]{32})~s', $message, $match))
+	// Append the key to the bottom of the plain section, it is always the first one
+	$message = preg_replace($regex['plain'], "$1{$line_break}{$line_break}[{$unq_head}]{$line_break}$2", $message);
+
+	// Quoted Printable, we can also just append the key section as the key is all standard ASCII
+	$message = preg_replace($regex['qp'], "$1$2{$line_break}{$line_break}[{$unq_head}]{$line_break}$3", $message);
+
+	// base64 the harder one as it must match RFC 2045 semantics
+	// Find the sections, decode, add in the new key, and encode the new message
+	if (preg_match($regex['base64'], $message, $match))
 	{
 		// un-chunk, add in our encoded key header, and re chunk, all so we match RFC 2045 semantics.
 		$encoded_message = base64_decode(str_replace($line_break, '', $match[2]));
@@ -1155,7 +498,8 @@ function list_getMailQueueSize()
 
 	// How many items do we have?
 	$request = $db->query('', '
-		SELECT COUNT(*) AS queue_size
+		SELECT 
+			COUNT(*) AS queue_size
 		FROM {db_prefix}mail_queue',
 		array()
 	);
@@ -1197,7 +541,8 @@ function list_MailQueueStatus()
 
 	// How many items do we have?
 	$request = $db->query('', '
-		SELECT COUNT(*) AS queue_size, MIN(time_sent) AS oldest
+		SELECT 
+		    COUNT(*) AS queue_size, MIN(time_sent) AS oldest
 		FROM {db_prefix}mail_queue',
 		array()
 	);
@@ -1303,7 +648,8 @@ function resetNextSendTime()
 /**
  * Update the next sending time for mail queue.
  *
- * - By default, move it 10 seconds for lower per mail_period_limits and 5 seconds for larger mail_period_limits
+ * - By default, move it 10 seconds for lower per mail_period_limits
+ * and 5 seconds for larger mail_period_limits
  * - Requires an affected row
  *
  * @return int|bool
@@ -1316,7 +662,9 @@ function updateNextSendTime()
 	$db = database();
 
 	// Set a delay based on the per minute limit (mail_period_limit)
-	$delay = !empty($modSettings['mail_queue_delay']) ? $modSettings['mail_queue_delay'] : (!empty($modSettings['mail_period_limit']) && $modSettings['mail_period_limit'] <= 5 ? 10 : 5);
+	$delay = !empty($modSettings['mail_queue_delay'])
+		? $modSettings['mail_queue_delay']
+		: (!empty($modSettings['mail_period_limit']) && $modSettings['mail_period_limit'] <= 5 ? 10 : 5);
 
 	$request = $db->query('', '
 		UPDATE {db_prefix}settings
@@ -1338,7 +686,9 @@ function updateNextSendTime()
 }
 
 /**
- * Retrieve all details from the database on the next emails.
+ * Retrieve all details from the database on the next emails in the queue
+ *
+ * - Will fetch the next batch number of queued emails, sorted by priority
  *
  * @param int $number
  * @return array
@@ -1347,12 +697,13 @@ function updateNextSendTime()
 function emailsInfo($number)
 {
 	$db = database();
-	$ids = array();
-	$emails = array();
+	$ids = [];
+	$emails = [];
 
 	// Get the next $number emails, with all that's to know about them and one more.
 	$db->fetchQuery('
-		SELECT /*!40001 SQL_NO_CACHE */ id_mail, recipient, body, subject, headers, send_html, time_sent, priority, private, message_id
+		SELECT /*!40001 SQL_NO_CACHE */ 
+			id_mail, recipient, body, subject, headers, send_html, time_sent, priority, private, message_id
 		FROM {db_prefix}mail_queue
 		ORDER BY priority ASC, id_mail ASC
 		LIMIT ' . $number,
@@ -1375,7 +726,7 @@ function emailsInfo($number)
 		}
 	);
 
-	return array($ids, $emails);
+	return [$ids, $emails];
 }
 
 /**
@@ -1392,231 +743,7 @@ function emailsInfo($number)
  */
 function reduceMailQueue($batch_size = false, $override_limit = false, $force_send = false)
 {
-	global $modSettings, $webmaster_email, $scripturl;
-
-	// Do we have another script to send out the queue?
-	if (!empty($modSettings['mail_queue_use_cron']) && empty($force_send))
-	{
-		return false;
-	}
-
-	// How many emails can we send each time we are called in a period
-	if (!$batch_size)
-	{
-		// Batch size has been set in the ACP, use it
-		if (!empty($modSettings['mail_batch_size']))
-		{
-			$batch_size = $modSettings['mail_batch_size'];
-		}
-		// No per period setting or batch size, set to send 5 every 5 seconds, or 60 per minute
-		elseif (empty($modSettings['mail_period_limit']))
-		{
-			$batch_size = 5;
-		}
-		// A per period limit but no defined batch size, set a batch size
-		else
-		{
-			// Based on the number of times we will potentially be called each minute
-			$delay = !empty($modSettings['mail_queue_delay']) ? $modSettings['mail_queue_delay'] : (!empty($modSettings['mail_period_limit']) && $modSettings['mail_period_limit'] <= 5 ? 10 : 5);
-			$batch_size = ceil($modSettings['mail_period_limit'] / ceil(60 / $delay));
-			$batch_size = ($batch_size == 1 && $modSettings['mail_period_limit'] > 1) ? 2 : $batch_size;
-		}
-	}
-
-	// If we came with a timestamp, and that doesn't match the next event, then someone else has beaten us.
-	if (isset($_GET['ts']) && $_GET['ts'] != $modSettings['mail_next_send'] && empty($force_send))
-	{
-		return false;
-	}
-
-	// Prepare to send each email, and log that for future proof.
-	require_once(SUBSDIR . '/Maillist.subs.php');
-
-	// Set the delay for the next sending
-	$delay = 0;
-	if (!$override_limit)
-	{
-		// Update next send time for our mail queue, if there was something to update. Otherwise bail out :P
-		$delay = updateNextSendTime();
-		if ($delay === false)
-		{
-			return false;
-		}
-
-		$modSettings['mail_next_send'] = time() + $delay;
-	}
-
-	// If we're not overriding, do we have quota left in this mail period limit?
-	if (!$override_limit && !empty($modSettings['mail_period_limit']))
-	{
-		// See if we have quota left to send another batch_size this minute or if we have to wait
-		list ($mail_time, $mail_number) = isset($modSettings['mail_recent']) ? explode('|', $modSettings['mail_recent']) : array(0, 0);
-
-		// Nothing worth noting...
-		if (empty($mail_number) || $mail_time < time() - 60)
-		{
-			$mail_time = time();
-			$mail_number = $batch_size;
-		}
-		// Otherwise we may still have quota to send a few more?
-		elseif ($mail_number < $modSettings['mail_period_limit'])
-		{
-			// If this is likely one of the last cycles for this period, then send any remaining quota
-			if (($mail_time - (time() - 60)) < $delay * 2)
-			{
-				$batch_size = $modSettings['mail_period_limit'] - $mail_number;
-			}
-			// Some batch sizes may need to be adjusted to fit as we approach the end
-			elseif ($mail_number + $batch_size > $modSettings['mail_period_limit'])
-			{
-				$batch_size = $modSettings['mail_period_limit'] - $mail_number;
-			}
-
-			$mail_number += $batch_size;
-		}
-		// No more I'm afraid, return!
-		else
-		{
-			return false;
-		}
-
-		// Reflect that we're about to send some, do it now to be safe.
-		updateSettings(array('mail_recent' => $mail_time . '|' . $mail_number));
-	}
-
-	// Now we know how many we're sending, let's send them.
-	list ($ids, $emails) = emailsInfo($batch_size);
-
-	// Delete, delete, delete!!!
-	if (!empty($ids))
-	{
-		deleteMailQueueItems($ids);
-	}
-
-	// Don't believe we have any left after this batch?
-	if (count($ids) < $batch_size)
-	{
-		resetNextSendTime();
-	}
-
-	if (empty($ids))
-	{
-		return false;
-	}
-
-	// We have some to send, lets send them!
-	$sent = array();
-	$failed_emails = array();
-
-	// Use sendmail or SMTP
-	$use_sendmail = empty($modSettings['mail_type']) || $modSettings['smtp_host'] == '';
-
-	// Line breaks need to be \r\n only in windows or for SMTP.
-	$line_break = detectServer()->is('windows') || !$use_sendmail ? "\r\n" : "\n";
-
-	foreach ($emails as $key => $email)
-	{
-		// So that we have it, just in case it's really needed - see #2245
-		$email['body_fail'] = $email['body'];
-		if ($email['message_id'] !== null && isset($email['message_id'][0]) && in_array($email['message_id'][0], array('m', 'p', 't')))
-		{
-			$email['message_type'] = $email['message_id'][0];
-			$email['message_id'] = substr($email['message_id'], 1);
-		}
-		else
-		{
-			$email['message_type'] = 'm';
-		}
-
-		// Use the right mail resource
-		if ($use_sendmail)
-		{
-			$email['subject'] = strtr($email['subject'], array("\r" => '', "\n" => ''));
-			$email['body_fail'] = $email['body'];
-
-			if (!empty($modSettings['mail_strip_carriage']))
-			{
-				$email['body'] = strtr($email['body'], array("\r" => ''));
-				$email['headers'] = strtr($email['headers'], array("\r" => ''));
-			}
-
-			// See the assignment 10 lines before this and #2245 - repeated here for the strtr
-			$email['body_fail'] = $email['body'];
-			$need_break = substr($email['headers'], -1) === "\n" || substr($email['headers'], -1) === "\r" ? false : true;
-
-			// Create our unique reply to email header if this message needs one
-			$unq_id = '';
-			$unq_head = '';
-			$unq_head_array = array();
-			if (!empty($modSettings['maillist_enabled']) && $email['message_id'] !== null && strpos($email['headers'], 'List-Id: <') !== false)
-			{
-				$unq_head_array[0] = md5($scripturl . microtime() . rand());
-				$unq_head_array[1] = $email['message_type'];
-				$unq_head_array[2] = $email['message_id'];
-				$unq_head = $unq_head_array[0] . '-' . $unq_head_array[1] . $unq_head_array[2];
-				$unq_id = ($need_break ? $line_break : '') . 'Message-ID: <' . $unq_head . strstr(empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'], '@') . '>';
-				$email['body'] = mail_insert_key($email['body'], $unq_head, $line_break);
-			}
-			elseif ($email['message_id'] !== null && empty($modSettings['mail_no_message_id']))
-			{
-				$unq_id = ($need_break ? $line_break : '') . 'Message-ID: <' . md5($scripturl . microtime()) . '-' . $email['message_id'] . strstr(empty($modSettings['maillist_mail_from']) ? $webmaster_email : $modSettings['maillist_mail_from'], '@') . '>';
-			}
-
-			// No point logging a specific error here, as we have no language. PHP error is helpful anyway...
-			$result = mail(strtr($email['to'], array("\r" => '', "\n" => '')), $email['subject'], $email['body'], $email['headers'] . $unq_id);
-
-			// If it sent, keep a record so we can save it in our allowed to reply log
-			if (!empty($unq_head) && $result)
-			{
-				$sent[] = array_merge($unq_head_array, array(time(), $email['to']));
-			}
-
-			// Track total emails sent
-			if ($result && !empty($modSettings['trackStats']))
-			{
-				trackStats(array('email' => '+'));
-			}
-
-			// Try to stop a timeout, this would be bad...
-			detectServer()->setTimeLimit(300);
-		}
-		else
-		{
-			$result = smtp_mail(array($email['to']), $email['subject'], $email['body'], $email['headers'], $email['priority'], $email['message_type'] . $email['message_id']);
-		}
-
-		// Hopefully it sent?
-		if (!$result)
-		{
-			$failed_emails[] = array(time(), $email['to'], $email['body_fail'], $email['subject'], $email['headers'], $email['send_html'], $email['priority'], $email['private'], $email['message_id']);
-		}
-	}
-
-	// Clear out the stat cache.
-	trackStats();
-
-	// Log each of the sent emails.
-	if (!empty($sent))
-	{
-		log_email($sent);
-	}
-
-	// Any emails that didn't send?
-	if (!empty($failed_emails))
-	{
-		// If it failed, add it back to the queue
-		updateFailedQueue($failed_emails);
-
-		return false;
-	}
-	// We were able to send the email, clear our failed attempts.
-	elseif (!empty($modSettings['mail_failed_attempts']))
-	{
-		updateSuccessQueue();
-	}
-
-	// Had something to send...
-	return true;
+	return (new QueueMail())->reduceMailQueue($batch_size, $override_limit, $force_send);
 }
 
 /**
@@ -1675,23 +802,23 @@ function time_since($time_diff)
 
 		return sprintf($days == 1 ? $txt['mq_day'] : $txt['mq_days'], $time_diff / 86400);
 	}
+
 	// Hours?
-	elseif ($time_diff > 3600)
+	if ($time_diff > 3600)
 	{
 		$hours = round($time_diff / 3600, 1);
 
 		return sprintf($hours == 1 ? $txt['mq_hour'] : $txt['mq_hours'], $hours);
 	}
+
 	// Minutes?
-	elseif ($time_diff > 60)
+	if ($time_diff > 60)
 	{
 		$minutes = (int) ($time_diff / 60);
 
 		return sprintf($minutes === 1 ? $txt['mq_minute'] : $txt['mq_minutes'], $minutes);
 	}
+
 	// Otherwise must be second
-	else
-	{
-		return sprintf($time_diff == 1 ? $txt['mq_second'] : $txt['mq_seconds'], $time_diff);
-	}
+	return sprintf($time_diff == 1 ? $txt['mq_second'] : $txt['mq_seconds'], $time_diff);
 }


### PR DESCRIPTION
This is an update to our `sendmail` functionality.  Sendmail was stuffed in `mail.subs.php` and had quite a few paths through the code along with some recursion etc.  

This PR breaks out (3) new classes to deal with what sendMail previously did.

- `BuildMail` is a class that deals with crafting the proper email headers, handling any special PBE needs.   It also builds the actual email message bodies.   The (3) bodies consist of:
  - Plain text.  This is an ASCII only version as required by mime multipart.  This has control characters removed and any >127 ASCII characters are converted to `#&123;` entities to remain complaint.  If HTML was supplied it is stripped out, although it adds some newlines at the block level elements `(</div> => "\n")`.
  - Encoded text.  This is a `base64` encoded version of the message.  Any entities are changed into proper utf-8 characters then the result is base64 encoded always.  The old function would only base64 if >127 ASCII characters were found but I feel this is a unnecessary distinction and simply adds another execution path.  This is set as text/plain
  - Encoded text.  This is a `quoted-printable` version of the message.  It undergoes the same processing as above but the result is then QP encoded.  If HTML is provided it will set it as text/html otherwise text/plain.  This section would not appear at all in the old function unless you set and supplied HTML -or- if it was doing a hotmail fix.
 - The `hotmail` processing used only for `at&t, bellsouth and comcast` has been removed.
---
- ```Mail``` class deals with the sending of what was created in `BuildMail`.  This will use php `mail()` or `SMTP` based on ACP settings.  Previously the `mail()` path was inside of sendmail and `SMTP` was its own function.  Lots of duplicate code between the two has now been removed and several issues resolved.  This function also takes care of the PBE code injection in to the various message bodies.
---
- ```QueueMail``` breaks out the `reduceQueue` function.   Here again there was a lot of duplicate code that was consolidated as this uses the `Mail` class to send and take care of PBE etc.

There is a basic abstract class to set linebreaks, transport and other things common to the above (3) new classes.  Everything is now in the Mail namespace.  I left wrapper functions in `Mail.subs.php` so old calls still work.  Did I break anything? most likely ;)