### PR TITLE
Theme pick

### DIFF
--- a/sources/ElkArte/Controller/Auth.php
+++ b/sources/ElkArte/Controller/Auth.php
@@ -815,7 +815,7 @@ function doLogin(UserSettingsLoader $user)
 	is_not_banned(true);
 
 	// Don't stick the language or theme after this point.
-	unset($_SESSION['language'], $_SESSION['id_theme']);
+	unset($_SESSION['language'], $_SESSION['theme']);
 
 	// We want to know if this is first login
 	if (User::$info->isFirstLogin())

--- a/sources/ElkArte/Controller/Profile.php
+++ b/sources/ElkArte/Controller/Profile.php
@@ -337,6 +337,18 @@ class Profile extends AbstractController
 							'any' => array('profile_extra_any'),
 						),
 					),
+					'pick' => array(
+						'label' => $txt['theme'],
+						'controller' => '\\ElkArte\\Controller\\ProfileOptions',
+						'function' => 'action_pick',
+						'hidden' => true,
+						'sc' => 'post',
+						'token' => 'profile-th%u',
+						'permission' => array(
+							'own' => array('profile_extra_any', 'profile_extra_own'),
+							'any' => array('profile_extra_any'),
+						),
+					),
 					'notification' => array(
 						'label' => $txt['notifications'],
 						'controller' => '\\ElkArte\\Controller\\ProfileOptions',
@@ -555,7 +567,9 @@ class Profile extends AbstractController
 			);
 		}
 
