### PR TITLE
Updates to ILA

### DIFF
--- a/sources/ElkArte/BBC/BBCParser.php
+++ b/sources/ElkArte/BBC/BBCParser.php
@@ -713,7 +713,7 @@ class BBCParser
 			}
 
 			// Not allowed in this parent, replace the tags or show it like regular text
-			if (isset($possible[Codes::ATTR_DISALLOW_PARENTS], $possible[Codes::ATTR_DISALLOW_PARENTS][$this->inside_tag[Codes::ATTR_TAG]]))
+			if (isset($possible[Codes::ATTR_DISALLOW_PARENTS][$this->inside_tag[Codes::ATTR_TAG]]))
 			{
 				if (!isset($possible[Codes::ATTR_DISALLOW_BEFORE], $possible[Codes::ATTR_DISALLOW_AFTER]))
 				{
@@ -732,6 +732,12 @@ class BBCParser
 
 		// +1 for [, then the length of the tag, then a space
 		$this->pos1 = $this->pos + 1 + $possible[Codes::ATTR_LENGTH] + 1;
+
+		// If we need to reset content attr, this is where we step in
+		if (isset($possible[Codes::ATTR_RESET]))
+		{
+			$possible[Codes::ATTR_CONTENT] = $possible[Codes::ATTR_RESET];
+		}
 
 		// This is long, but it makes things much easier and cleaner.
 		if (!empty($possible[Codes::ATTR_PARAM]))
@@ -1606,6 +1612,9 @@ class BBCParser
 	}
 
 	/**
+	 * Substitutes parameter attribute values in to the tag context
+	 * e.g. tag width={width} => tag width=300px
+	 *
 	 * @param array $possible
 	 * @param array $matches
 	 *
@@ -1767,6 +1776,6 @@ class BBCParser
 	 */
 	protected function filterData(array &$tag, &$data)
 	{
-		$tag[Codes::ATTR_VALIDATE]($data, $this->bbc->getDisabled());
+		$tag[Codes::ATTR_VALIDATE]($data, $this->bbc->getDisabled(), $tag);
 	}
 }

--- a/sources/ElkArte/BBC/Codes.php
+++ b/sources/ElkArte/BBC/Codes.php
@@ -169,6 +169,8 @@ class Codes
 	 */
 	public const ATTR_NO_CACHE = 25;
 
+	public const ATTR_RESET = 26;
+
 	/** [tag]parsed content[/tag] */
 	public const TYPE_PARSED_CONTENT = 0;
 
@@ -232,7 +234,6 @@ class Codes
 	 */
 	protected $bbc = array();
 	protected $itemcodes = array();
-	protected $additional_bbc = array();
 	protected $disabled = array();
 	protected $parsing_codes = array();
 
@@ -242,16 +243,14 @@ class Codes
 	 * @param array $tags
 	 * @param array $disabled
 	 */
-	public function __construct(array $tags = array(), array $disabled = array())
+	public function __construct(array $additional_bbc = array(), array $disabled = array())
 	{
-		$this->additional_bbc = $tags;
-
 		foreach ($disabled as $tag)
 		{
 			$this->disable($tag);
 		}
 
-		foreach ($tags as $tag)
+		foreach ($additional_bbc as $tag)
 		{
 			$this->add($tag);
 		}
@@ -974,7 +973,7 @@ class Codes
 			foreach ($item_codes as $c => $dummy)
 			{
 				// Skip anything "bad"
-				if (!is_string($c) || (is_string($c) && trim($c) === ''))
+				if (!is_string($c) || trim($c) === '')
 				{
 					continue;
 				}
@@ -986,7 +985,7 @@ class Codes
 		$return = array();
 
 		// Find the first letter of the tag faster
-		foreach ($bbc as &$code)
+		foreach ($bbc as $code)
 		{
 			$return[$code[self::ATTR_TAG][0]][] = $code;
 		}

--- a/sources/ElkArte/Modules/Attachments/Display.php
+++ b/sources/ElkArte/Modules/Attachments/Display.php
@@ -71,6 +71,6 @@ class Display extends AbstractModule
 	 */
 	public static function integrate_prepare_display_context(&$output, &$this_message, $counter)
 	{
-		$output['attachment'] = self::$attachments->loadAttachmentContext($this_message['id_msg']);
+		[$output['attachment'], $output['ila']] = self::$attachments->loadAttachmentContext($this_message['id_msg']);
 	}
 }

--- a/sources/subs/Attachments.subs.php
+++ b/sources/subs/Attachments.subs.php
@@ -611,7 +611,6 @@ function isAttachmentImage($id_attach)
 			INNER JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board AND {query_see_board})
 		WHERE id_attach = {int:attach}
 			AND attachment_type = {int:type}
