### PR TITLE
Fix issue that prevented fallback to GD for webp

### DIFF
--- a/sources/admin/ManageAttachments.controller.php
+++ b/sources/admin/ManageAttachments.controller.php
@@ -307,8 +307,11 @@ class ManageAttachments_Controller extends Action_Controller
 		// Perform a test to see if the GD module or ImageMagick are installed.
 		require_once(SUBSDIR . '/Graphics.subs.php');
 		$testImg = checkGD() || checkImagick();
-		$testWebP = hasWebpSupport();
 		$testImgRotate = checkImagick() || (checkGD() && function_exists('exif_read_data'));
+
+		$testWebP = hasWebpSupport();
+		if (!$testWebP && !empty($modSettings['attachment_webp_enable']))
+			updateSettings(array('attachment_webp_enable' => 0));
 
 		// See if we can find if the server is set up to support the attachment limits
 		$post_max_size = ini_get('post_max_size');

--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -3193,6 +3193,7 @@ img.new_posts {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	padding: 0 .5em;
+	margin: 0 auto;
 }
 .attachment_name {
 	 margin: .5em 0 0 0;


### PR DESCRIPTION
Some systems may have imagick installed w/o webp support but also have GD w webp support.  This change allows fallback to use GD for processing webp images, the previoud logic was that the imagick install would always have the same capabilities as GD but this is not always the case.