-		if (!empty($this->_current_subsection) && $this->_profile_include_data['subsections'][$this->_current_subsection]['label'] !== $this->_profile_include_data['label'])
+		if (!empty($this->_current_subsection)
+			&& isset($this->_profile_include_data['subsections'][$this->_current_subsection])
+			&& $this->_profile_include_data['subsections'][$this->_current_subsection]['label'] !== $this->_profile_include_data['label'])
 		{
 			$context['linktree'][] = array(
 				'url' => getUrl('profile', ['action' => 'profile', 'area' => $this->_profile_include_data['current_area'], 'sa' => $this->_current_subsection, 'u' => $this->_memID, 'name' => $this->_profile['real_name']]),

--- a/themes/default/ManageThemes.template.php
+++ b/themes/default/ManageThemes.template.php
@@ -74,7 +74,9 @@ function template_manage_themes()
 
 	echo '
 							</select>
-							<span class="smalltext pick_theme"><a href="', $scripturl, '?action=theme;sa=pick;u=-1;', $context['session_var'], '=', $context['session_id'], '">', $txt['theme_select'], '</a></span>
+							<span class="smalltext pick_theme">
+								<a class="linkbutton" href="', $scripturl, '?action=admin;area=theme;sa=pick;u=-1;', $context['session_var'], '=', $context['session_id'], '">', $txt['theme_select'], '</a>
+							</span>
 						</dd>
 						<dt>
 							<label for="theme_reset">', $txt['theme_reset'], '</label>
@@ -93,7 +95,9 @@ function template_manage_themes()
 
 	echo '
 							</select>
-							<span class="smalltext pick_theme"><a href="', $scripturl, '?action=theme;sa=pick;u=0;', $context['session_var'], '=', $context['session_id'], '">', $txt['theme_select'], '</a></span>
+							<span class="smalltext pick_theme">
+								<a class="linkbutton" href="', $scripturl, '?action=admin;area=theme;sa=pick;u=0;', $context['session_var'], '=', $context['session_id'], '">', $txt['theme_select'], '</a>
+							</span>
 						</dd>
 					</dl>
 					<div class="submitbutton">
@@ -170,7 +174,7 @@ function template_manage_themes()
  */
 function template_list_themes()
 {
-	global $context, $settings, $scripturl, $txt;
+	global $context, $scripturl, $txt;
 
 	echo '
 	<div id="admincenter">
@@ -419,19 +423,6 @@ function template_set_settings()
 
 	echo '
 			<h2 class="category_header hdicon cat_img_config">
-				', $txt['theme_edit'], '
-			</h2>
-			<ul class="basic_options content">
-				<li>
-					<a class="linkbutton" href="', $scripturl, '?action=admin;area=theme;th=', $context['theme_settings']['theme_id'], ';', $context['session_var'], '=', $context['session_id'], ';sa=edit;filename=index.template.php">', $txt['theme_edit_index'], '</a>
-				</li>
-				<li>
-					<a class="linkbutton" href="', $scripturl, '?action=admin;area=theme;th=', $context['theme_settings']['theme_id'], ';', $context['session_var'], '=', $context['session_id'], ';sa=browse;directory=css">', $txt['theme_edit_style'], '</a>
-				</li>
-			</ul>';
-
-	echo '
-			<h2 class="category_header hdicon cat_img_config">
 				', $txt['theme_url_config'], '
 			</h2>
 			<div class="content theme_settings">
@@ -663,19 +654,19 @@ function template_pick()
 
 	echo '
 	<div id="pick_theme">
-		<form action="', $scripturl, '?action=theme;sa=pick;u=', $context['current_member'], ';', $context['session_var'], '=', $context['session_id'], '" method="post" accept-charset="UTF-8">';
+		<form action="', $scripturl, '?action=admin;area=theme;sa=pick;u=', $context['current_member'], ';', $context['session_var'], '=', $context['session_id'], '" method="post" accept-charset="UTF-8">';
 
 	// Just go through each theme and show its information - thumbnail, etc.
 	foreach ($context['available_themes'] as $theme)
 	{
 		echo '
 			<h2 class="category_header">
-				<a href="', $scripturl, '?action=theme;sa=pick;u=', $context['current_member'], ';th=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], !empty($theme['variants']) ? ';vrt=' . $theme['selected_variant'] : '', '">', $theme['name'], '</a>
+				', $theme['name'], '
 			</h2>
 			<div class="flow_hidden content">
 				<div class="floatright">
-					<a href="', $scripturl, '?action=theme;sa=pick;u=', $context['current_member'], ';theme=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], '" id="theme_thumb_preview_', $theme['id'], '" title="', $txt['theme_preview'], '">
-						<img src="', $theme['thumbnail_href'], '" id="theme_thumb_', $theme['id'], '" alt="" />
+					<a href="', $scripturl, '?action=admin;area=theme;sa=pick;u=', $context['current_member'], ';theme=', $theme['id'], ';variant=', $theme['selected_variant'], ';', $context['session_var'], '=', $context['session_id'], '" id="theme_thumb_preview_', $theme['id'], '" title="', $txt['theme_preview'], '">
+						<img class="avatar" src="', $theme['thumbnail_href'], '" id="theme_thumb_', $theme['id'], '" alt="" />
 					</a>
 				</div>
 				<p>', $theme['description'], '</p>';
@@ -705,16 +696,16 @@ function template_pick()
 					<em>', $theme['num_users'], ' ', ($theme['num_users'] == 1 ? $txt['theme_user'] : $txt['theme_users']), '</em>
 				</p>
 				<div class="separator"></div>
-				<a class="linkbutton" href="', $scripturl, '?action=theme;sa=pick;u=', $context['current_member'], ';th=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], !empty($theme['variants']) ? ';vrt=' . $theme['selected_variant'] : '', '" id="theme_use_', $theme['id'], '">', $txt['theme_set'], '</a>
-				<a class="linkbutton" href="', $scripturl, '?action=theme;sa=pick;u=', $context['current_member'], ';theme=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], '" id="theme_preview_', $theme['id'], '">', $txt['theme_preview'], '</a>
+				<a class="linkbutton" href="', $scripturl, '?action=admin;area=theme;sa=pick;u=', $context['current_member'], ';th=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], !empty($theme['variants']) ? ';vrt=' . $theme['selected_variant'] : '', '" id="theme_use_', $theme['id'], '">', $txt['theme_set'], '</a>
+				<a class="linkbutton" href="', $scripturl, '?action=admin;area=theme;sa=pick;u=', $context['current_member'], ';theme=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], ';variant=', $theme['selected_variant'], '" id="theme_preview_', $theme['id'], '">', $txt['theme_preview'], '</a>
 			</div>';
 
 		if (!empty($theme['variants']))
 		{
 			echo '
 			<script>
-				var sBaseUseUrl', $theme['id'], ' = elk_prepareScriptUrl(elk_scripturl) + \'action=theme;sa=pick;u=', $context['current_member'], ';th=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], '\',
-					sBasePreviewUrl', $theme['id'], ' = elk_prepareScriptUrl(elk_scripturl) + \'action=theme;sa=pick;u=', $context['current_member'], ';theme=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], '\',
+				let sBaseUseUrl', $theme['id'], ' = elk_prepareScriptUrl(elk_scripturl) + \'action=admin;area=theme;sa=pick;u=', $context['current_member'], ';th=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], '\',
+					sBasePreviewUrl', $theme['id'], ' = elk_prepareScriptUrl(elk_scripturl) + \'action=admin;area=theme;sa=pick;u=', $context['current_member'], ';theme=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], '\',
 					oThumbnails', $theme['id'], ' = {';
 
 			// All the variant thumbnails.
@@ -767,4 +758,3 @@ function template_installed()
 		</div>
 	</div>';
 }
-

--- a/themes/default/ProfileOptions.template.php
+++ b/themes/default/ProfileOptions.template.php
@@ -1450,7 +1450,7 @@ function template_profile_timeoffset_modify()
 }
 
 /**
- * Interface to allow the member to pick a theme.
+ * Button to allow the member to pick a theme.
  */
 function template_profile_theme_pick()
 {
@@ -1461,7 +1461,7 @@ function template_profile_theme_pick()
 								<label>', $txt['current_theme'], '</label>
 							</dt>
 							<dd>
-								', $context['member']['theme']['name'], ' <a class="linkbutton" href="', getUrl('action', ['action' => 'theme', 'sa' => 'pick', 'u' => $context['id_member'], '{session_data}']), '">', $txt['change'], '</a>
+								', $context['member']['theme']['name'], ' <a class="linkbutton" href="', getUrl('action', ['action' => 'profile', 'area' => 'pick', 'u' => $context['id_member'], '{session_data}']), '">', $txt['change'], '</a>
 							</dd>';
 }
 
@@ -1557,4 +1557,95 @@ function template_authentication_method()
 		var verificationHandle = new elkRegister("creator", ', empty($modSettings['password_strength']) ? 0 : $modSettings['password_strength'], ', regTextStrings);
 
 	</script>';
+}
+
+/**
+ * This template allows for the selection of different themes.
+ */
+function template_pick()
+{
+	global $context, $scripturl, $txt;
+
+	echo '
+	<div id="pick_theme">
+		<form action="', $scripturl, '?action=profile;area=pick;u=', $context['current_member'], ';', $context['session_var'], '=', $context['session_id'], '" method="post" accept-charset="UTF-8">';
+
+	// Just go through each theme and show its information - thumbnail, etc.
+	foreach ($context['available_themes'] as $theme)
+	{
+		echo '
+			<h2 class="category_header">
+				', $theme['name'], '
+			</h2>
+			<div class="flow_hidden content">
+				<div class="floatright">
+					<a href="', $scripturl, '?action=profile;area=pick;u=', $context['current_member'], ';theme=', $theme['id'], ';variant=', $theme['selected_variant'], ';', $context['session_var'], '=', $context['session_id'], '" id="theme_thumb_preview_', $theme['id'], '" title="', $txt['theme_preview'], '">
+						<img class="avatar" src="', $theme['thumbnail_href'], '" id="theme_thumb_', $theme['id'], '" alt="" />
+					</a>
+				</div>
+				<p>', $theme['description'], '</p>';
+
+		if (!empty($theme['variants']))
+		{
+			echo '
+				<label for="variant', $theme['id'], '">
+					<strong>', $theme['pick_label'], '</strong>
+				</label>
+				<select id="variant', $theme['id'], '" name="vrt[', $theme['id'], ']" onchange="changeVariant', $theme['id'], '(this.value);">';
+
+			foreach ($theme['variants'] as $key => $variant)
+			{
+				echo '
+					<option value="', $key, '" ', $theme['selected_variant'] == $key ? 'selected="selected"' : '', '>', $variant['label'], '</option>';
+			}
+
+			echo '
+				</select>
+				<noscript>
+					<input type="submit" name="save[', $theme['id'], ']" value="', $txt['save'], '" />
+				</noscript>';
+		}
+
+		echo '
+				<br />
+				<div class="separator"></div>
+				<a class="linkbutton" href="', $scripturl, '?action=profile;area=pick;u=', $context['current_member'], ';th=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], !empty($theme['variants']) ? ';vrt=' . $theme['selected_variant'] : '', '" id="theme_use_', $theme['id'], '">', $txt['theme_set'], '</a>
+				<a class="linkbutton" href="', $scripturl, '?action=profile;area=pick;u=', $context['current_member'], ';theme=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], ';variant=', $theme['selected_variant'], '" id="theme_preview_', $theme['id'], '">', $txt['theme_preview'], '</a>
+			</div>';
+
+		if (!empty($theme['variants']))
+		{
+			echo '
+			<script>
+				let sBaseUseUrl', $theme['id'], ' = elk_prepareScriptUrl(elk_scripturl) + \'action=profile;area=pick;u=', $context['current_member'], ';th=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], '\',
+					sBasePreviewUrl', $theme['id'], ' = elk_prepareScriptUrl(elk_scripturl) + \'action=profile;area=pick;u=', $context['current_member'], ';theme=', $theme['id'], ';', $context['session_var'], '=', $context['session_id'], '\',
+					oThumbnails', $theme['id'], ' = {';
+
+			// All the variant thumbnails.
+			$count = 1;
+			foreach ($theme['variants'] as $key => $variant)
+			{
+				echo '
+					\'', $key, '\': \'', $variant['thumbnail'], '\'', (count($theme['variants']) === $count ? '' : ',');
+
+				$count++;
+			}
+
+			echo '
+				};
+
+				function changeVariant', $theme['id'], '(sVariant)
+				{
+					document.getElementById(\'theme_thumb_', $theme['id'], '\').src = oThumbnails', $theme['id'], '[sVariant];
+					document.getElementById(\'theme_use_', $theme['id'], '\').href = sBaseUseUrl', $theme['id'] == 0 ? $context['default_theme_id'] : $theme['id'], ' + \';vrt=\' + sVariant;
+					document.getElementById(\'theme_thumb_preview_', $theme['id'], '\').href = sBasePreviewUrl', $theme['id'], ' + \';variant=\' + sVariant;
+					document.getElementById(\'theme_preview_', $theme['id'], '\').href = sBasePreviewUrl', $theme['id'], ' + \';variant=\' + sVariant;
+				}
+			</script>';
+		}
+	}
+
+	echo '
+		</form>
+	</div>';
 }


### PR DESCRIPTION
This PR breaks out the user theme pick from the Admin controller (managethemes).

Previously when the user was choosing their theme of choice, from their profile, the code they were running was actually in the Admin conrtoller `ManageThemes.php` which contained various section they were allowed to run as long as they were not the Admin, yes that is how it was LOL  Anyway it was not ideal construct so now its a separate profile function and separate profile templates.   This does cause some amount of duplication but at least things are properly aligned.  

As always there were a few bugs stomped along the way, theme preview was not working, variant selection lists were wrong and always showed the default theme, etc