-			AND a.approved = {int:approved}
 		LIMIT 1',
 		array(
 			'attach' => $id_attach,
@@ -623,6 +622,7 @@ function isAttachmentImage($id_attach)
 			$attachmentData = $row;
 			$attachmentData['is_image'] = substr($attachmentData['mime_type'], 0, 5) === 'image';
 			$attachmentData['size'] = byte_format($attachmentData['size']);
+			$attachmentData['is_approved'] = $row['approved'] === '1';
 		}
 	);
 


### PR DESCRIPTION
This started as a simple return both a below post attachment array and the ILA array.  

Next was the ILA code was not handling non approved attachments in a graceful way (simply ignored them, left bad attach code in place), this now will present a pending approval image.  Renamed the `action_no_attach` method to `action_text_to_image`, since its used for both attachment missing and awaiting activation string, and added some features.

Next while testing ILA, there were a few edge problems, like if someone used a width attribute on a file attachment, plain `[attach]tags[/attach]` were not working.  detecting the no approved status was problematic, and a several other tag creation issues.  

To fix the problems and not make the ILA code overly complex, and still not working in all cases, I chose to add a new feature to the `BBC Parser`. to overcome the way the parser builds the tags.  Short explanation:

For a tag with parameters say `[attach width=300]x[/attach]`,  First the parameter attr values are determined, like `width=300` and then it will do a swap/replace to replace any `{width}` tags in the defined `ATTR_CONTENT`.  Next, it will run any `ATTR_VALIDATE` function and take those results and substitute for any `$1` strings in the `ATTR_CONTENT` value.   This allows a context tag like `<img style="{width}" datalightbox="$1">...` to render.  

The _short coming_ is for something like ILA, which has to deal with images and files and thumbnails and links, a single `ATTR_CONTENT` can not be built.  Currently the ILA the tag is a confusing template of `$1's and {parms}` which had sneaky open quotes but when all was combined made a valid html tag.  But this has major short comings when you have to build image and non image tags.  You could make `ATTR_CONTENT`  just be $1 and build the entire tag in the validation function, but the short coming there is you can't get at the `{param}` values the parser created since they don't exist as substituion strings in `ATTR_CONTENT` .

To help with the above I added a new code attribute to the Code class that Parsebbc will use.  The new Code param is `Codes::ATTR_RESET]` which will take a string like `{width}~{height}~{type}`  This allows the true final context tag to be dynamically set. 

What happens internally, Parsebbc will render this "reset" tag as the tags `ATTR_CONTENT` and then pass the results to any `ATTR_VALIDATE` function (defined by the bbc tag) which in turn can use them to build a final `ATTR_CONTENT` which simply points back to the reference &variable we set.  I think you could just use `$1` as well and skip having the reference pointer and just return the completed tag ( I may check that now).  

Now each `[attach]` tag gets a `Codes::ATTR_RESET]` value that corresponds to the parameters it accepts, parsebbc does its thing and parses those values then sets them to the tag being rendered.  That rendered tag is passed to the validation function with itself returns the completed string back to `ATTR_CONTENT`  which then becomes the rendered tags content back in parsebbc.

**TLDR** I added a single line of code to parsebbc and a new optional attr tag to Code:: which allows us to remove a bunch of crud in ILA and make it more robust.  I wanted to detail the why it was done since I will forget by next week!