### PR TITLE
Various 1.1.9 fixes applied

### DIFF
--- a/.github/setup-selenium.sh
+++ b/.github/setup-selenium.sh
@@ -32,7 +32,8 @@ echo "Installing Browser"
 # Available Chrome Versions
 # https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable?id=202706
 #
-CHROME_VERSION='91.0.4472.114-1'
+CHROME_VERSION='110.0.5481.100-1' # '91.0.4472.114-1'
+
 wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb -q
 sudo dpkg -i google-chrome-stable_${CHROME_VERSION}_amd64.deb
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,11 +3,9 @@ name: MaxPain
 on:
   push:
     branches:        # Run tests when commits are pushed to these branches
-      - master
       - development
   pull_request:      # Run tests when pull requests are made on these branches
     branches:
-      - master
       - development
 
 env:
@@ -69,7 +67,7 @@ jobs:
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
-      - name: Setup Server Enviroment
+      - name: Setup Server Environment
         env:
           DB: ${{ matrix.db }}
           PHP_VERSION: ${{ matrix.php }}
@@ -135,7 +133,7 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 18
 
       - name: Install Linters
         run: npm install --save-dev jshint stylelint stylelint-order stylelint-config-recommended
@@ -210,7 +208,7 @@ jobs:
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
-      - name: Setup Server Enviroment
+      - name: Setup Server Environment
         env:
           DB: ${{steps.database-type.outputs.db}}
           PHP_VERSION: ${{ matrix.php }}

--- a/install/TemplateInstall.php
+++ b/install/TemplateInstall.php
@@ -459,7 +459,7 @@ function template_database_settings()
 	<script>
 		function validatePgsql()
 		{
-			var dbtype = document.getElementById(\'db_type_input\');
+			let dbtype = document.getElementById(\'db_type_input\');
 
 			if (dbtype !== null && dbtype.value == \'postgresql\')
 				document.getElementById(\'db_name_info_warning\').style.display = \'none\';

--- a/install/install.php
+++ b/install/install.php
@@ -109,7 +109,7 @@ function setTimeZone() {
 	}
 
 	// Validate this is a valid zone
-	if (!in_array($timezone_id, timezone_identifiers_list()))
+	if (!in_array($timezone_id, timezone_identifiers_list(), true))
 	{
 		// Tray and make one up
 		$server_offset = @mktime(0, 0, 0, 1, 1, 1970) * -1;
@@ -287,16 +287,14 @@ function parseSqlLines($sql_file, $replaces)
 
 	// Each method is a separate installation step
 	$methods = get_class_methods($install_instance);
-
-	// Find all the tables we need to create and inserts that need to be done
-	$tables = array_filter($methods, function ($method) {
+	$tables = array_filter($methods, static function ($method) {
 		return strpos($method, 'table_') === 0;
 	});
-	$inserts = array_filter($methods, function ($method) {
+	$inserts = array_filter($methods, static function ($method) {
 		return strpos($method, 'insert_') === 0;
 	});
-	$others = array_filter($methods, function ($method) {
-		return substr($method, 0, 2) !== '__' && strpos($method, 'insert_') !== 0 && strpos($method, 'table_') !== 0;
+	$others = array_filter($methods, static function ($method) {
+		return strpos($method, '__') !== 0 && strpos($method, 'insert_') !== 0 && strpos($method, 'table_') !== 0;
 	});
 
 	// Create tables if they do not exist
@@ -339,7 +337,7 @@ function parseSqlLines($sql_file, $replaces)
 		$table_name = substr($insert_method, 6);
 
 		// Don't insert data if the table already existed before we started
-		if (in_array($table_name, $exists))
+		if (in_array($table_name, $exists, true))
 		{
 			$db_wrapper->countMode();
 			$incontext['sql_results']['insert_dups'] += $install_instance->{$insert_method}();
@@ -371,7 +369,7 @@ function parseSqlLines($sql_file, $replaces)
 	// Sort out the context for the SQL.
 	foreach ($incontext['sql_results'] as $key => $number)
 	{
-		if ($number == 0)
+		if ($number === 0)
 		{
 			unset($incontext['sql_results'][$key]);
 		}
@@ -428,7 +426,7 @@ function fixModSecurity()
 
 	if (is_writable(TMP_BOARDDIR))
 	{
-		if ($ht_handle = fopen(TMP_BOARDDIR . '/.htaccess', 'w'))
+		if ($ht_handle = fopen(TMP_BOARDDIR . '/.htaccess', 'wb'))
 		{
 			fwrite($ht_handle, $htaccess_addition);
 			fclose($ht_handle);

--- a/install/installcore.php
+++ b/install/installcore.php
@@ -29,9 +29,9 @@ function getUpgradeFiles()
 	return array(
 		array('upgrade_1-0.php', '1.0', '1.0'),
 		array('upgrade_1-0_' . $db_type . '.php', '1.0', '1.0'),
-		array('upgrade_1-1.php', '1.1', '1.1'),
-		array('upgrade_1-1_' . $db_type . '.php', '1.1', '1.1'),
-		array('upgrade_2-0.php', '2.0 dev', CURRENT_VERSION),
-		array('upgrade_2-0_' . $db_type . '.php', '2.0 dev', CURRENT_VERSION),
+		array('upgrade_1-1.php', '1.2', '1.1'),
+		array('upgrade_1-1_' . $db_type . '.php', '1.2', '1.1'),
+		array('upgrade_2-0.php', '2.1', CURRENT_VERSION),
+		array('upgrade_2-0_' . $db_type . '.php', '2.1', CURRENT_VERSION),
 	);
 }

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -23,7 +23,7 @@ $upgradeurl = $_SERVER['PHP_SELF'];
 $disable_security = false;
 
 // How long, in seconds, must admin be inactive to allow someone else to run?
-$upcontext['inactive_timeout'] = 30;
+$upcontext['inactive_timeout'] = 15;
 
 // This bunch of indexes necessary in the template and are set a bit too late
 $upcontext['current_item_num'] = 0;
@@ -51,7 +51,7 @@ $upcontext['database_step'] = 3;
 @ini_set('memory_limit', '256M');
 
 // Clean the upgrade path if this is from the client.
-if (!empty($_SERVER['argv']) && PHP_SAPI === 'cli' && empty($_SERVER['REMOTE_ADDR']))
+if (PHP_SAPI === 'cli' && !empty($_SERVER['argv']) && empty($_SERVER['REMOTE_ADDR']))
 {
 	for ($i = 1; $i < $_SERVER['argc']; $i++)
 	{
@@ -72,7 +72,7 @@ require_once(__DIR__ . '/TemplateUpgrade.php');
 
 // Are we from the client?
 $command_line = false;
-if (php_sapi_name() === 'cli' && empty($_SERVER['REMOTE_ADDR']))
+if (PHP_SAPI === 'cli' && empty($_SERVER['REMOTE_ADDR']))
 {
 	$command_line = true;
 	$disable_security = 1;
@@ -84,7 +84,7 @@ require_once(TMP_BOARDDIR . '/Settings.php');
 $db_type = $db_type === 'mysql' ? 'mysqli' : $db_type;
 
 // Fix for using the current directory as a path.
-if (substr($sourcedir, 0, 1) === '.' && substr($sourcedir, 1, 1) !== '.')
+if (strpos($sourcedir, '.') === 0 && substr($sourcedir, 1, 1) !== '.')
 {
 	$sourcedir = TMP_BOARDDIR . substr($sourcedir, 1);
 }
@@ -127,14 +127,14 @@ if ((empty($languagedir) || !file_exists($languagedir)) && file_exists($sourcedi
 }
 
 // Time to forget about variables and go with constants!
-DEFINE('BOARDDIR', $boarddir);
-DEFINE('CACHEDIR', $cachedir);
-DEFINE('EXTDIR', $extdir);
-DEFINE('LANGUAGEDIR', $languagedir);
-DEFINE('SOURCEDIR', $sourcedir);
-DEFINE('ADMINDIR', $sourcedir . '/admin');
-DEFINE('CONTROLLERDIR', $sourcedir . '/controllers');
-DEFINE('SUBSDIR', $sourcedir . '/subs');
+define('BOARDDIR', $boarddir);
+define('CACHEDIR', $cachedir);
+define('EXTDIR', $extdir);
+define('LANGUAGEDIR', $languagedir);
+define('SOURCEDIR', $sourcedir);
+define('ADMINDIR', $sourcedir . '/admin');
+define('CONTROLLERDIR', $sourcedir . '/controllers');
+define('SUBSDIR', $sourcedir . '/subs');
 
 // Are we logged in?
 if (isset($upgradeData))
@@ -237,7 +237,7 @@ $upcontext['right_to_left'] = $txt['lang_rtl'] ?? false;
 // Have we got log data - if so use it (It will be clean!)
 if (isset($_GET['data']))
 {
-	$upcontext['upgrade_status'] = unserialize(base64_decode($_GET['data']));
+	$upcontext['upgrade_status'] = unserialize(base64_decode($_GET['data']), array('allowed_classes' => false));
 	$upcontext['current_step'] = $upcontext['upgrade_status']['curstep'];
 	$upcontext['language'] = ucfirst($upcontext['upgrade_status']['lang']);
 	$upcontext['rid'] = $upcontext['upgrade_status']['rid'];
@@ -245,9 +245,10 @@ if (isset($_GET['data']))
 	$support_js = $upcontext['upgrade_status']['js'];
 
 	// Load the language.
-	global $txt;
-	$lang = new \ElkArte\Languages\Loader($upcontext['language'], $txt, database());
-	$lang->load('Install');
+	if (file_exists($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/Install.' . $upcontext['language'] . '.php'))
+	{
+		require_once($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/Install.' . $upcontext['language'] . '.php');
+	}
 }
 // Set the defaults.
 else
@@ -256,14 +257,14 @@ else
 	$upcontext['rid'] = mt_rand(0, 5000);
 	$upcontext['upgrade_status'] = array(
 		'curstep' => 0,
-		// memo: .lng files were used by YaBB SE, $language is defined in Settings.php
-		'lang' => $_GET['lang'] ?? ucfirst(basename($language, '.lng')),
+		// memo: .lng files were used by YaBB SE
+		'lang' => isset($_GET['lang']) ? $_GET['lang'] : basename($language, '.lng'),
 		'rid' => $upcontext['rid'],
 		'pass' => 0,
 		'debug' => 0,
 		'js' => 0,
 	);
-	$upcontext['language'] = ucfirst($upcontext['upgrade_status']['lang']);
+	$upcontext['language'] = $upcontext['upgrade_status']['lang'];
 }
 
 // If this isn't the first stage see whether they are logging in and resuming.
@@ -307,7 +308,8 @@ foreach ($upcontext['steps'] as $num => $step)
 		{
 			break;
 		}
-		elseif (function_exists($step[2]))
+
+		if (function_exists($step[2]))
 		{
 			$upcontext['current_step']++;
 		}
@@ -321,7 +323,7 @@ upgradeExit();
 /**
  * Exit the upgrade script.
  *
- * @param boolean $fallThrough
+ * @param bool $fallThrough
  */
 function upgradeExit($fallThrough = false)
 {
@@ -333,9 +335,7 @@ function upgradeExit($fallThrough = false)
 		$upcontext['user']['step'] = $upcontext['current_step'];
 		$upcontext['user']['substep'] = $_GET['substep'];
 		$upcontext['user']['updated'] = time();
-
-		// Make a copy, then save the data in Settings.php
-		$upgradeData = base64_encode(json_encode($upcontext['user']));
+		$upgradeData = base64_encode(serialize($upcontext['user']));
 		copy(BOARDDIR . '/Settings.php', BOARDDIR . '/Settings_bak.php');
 		changeSettings(array('upgradeData' => '\'' . $upgradeData . '\''));
 		updateLastError();
@@ -361,16 +361,12 @@ function upgradeExit($fallThrough = false)
 				debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 			}
 
-			echo "\n" . 'Error: Unexpected call to use the ' . ($upcontext['sub_template'] ?? '') . ' template. Please copy and paste all the text above and visit the ElkArte Community to tell the Developers that they\'ve made a doh!; they\'ll get you up and running again.';
+			echo "\n" . 'Error: Unexpected call to use the ' . (isset($upcontext['sub_template']) ? $upcontext['sub_template'] : '') . ' template. Please copy and paste all the text above and visit the ElkArte Community to tell the Developers that they\'ve made a doh!; they\'ll get you up and running again.';
 			flush();
 			die();
 		}
 
-		if (!isset($_GET['xml']))
-		{
-			template_upgrade_above();
-		}
-		else
+		if (isset($_GET['xml']))
 		{
 			header('Content-Type: text/xml; charset=UTF-8');
 
@@ -378,13 +374,17 @@ function upgradeExit($fallThrough = false)
 			$upcontext['get_data'] = array();
 			foreach ($_GET as $k => $v)
 			{
-				if (substr($k, 0, 3) !== 'amp' && !in_array($k, array('xml', 'substep', 'lang', 'data', 'step', 'filecount')))
+				if (strpos($k, 'amp') !== 0 && !in_array($k, array('xml', 'substep', 'lang', 'data', 'step', 'filecount')))
 				{
 					$upcontext['get_data'][$k] = $v;
 				}
 			}
 
 			template_xml_above();
+		}
+		else
+		{
+			template_upgrade_above();
 		}
 
 		// Call the template.
@@ -409,13 +409,13 @@ function upgradeExit($fallThrough = false)
 		}
 
 		// Show the footer.
-		if (!isset($_GET['xml']))
+		if (isset($_GET['xml']))
 		{
-			template_upgrade_below();
+			template_xml_below();
 		}
 		else
 		{
-			template_xml_below();
+			template_upgrade_below();
 		}
 	}
 
@@ -426,8 +426,8 @@ function upgradeExit($fallThrough = false)
 /**
  * Used to direct the user to another location.
  *
- * @param string $location
- * @param boolean $addForm
+ * @param string  $location
+ * @param bool $addForm
  */
 function redirectLocation($location, $addForm = true)
 {
@@ -446,10 +446,12 @@ function redirectLocation($location, $addForm = true)
 		$location = $upgradeurl . '?step=' . $upcontext['current_step'] . '&substep=' . $_GET['substep'] . '&data=' . base64_encode(serialize($upcontext['upgrade_status'])) . $location;
 	}
 
-	while (@ob_end_clean())
+	while (ob_get_level() > 0)
 	{
-		header('Location: ' . strtr($location, array('&amp;' => '&')));
+		@ob_end_clean();
 	}
+
+	header('Location: ' . strtr($location, array('&amp;' => '&')));
 
 	// Exit - saving status as we go.
 	upgradeExit(true);
@@ -462,6 +464,12 @@ function loadEssentialData()
 {
 	global $db_character_set, $db_type, $modSettings;
 
+	// Do the non-SSI stuff...
+	if (function_exists('set_magic_quotes_runtime'))
+	{
+		@set_magic_quotes_runtime(0);
+	}
+
 	// Report all errors except for depreciation notices so users don't complain.
 	error_reporting(E_ALL & ~E_DEPRECATED);
 
@@ -470,59 +478,65 @@ function loadEssentialData()
 		define('ELK', 1);
 	}
 
-	header('X-Frame-Options: SAMEORIGIN');
-	header('X-XSS-Protection: 1');
-	header('X-Content-Type-Options: nosniff');
-
 	// Start the session.
-	if (ini_get('session.save_handler') === 'user')
+	if (ini_get('session.save_handler') == 'user')
 	{
 		@ini_set('session.save_handler', 'files');
 	}
+
 	@session_start();
 
-	// Initialize everything...
 	definePaths();
+
+	// Initialize everything...
 	initialize_inputs();
 
 	if (file_exists(SOURCEDIR . '/database/Database.subs.php'))
 	{
 		require_once(SOURCEDIR . '/Subs.php');
+		require_once(SOURCEDIR . '/Errors.class.php');
 		require_once(SOURCEDIR . '/Logging.php');
 		require_once(SOURCEDIR . '/Load.php');
 		require_once(SUBSDIR . '/Cache.subs.php');
 		require_once(SOURCEDIR . '/Security.php');
-		require_once(EXTDIR . '/ClassLoader.php');
-
-		$loader = new \ElkArte\ext\Composer\Autoload\ClassLoader();
-		$loader->setPsr4('ElkArte\\', SOURCEDIR . '/ElkArte');
-		$loader->setPsr4('BBC\\', SOURCEDIR . '/ElkArte/BBC');
-		$loader->register();
-		require_once('./DatabaseCode.php');
+		require_once(SOURCEDIR . '/Autoloader.class.php');
+		$autoloder = Elk_Autoloader::instance();
+		$autoloder->setupAutoloader(array(SOURCEDIR, SUBSDIR, CONTROLLERDIR, ADMINDIR, ADDONSDIR));
+		$autoloder->register(SOURCEDIR, '\\ElkArte');
+		load_possible_databases($db_type);
 
 		$db = load_database();
 
-		// Load the modSettings data...
-		$modSettings = array();
 		$db->skip_next_error();
-		$db->fetchQuery('
+		if ($db_type === 'mysql' && isset($db_character_set) && preg_match('~^\w+$~', $db_character_set) === 1)
+		{
+			$db->query('', '
+				SET NAMES ' . $db_character_set,
+				array()
+			);
+		}
+
+		// Load the modSettings data...
+		$db->skip_next_error();
+		$request = $db->query('', '
 			SELECT 
-				variable, value
+			    variable, value
 			FROM {db_prefix}settings',
 			array()
-		)->fetch_callback(
-			function ($row) use (&$modSettings) {
-				$modSettings[$row['variable']] = $row['value'];
-			}
 		);
+		$modSettings = array();
+		while ($row = $db->fetch_assoc($request))
+		{
+			$modSettings[$row['variable']] = $row['value'];
+		}
+		$db->free_result($request);
 	}
 	else
 	{
 		return throw_error('Cannot find ' . SOURCEDIR . '/database/Database.subs.php. Please check you have uploaded all source files and have the correct paths set.');
 	}
 
-	// If they don't have the file, they're going to get a warning anyway,
-	// so we won't need to clean request vars.
+	// If they don't have the file, they're going to get a warning anyway, so we won't need to clean request vars.
 	if (file_exists(SOURCEDIR . '/QueryString.php'))
 	{
 		require_once(SOURCEDIR . '/QueryString.php');
@@ -536,11 +550,14 @@ function loadEssentialData()
 		$modSettings['admin_session_lifetime'] = 5;
 	}
 
-	$_GET['substep'] = $_GET['substep'] ?? 0;
+	if (!isset($_GET['substep']))
+	{
+		$_GET['substep'] = 0;
+	}
 }
 
 /**
- * Prepare for the installation, set up which set we are on, etc
+ * Prepare for the install, set up which set we are on, etc
  */
 function initialize_inputs()
 {
@@ -572,9 +589,13 @@ function initialize_inputs()
 		$temp = substr($temp, 1);
 	}
 
+	header('X-Frame-Options: SAMEORIGIN');
+	header('X-XSS-Protection: 1');
+	header('X-Content-Type-Options: nosniff');
+
 	// Force a step, defaulting to 0.
-	$_GET['step'] = $_GET['step'] ?? 0;
-	$_GET['substep'] = $_GET['substep'] ?? 0;
+	$_GET['step'] = !isset($_GET['step']) ? 0 : (int) $_GET['step'];
+	$_GET['substep'] = !isset($_GET['substep']) ? 0 : (int) $_GET['substep'];
 }
 
 /**
@@ -587,39 +608,38 @@ function initialize_inputs()
  */
 function action_welcomeLogin()
 {
-	global $modSettings, $upgradeurl, $upcontext, $db_type, $db_character_set, $txt, $boardurl;
+	global $modSettings, $upgradeurl, $upcontext, $db_type, $databases, $db_character_set, $txt, $boardurl;
 
 	$db = load_database();
-	load_possible_databases();
-	$fileFunc = \ElkArte\FileFunctions::instance();
 
 	$upcontext['sub_template'] = 'welcome_message';
-	$upcontext['language'] = !empty($upcontext['language']) ? ucfirst($upcontext['language']): 'English';
 
 	// Check for some key files - one template, one language, and a new and an old source file.
-	$check = $fileFunc->fileExists($modSettings['theme_dir'] . '/index.template.php')
-		&& $fileFunc->fileExists(SOURCEDIR . '/QueryString.php')
-		&& $fileFunc->fileExists(SOURCEDIR . '/ElkArte/Database/' . ucfirst($db_type) . '/Query.php')
-		&& $fileFunc->fileExists(__DIR__ . '/upgrade_' . DB_SCRIPT_VERSION . '.php');
+	$check = @file_exists($modSettings['theme_dir'] . '/index.template.php')
+		&& @file_exists(SOURCEDIR . '/QueryString.php')
+		&& @file_exists(SOURCEDIR . '/database/Db-' . $db_type . '.class.php')
+		&& @file_exists(__DIR__ . '/upgrade_' . DB_SCRIPT_VERSION . '.php');
 
 	// This needs to exist!
-	if (!$fileFunc->fileExists(SOURCEDIR . '/ElkArte/Languages/Install/' . $upcontext['language'] . '.php'))
+	if (file_exists($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/Install.' . $upcontext['language'] . '.php'))
+	{
+		require_once($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/Install.' . $upcontext['language'] . '.php');
+	}
+	else
 	{
 		return throw_error('The upgrade script could not find the &quot;Install&quot; language file for the forum default language, ' . $upcontext['language'] . '.<br /><br />Please make certain you uploaded all the files included in the package, even the theme and language files for the default theme.<br />&nbsp;&nbsp;&nbsp;[<a href="' . $upgradeurl . '?lang=english">Try English</a>]');
 	}
-	require_once(SOURCEDIR . '/ElkArte/Languages/Install/' . $upcontext['language'] . '.php');
 
 	// Do not try to upgrade to the same version you are already running
-	if (isset($_GET['v']) && defined('CURRENT_VERSION') && !empty($_SESSION['installing']))
+	if (isset($_GET['v']) && defined('CURRENT_VERSION')
+		&& !empty($_SESSION['installing'])
+		&& $_GET['v'] === CURRENT_VERSION)
 	{
-		if ($_GET['v'] === CURRENT_VERSION)
-		{
-			$upcontext['current_step'] = 4;
-			$upcontext['overall_percent'] = 100;
-			unset($_GET['v']);
+		$upcontext['current_step'] = 4;
+		$upcontext['overall_percent'] = 100;
+		unset($_GET['v']);
 
-			return throw_error(sprintf($txt['upgrade_warning_already_done'], CURRENT_VERSION, $boardurl), true);
-		}
+		return throw_error(sprintf($txt['upgrade_warning_already_done'], CURRENT_VERSION, $boardurl), true);
 	}
 
 	// If the db is not UTF
@@ -643,21 +663,21 @@ function action_welcomeLogin()
 
 	if (!db_version_check())
 	{
-		return throw_error('Your ' . $GLOBALS['databases'][$db_type]['name'] . ' version does not meet the minimum requirements of ElkArte.<br /><br />Please ask your host to upgrade.');
+		return throw_error('Your ' . $databases[$db_type]['name'] . ' version does not meet the minimum requirements of ElkArte.<br /><br />Please ask your host to upgrade.');
 	}
 
 	// Do they have ALTER privileges?
 	$db->skip_next_error();
-	if (!empty($GLOBALS['databases'][$db_type]['alter_support'])
+	if (!empty($databases[$db_type]['alter_support'])
 		&& $db->query('', '	ALTER TABLE {db_prefix}log_digest ORDER BY id_topic', array()) === false)
 	{
-		return throw_error('The ' . $GLOBALS['databases'][$db_type]['name'] . ' user you have set in Settings.php does not have proper privileges.<br /><br />Please ask your host to give this user the ALTER, CREATE, and DROP privileges.');
+		return throw_error('The ' . $databases[$db_type]['name'] . ' user you have set in Settings.php does not have proper privileges.<br /><br />Please ask your host to give this user the ALTER, CREATE, and DROP privileges.');
 	}
 
 	// Do a quick version spot check.
 	$temp = substr(@implode('', @file(BOARDDIR . '/bootstrap.php')), 0, 4096);
 	preg_match('~\*\s@version\s+(.+)~i', $temp, $match);
-	if (empty($match[1]) || compareVersions(trim($match[1]), CURRENT_VERSION) != 0)
+	if (empty($match[1]) || compareVersions(trim(str_replace('Release Candidate', 'RC', $match[1])), CURRENT_VERSION) != 0)
 	{
 		return throw_error('The upgrader found some old or outdated files.<br /><br />Please make certain you uploaded the new versions of all the files included in the package.');
 	}
@@ -670,28 +690,27 @@ function action_welcomeLogin()
 
 	// Check the cache directory.
 	$CACHEDIR_temp = !defined('CACHEDIR') ? BOARDDIR . '/cache' : CACHEDIR;
-	if (!$fileFunc->createDirectory($CACHEDIR_temp))
+	if (!file_exists($CACHEDIR_temp))
+	{
+		if (!mkdir($CACHEDIR_temp) && !is_dir($CACHEDIR_temp))
+		{
+			return throw_error(sprintf('The cache directory "%s" could not be created.<br /><br />Please make sure you have a directory called &quot;cache&quot; in your forum directory before continuing.', $CACHEDIR_temp));
+		}
+	}
+
+	if (!file_exists($CACHEDIR_temp))
 	{
 		return throw_error('The cache directory could not be found.<br /><br />Please make sure you have a directory called &quot;cache&quot; in your forum directory before continuing.');
 	}
 
-	// Make sure the custom avatar directory exists and is writable!
-	$custom_avatar_dir = !empty($modSettings['custom_avatar_dir']) ? $modSettings['custom_avatar_dir'] : BOARDDIR . '/avatars_user';
-	if (!$fileFunc->createDirectory($custom_avatar_dir))
-	{
-		print_error('Error: Unable to obtain write access to "' . $custom_avatar_dir . '"', true);
-	}
-
-	// Do we have a language file to use
-	if (!$fileFunc->fileExists(SOURCEDIR . '/ElkArte/Languages/Index/' . $upcontext['language'] . '.php') && !isset($modSettings['elkVersion'], $_GET['lang']))
+	if (!file_exists($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/index.' . $upcontext['language'] . '.php') && !isset($modSettings['elkVersion']) && !isset($_GET['lang']))
 	{
 		return throw_error('The upgrader was unable to find language files for the language specified in Settings.php.<br />ElkArte will not work without the primary language files installed.<br /><br />Please either install them, or <a href="' . $upgradeurl . '?step=0;lang=english">use english instead</a>.');
 	}
 
-	// Is it for this version of ElkArte?
 	if (!isset($_GET['skiplang']))
 	{
-		$temp = substr(@implode('', @file(SOURCEDIR . '/ElkArte/Languages/Index/' . $upcontext['language'] . '.php')), 0, 4096);
+		$temp = substr(@implode('', @file($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/index.' . $upcontext['language'] . '.php')), 0, 4096);
 		preg_match('~(?://|/\*)\s*Version:\s+(.+?);\s*index(?:[\s]{2}|\*/)~i', $temp, $match);
 
 		if (empty($match[1]) || $match[1] != CURRENT_LANG_VERSION)
@@ -705,12 +724,27 @@ function action_welcomeLogin()
 		return false;
 	}
 
+	// Check agreement.txt. (it may not exist, in which case BOARDDIR must be writable.)
+	if (isset($modSettings['agreement']) && (!is_writable(BOARDDIR) || file_exists(BOARDDIR . '/agreement.txt')) && !is_writable(BOARDDIR . '/agreement.txt'))
+	{
+		return throw_error('The upgrader was unable to obtain write access to agreement.txt.<br /><br />If you are using a linux or unix based server, please ensure that the file is chmod\'d to 777, or if it does not exist that the directory this upgrader is in is 777.<br />If your server is running Windows, please ensure that the internet guest account has the proper permissions on it or its folder.');
+	}
+
+	if (isset($modSettings['agreement']))
+	{
+		$fp = fopen(BOARDDIR . '/agreement.txt', 'wb');
+		fwrite($fp, $modSettings['agreement']);
+		fclose($fp);
+	}
+
+	// Upgrade the agreement.
+
 	// We're going to check that their board dir setting is right in case they've been moving stuff around.
-	if (strtr(BOARDDIR, array('/' => '', '\\' => '')) != strtr(TMP_BOARDDIR, array('/' => '', '\\' => '')))
+	if (strtr(BOARDDIR, array('/' => '', '\\' => '')) !== strtr(TMP_BOARDDIR, array('/' => '', '\\' => '')))
 	{
 		$upcontext['warning'] = '
 			It looks as if your board directory settings <em>might</em> be incorrect. Your board directory is currently set to &quot;' . BOARDDIR . '&quot; but should probably be &quot;' . TMP_BOARDDIR . '&quot;. Settings.php currently lists your paths as:<br />
-			<ul class="bbc_list">
+			<ul>
 				<li>Board Directory: ' . BOARDDIR . '</li>
 				<li>Source Directory: ' . BOARDDIR . '</li>
 				<li>Cache Directory: ' . $CACHEDIR_temp . '</li>
@@ -749,24 +783,60 @@ function checkLogin()
 			$_POST['user'] = 'Administrator';
 		}
 
-		// Get what we believe to be their details.
-		if (!$disable_security)
+		// Before SMF 2.0 these column names were different!
+		$oldDB = false;
+		if (empty($db_type) || $db_type == 'mysql')
 		{
 			$db->skip_next_error();
 			$request = $db->query('', '
-				SELECT 
-					id_member, member_name, passwd, id_group, additional_groups, lngfile
+				SHOW COLUMNS
 				FROM {db_prefix}members
-				WHERE member_name = {string:member_name}',
+				LIKE {string:member_name}',
 				array(
-					'member_name' => $_POST['user'],
+					'member_name' => 'memberName',
 				)
 			);
-
-			if ($request->num_rows() != 0)
+			if ($db->num_rows($request) != 0)
 			{
-				list ($id_member, $name, $password, $id_group, $addGroups, $user_language) = $request->fetch_row();
-				$user_language = ucfirst($user_language);
+				$oldDB = true;
+			}
+			$db->free_result($request);
+		}
+
+		// Get what we believe to be their details.
+		if (!$disable_security)
+		{
+			if ($oldDB)
+			{
+				$db->skip_next_error();
+				$request = $db->query('', '
+					SELECT 
+						id_member, memberName AS member_name, passwd, id_group,
+						additionalGroups AS additional_groups, lngfile
+					FROM {db_prefix}members
+					WHERE memberName = {string:member_name}',
+					array(
+						'member_name' => $_POST['user'],
+					)
+				);
+			}
+			else
+			{
+				$db->skip_next_error();
+				$request = $db->query('', '
+					SELECT 
+						id_member, member_name, passwd, id_group, additional_groups, lngfile
+					FROM {db_prefix}members
+					WHERE member_name = {string:member_name}',
+					array(
+						'member_name' => $_POST['user'],
+					)
+				);
+			}
+
+			if ($db->num_rows($request) != 0)
+			{
+				list ($id_member, $name, $password, $id_group, $addGroups, $user_language) = $db->fetch_row($request);
 
 				// These will come in handy, if you want to login
 				require_once(SOURCEDIR . '/Security.php');
@@ -812,7 +882,7 @@ function checkLogin()
 				if ($valid_password === false && !empty($_POST['passwrd']))
 				{
 					// SHA-1 from SMF?
-					$sha_passwd = sha1(\ElkArte\Util::strtolower($_POST['user']) . $_POST['passwrd']);
+					$sha_passwd = sha1(Util::strtolower($_POST['user']) . $_POST['passwrd']);
 					$valid_password = $sha_passwd === $password;
 
 					// Lets upgrade this to our new password
@@ -833,7 +903,7 @@ function checkLogin()
 				$upcontext['username_incorrect'] = true;
 			}
 
-			$request->free_result();
+			$db->free_result($request);
 		}
 
 		$upcontext['username'] = $_POST['user'];
@@ -860,7 +930,7 @@ function checkLogin()
 		{
 			// MD5?
 			$md5pass = md5_hmac($_REQUEST['passwrd'], strtolower($_POST['user']));
-			if ($md5pass != $password)
+			if ($md5pass !== $password)
 			{
 				$upcontext['password_failed'] = true;
 
@@ -872,7 +942,12 @@ function checkLogin()
 		if ((empty($upcontext['password_failed']) && !empty($name)) || $disable_security)
 		{
 			// Set the password.
-			if (!$disable_security)
+			if ($disable_security)
+			{
+				$upcontext['user']['id'] = 1;
+				$upcontext['user']['name'] = 'Administrator';
+			}
+			else
 			{
 				// Do we actually have permission?
 				if (!in_array(1, $groups))
@@ -889,52 +964,45 @@ function checkLogin()
 							'admin_forum' => 'admin_forum',
 						)
 					);
-					if ($request->num_rows() == 0)
+					if ($db->num_rows($request) == 0)
 					{
 						return throw_error('You need to be an admin to perform an upgrade!');
 					}
-					$request->free_result();
+					$db->free_result($request);
 				}
 
 				$upcontext['user']['id'] = $id_member;
 				$upcontext['user']['name'] = $name;
 			}
-			else
-			{
-				$upcontext['user']['id'] = 1;
-				$upcontext['user']['name'] = 'Administrator';
-			}
 
 			$upcontext['user']['pass'] = mt_rand(0, 60000);
-			$user_language = ucfirst($user_language) ?? null;
-			$upcontext['language'] = ucfirst($upcontext['language']);
 
 			// This basically is used to match the GET variables to Settings.php.
 			$upcontext['upgrade_status']['pass'] = $upcontext['user']['pass'];
 
 			// Set the language to that of the user?
-			if (isset($user_language) && $user_language !== $upcontext['language'] && file_exists(SOURCEDIR . '/ElkArte/Languages/Index/' . basename($user_language, '.lng') . '.php'))
+			if (isset($user_language) && $user_language !== $upcontext['language'] && file_exists($modSettings['theme_dir'] . '/languages/' . basename($user_language, '.lng') . '/index.' . basename($user_language, '.lng') . '.php'))
 			{
 				$user_language = basename($user_language, '.lng');
-				$temp = substr(@implode('', @file(SOURCEDIR . '/ElkArte/Languages/Index/' . $user_language . '.php')), 0, 4096);
+				$temp = substr(@implode('', @file($modSettings['theme_dir'] . '/languages/' . $user_language . '/index.' . $user_language . '.php')), 0, 4096);
 				preg_match('~(?://|/\*)\s*Version:\s+(.+?);\s*index(?:[\s]{2}|\*/)~i', $temp, $match);
 
-				if (empty($match[1]) || $match[1] !== CURRENT_LANG_VERSION)
+				if (empty($match[1]) || $match[1] != CURRENT_LANG_VERSION)
 				{
 					$upcontext['upgrade_options_warning'] = 'The language files for your selected language, ' . $user_language . ', have not been updated to the latest version. Upgrade will continue with the forum default, ' . $upcontext['language'] . '.';
 				}
-				elseif (!file_exists(SOURCEDIR . '/ElkArte/Languages/Install/' . $user_language . '.php'))
-				{
-					$upcontext['upgrade_options_warning'] = 'The language files for your selected language, ' . $user_language . ', have not been uploaded/updated as the &quot;Install&quot; language file is missing. Upgrade will continue with the forum default, ' . $upcontext['language'] . '.';
-				}
-				else
+				elseif (file_exists($modSettings['theme_dir'] . '/languages/' . $user_language . '/Install.' . $user_language . '.php'))
 				{
 					// Set this as the new language.
 					$upcontext['language'] = $user_language;
 					$upcontext['upgrade_status']['lang'] = $upcontext['language'];
 
 					// Include the file.
-					require_once(SOURCEDIR . '/ElkArte/Languages/Install/' . $user_language . '.php');
+					require_once($modSettings['theme_dir'] . '/languages/' . $user_language . '/Install.' . $user_language . '.php');
+				}
+				else
+				{
+					$upcontext['upgrade_options_warning'] = 'The language files for your selected language, ' . $user_language . ', have not been uploaded/updated as the &quot;Install&quot; language file is missing. Upgrade will continue with the forum default, ' . $upcontext['language'] . '.';
 				}
 			}
 
@@ -957,7 +1025,7 @@ function checkLogin()
  */
 function action_upgradeOptions()
 {
-	global $command_line, $is_debug, $maintenance, $upcontext, $db_type;
+	global $command_line, $modSettings, $is_debug, $maintenance, $upcontext, $db_type;
 
 	$upcontext['sub_template'] = 'upgrade_options';
 	$upcontext['page_title'] = 'Upgrade Options';
@@ -970,6 +1038,16 @@ function action_upgradeOptions()
 
 	// Get hold of our db
 	$db = load_database();
+
+	// No one opts in so why collect incomplete stats
+	$db->skip_next_error();
+	$db->query('', '
+		DELETE FROM {db_prefix}settings
+		WHERE variable = {string:allow_sm_stats}',
+		array(
+			'allow_sm_stats' => 'allow_sm_stats',
+		)
+	);
 
 	// Cleanup all the hooks (we are upgrading, so better have everything cleaned up)
 	$db->skip_next_error();
@@ -984,15 +1062,18 @@ function action_upgradeOptions()
 	// Optionally empty the error log?
 	if (!empty($_POST['empty_error']))
 	{
-		$db->truncate('{db_prefix}log_errors');
+		$db->query('truncate_table', '
+			TRUNCATE {db_prefix}log_errors',
+			array()
+		);
 	}
 
 	$changes = array();
 
 	// If we're overriding the language follow it through.
-	if (isset($_GET['lang']) && file_exists(SOURCEDIR . '/ElkArte/Languages/Index/' . ucfirst($_GET['lang']) . '.php'))
+	if (isset($_GET['lang']) && file_exists($modSettings['theme_dir'] . '/languages/' . $_GET['lang'] . '/index.' . $_GET['lang'] . '.php'))
 	{
-		$changes['language'] = '\'' . ucfirst($_GET['lang']) . '\'';
+		$changes['language'] = '\'' . $_GET['lang'] . '\'';
 	}
 
 	// Place the board in to maintance mode?
@@ -1025,17 +1106,17 @@ function action_upgradeOptions()
 	copy(BOARDDIR . '/Settings.php', BOARDDIR . '/Settings_bak.php');
 
 	// Fix some old paths.
-	if (substr(BOARDDIR, 0, 1) === '.')
+	if (strpos(BOARDDIR, '.') === 0)
 	{
 		$changes['boarddir'] = '\'' . fixRelativePath(BOARDDIR) . '\'';
 	}
 
-	if (substr(SOURCEDIR, 0, 1) === '.')
+	if (strpos(SOURCEDIR, '.') === 0)
 	{
 		$changes['sourcedir'] = '\'' . fixRelativePath(SOURCEDIR) . '\'';
 	}
 
-	if (!defined('CACHEDIR') || substr(CACHEDIR, 0, 1) === '.')
+	if (!defined('CACHEDIR') || strpos(CACHEDIR, '.') === 0)
 	{
 		$changes['cachedir'] = '\'' . fixRelativePath(BOARDDIR) . '/cache\'';
 	}
@@ -1093,12 +1174,12 @@ function action_backupDatabase()
 	// Get all the table names.
 	$filter = str_replace('_', '\_', preg_match('~^`(.+?)`\.(.+?)$~', $db_prefix, $match) != 0 ? $match[2] : $db_prefix) . '%';
 	$db_name = preg_match('~^`(.+?)`\.(.+?)$~', $db_prefix, $match) != 0 ? strtr($match[1], array('`' => '')) : false;
-	$tables = $db->list_tables($db_name, $filter);
+	$tables = $db->db_list_tables($db_name, $filter);
 
 	$table_names = array();
 	foreach ($tables as $table)
 	{
-		if (substr($table, 0, 7) !== 'backup_')
+		if (strpos($table, 'backup_') !== 0)
 		{
 			$table_names[] = $table;
 		}
@@ -1106,7 +1187,7 @@ function action_backupDatabase()
 
 	$upcontext['table_count'] = count($table_names);
 	$upcontext['cur_table_num'] = $_GET['substep'];
-	$upcontext['cur_table_name'] = str_replace($db_prefix, '', $table_names[$_GET['substep']] ?? $table_names[0]);
+	$upcontext['cur_table_name'] = str_replace($db_prefix, '', isset($table_names[$_GET['substep']]) ? $table_names[$_GET['substep']] : $table_names[0]);
 	$upcontext['step_progress'] = (int) (($upcontext['cur_table_num'] / $upcontext['table_count']) * 100);
 
 	// For non-java auto submit...
@@ -1132,7 +1213,7 @@ function action_backupDatabase()
 		// Backup each table!
 		for ($substep = $_GET['substep'], $n = count($table_names); $substep < $n; $substep++)
 		{
-			$upcontext['cur_table_name'] = str_replace($db_prefix, '', ($table_names[$substep + 1] ?? $table_names[$substep]));
+			$upcontext['cur_table_name'] = str_replace($db_prefix, '', (isset($table_names[$substep + 1]) ? $table_names[$substep + 1] : $table_names[$substep]));
 			$upcontext['cur_table_num'] = $substep + 1;
 			$upcontext['step_progress'] = (int) (($upcontext['cur_table_num'] / $upcontext['table_count']) * 100);
 
@@ -1184,7 +1265,7 @@ function backupTable($table)
 	}
 
 	$db = load_database();
-	$db->backup_table($table, 'backup_' . $table);
+	$db->db_backup_table($table, 'backup_' . $table);
 
 	if ($is_debug && $command_line)
 	{
@@ -1197,7 +1278,7 @@ function backupTable($table)
  */
 function action_databaseChanges()
 {
-	global $modSettings, $command_line, $upcontext, $support_js;
+	global $db_prefix, $modSettings, $command_line, $upcontext, $support_js;
 
 	$db = load_database();
 
@@ -1253,7 +1334,7 @@ function action_databaseChanges()
 			if ($nextFile)
 			{
 				// Only update the version of this if complete.
-				$db->replace(
+				$db->insert('replace',
 					'{db_prefix}settings',
 					array('variable' => 'string', 'value' => 'string'),
 					array('elkVersion', $file[2]),
@@ -1277,7 +1358,8 @@ function action_databaseChanges()
 
 				return upgradeExit();
 			}
-			elseif ($support_js)
+
+			if ($support_js)
 			{
 				break;
 			}
@@ -1294,7 +1376,7 @@ function action_databaseChanges()
 	{
 		$upcontext['changes_complete'] = true;
 
-		// If this is the command line we can't do any more.
+		// If this is the command line we can't do anymore.
 		if ($command_line)
 		{
 			return action_deleteUpgrade();
@@ -1307,143 +1389,17 @@ function action_databaseChanges()
 }
 
 /**
- * Remove 1.x files that have been moved or removed from 2.0
- */
-function action_deleteOldFiles()
-{
-	$fileFunc = \ElkArte\FileFunctions::instance();
-
-	// Remove old files
-	$fileFunc->delete(BOARDDIR . '/sources/AbstractModel.php');
-	$fileFunc->delete(BOARDDIR . '/sources/Action.controller.php');
-	$fileFunc->delete(BOARDDIR . '/sources/Autoloader.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/BrowserDetector.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/CurlFetchWebdata.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/Debug.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/Errors.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/Errors.php');
-	$fileFunc->delete(BOARDDIR . '/sources/FrontpageInterface.php');
-	$fileFunc->delete(BOARDDIR . '/sources/Hooks.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/Request.php');
-	$fileFunc->delete(BOARDDIR . '/sources/Server.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/SiteCombiner.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/SiteDispatcher.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/Templates.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/Theme.php');
-	$fileFunc->delete(BOARDDIR . '/sources/ValuesContainer.php');
-	$fileFunc->delete(BOARDDIR . '/sources/database/Db-abstract.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/database/Db-mysql.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/database/Db-postgresql.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/database/Db.php');
-	$fileFunc->delete(BOARDDIR . '/sources/database/DbSearch-mysql.php');
-	$fileFunc->delete(BOARDDIR . '/sources/database/DbSearch-postgresql.php');
-	$fileFunc->delete(BOARDDIR . '/sources/database/DbSearch.php');
-	$fileFunc->delete(BOARDDIR . '/sources/database/DbTable-mysql.php');
-	$fileFunc->delete(BOARDDIR . '/sources/database/DbTable-postgresql.php');
-	$fileFunc->delete(BOARDDIR . '/sources/database/DbTable.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/ext/PasswordHash.php');
-	$fileFunc->delete(BOARDDIR . '/sources/ext/serialize.php');
-	$fileFunc->delete(BOARDDIR . '/sources/ext/cssmin/cssmin.php');
-	$fileFunc->delete(BOARDDIR . '/sources/ext/cssmin/README.md');
-	$fileFunc->delete(BOARDDIR . '/sources/ext/cssmin/tubalmartin');
-	$fileFunc->delete(BOARDDIR . '/sources/ext/cssmin/cssmin.php');
-	$fileFunc->delete(BOARDDIR . '/sources/ext/cssmin/README.md');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/MentionType/BuddyMention.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/MentionType/LikemsgMention.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/MentionType/MailfailMention.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/MentionType/MentionBoardAccessAbstract.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/MentionType/MentionmemMention.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/MentionType/MentionMessageAbstract.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/MentionType/MentionTypeInterface.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/MentionType/QuotedmemMention.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/MentionType/RlikemsgMention.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Action.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/AdminSettingsSearch.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Agreement.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/BadBehavior.subs.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/BoardsList.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Cache.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/CalendarEvent.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Censor.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/DataValidator.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Drafts.integrate.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/EmailFormat.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/EmailParse.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/EmailSettings.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Event.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/EventManager.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/FtpConnection.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/GenericList.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Html2BBC.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Html2Md.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/HttpReq.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Ila.integrate.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Mentioning.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/MessagesDelete.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/MessageTopicIcons.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Notifications.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/NotificationsTask.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/OpenID.subs.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/PackagesFilterIterator.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/PbeImap.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Permission.subs.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Permissions.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Priority.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/PrivacyPolicy.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/QueryAnalysis.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Recent.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Search.subs.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/SettingsForm.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Subscriptions-Authorize.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Subscriptions-PayPal.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Subscriptions-twoCheckOut.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Suggest.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/TemplateLayers.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/TokenHash.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/TopicsMerge.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/TopicUtil.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Unread.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/UnTgz.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/UnZip.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/UserNotification.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/UserNotification.integrate.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/Util.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/VerificationControls.class.php');
-	$fileFunc->delete(BOARDDIR . '/sources/subs/XmlArray.class.php');
-	$fileFunc->delete(BOARDDIR . '/themes/default/BadBehavior.template.php');
-	$fileFunc->delete(BOARDDIR . '/themes/default/images/profile/aim.png');
-	$fileFunc->delete(BOARDDIR . '/themes/default/scripts/jquery-ui-1.12.1.min.js');
-	$fileFunc->delete(BOARDDIR . '/themes/default/scripts/spellcheck.js');
-
-	// Remove old directories and their files
-	$fileFunc->rmDir(BOARDDIR . '/sources/admin');
-	$fileFunc->rmDir(BOARDDIR . '/sources/controllers');
-	$fileFunc->rmDir(BOARDDIR . '/sources/modules');
-	$fileFunc->rmDir(BOARDDIR . '/sources/ext/bad-behavior');
-	$fileFunc->rmDir(BOARDDIR . '/sources/ext/cssmin/tubalmartin');
-	$fileFunc->rmDir(BOARDDIR . '/themes/default/languages');
-	$fileFunc->rmDir(BOARDDIR . '/sources/subs/BBC');
-	$fileFunc->rmDir(BOARDDIR . '/sources/subs/CacheMethod');
-	$fileFunc->rmDir(BOARDDIR . '/sources/subs/Errors');
-	$fileFunc->rmDir(BOARDDIR . '/sources/subs/Exception');
-	$fileFunc->rmDir(BOARDDIR . '/sources/subs/ScheduledTask');
-	$fileFunc->rmDir(BOARDDIR . '/sources/subs/Search');
-	$fileFunc->rmDir(BOARDDIR . '/sources/subs/SessionHandler');
-	$fileFunc->rmDir(BOARDDIR . '/sources/subs/SettingsFormAdapter');
-}
-
-/**
  * Delete the damn thing!
  * Finalizes the upgrade
- * Updates' maintenance mode to what it was before the upgrade started
+ * Updates maintenance mode to what it was before the upgrade started
  * Updates settings.php, sometimes even correctly
  * Flushes the cache so there is a clean start
  */
 function action_deleteUpgrade()
 {
-	global $command_line, $language, $upcontext, $maintenance, $db_type, $modSettings;
+	global $command_line, $language, $upcontext, $user_info, $maintenance, $db_type, $modSettings;
 
-	// Now it's nice to have some of the basic source files.
+	// Now it's nice to have some basic source files.
 	if (!isset($_GET['ssi']) && !$command_line)
 	{
 		redirectLocation('&ssi=1');
@@ -1457,6 +1413,7 @@ function action_deleteUpgrade()
 	$changes = array(
 		'language' => '\'' . (substr($language, -4) === '.lng' ? substr($language, 0, -4) : $language) . '\'',
 		'db_error_send' => '1',
+		'upgradeData' => '#remove#'
 	);
 
 	// Are we in maintenance mode?
@@ -1466,7 +1423,6 @@ function action_deleteUpgrade()
 		{
 			echo ' * ';
 		}
-
 		$upcontext['removed_maintenance'] = true;
 		$changes['maintenance'] = $upcontext['user']['main'];
 	}
@@ -1479,15 +1435,7 @@ function action_deleteUpgrade()
 	// Wipe this out...
 	$upcontext['user'] = array();
 
-	// @todo this is mad and needs to be looked at
 	// Make a backup of Settings.php first as otherwise earlier changes are lost.
-	copy(BOARDDIR . '/Settings.php', BOARDDIR . '/Settings_bak.php');
-	changeSettings($changes);
-
-	// Now remove our marker
-	$changes = array(
-		'upgradeData' => '#remove#',
-	);
 	copy(BOARDDIR . '/Settings.php', BOARDDIR . '/Settings_bak.php');
 	changeSettings($changes);
 
@@ -1498,9 +1446,9 @@ function action_deleteUpgrade()
 	$upcontext['can_delete_script'] = is_writable(__DIR__) || is_writable(__FILE__);
 
 	// Log what we've done.
-	if (empty(ElkArte\User::$info->id))
+	if (empty($user_info['id']))
 	{
-		ElkArte\User::$info->id = !empty($upcontext['user']['id']) ? $upcontext['user']['id'] : 0;
+		$user_info['id'] = !empty($upcontext['user']['id']) ? $upcontext['user']['id'] : 0;
 	}
 
 	// We need to log in the database
@@ -1514,18 +1462,18 @@ function action_deleteUpgrade()
 			'id_board' => 'int', 'id_topic' => 'int', 'id_msg' => 'int', 'extra' => 'string-65534',
 		),
 		array(
-			time(), 3, ElkArte\User::$info->id, $command_line ? '127.0.0.1' : ElkArte\User::$info->ip, 'upgrade',
-			0, 0, 0, serialize(array('version' => CURRENT_VERSION, 'member' => ElkArte\User::$info->id)),
+			time(), 3, $user_info['id'], $command_line ? '127.0.0.1' : $user_info['ip'], 'upgrade',
+			0, 0, 0, serialize(array('version' => CURRENT_VERSION, 'member' => $user_info['id'])),
 		),
 		array('id_action')
 	);
 
-	ElkArte\User::$info->id = 0;
+	$user_info['id'] = 0;
 
 	// Drop old check for MySQL 5.0.50 and 5.0.51 bug.
 	removeSettings('db_mysql_group_by_fix');
 
-	// Set jquery to auto if its not already set
+	// Set jquery to auto, if it's not already set
 	if (!isset($modSettings['jquery_source']))
 	{
 		updateSettings(array('jquery_source' => 'auto'));
@@ -1552,7 +1500,7 @@ function action_deleteUpgrade()
 }
 
 /**
- * Reads in setting_bak.php file
+ * Reads in our backup setting_bak.php file
  * Removes flagged settings
  * Appends new settings as passed in $config_vars to the array
  * Writes out a new Settings.php file, overwriting any that may have existed
@@ -1563,6 +1511,11 @@ function changeSettings($config_vars)
 {
 	$settingsArray = file(BOARDDIR . '/Settings_bak.php');
 
+	if (count($settingsArray) === 1)
+	{
+		$settingsArray = preg_split('~[\r\n]~', $settingsArray[0]);
+	}
+
 	$save_vars = array();
 	foreach ($config_vars as $key => $var)
 	{
@@ -1570,6 +1523,56 @@ function changeSettings($config_vars)
 	}
 
 	saveFileSettings($save_vars, $settingsArray);
+}
+
+/**
+ * Loads all the member groups from the database
+ */
+function getMemberGroups()
+{
+	static $member_groups = array();
+
+	if (!empty($member_groups))
+	{
+		return $member_groups;
+	}
+
+	$db = load_database();
+
+	$db->skip_next_error();
+	$request = $db->query('', '
+		SELECT 
+			group_name, id_group
+		FROM {db_prefix}membergroups
+		WHERE id_group = {int:admin_group} OR id_group > {int:old_group}',
+		array(
+			'admin_group' => 1,
+			'old_group' => 7,
+		)
+	);
+
+	if ($request === false)
+	{
+		$db->skip_next_error();
+		$request = $db->query('', '
+			SELECT 
+				membergroup, id_group
+			FROM {db_prefix}membergroups
+			WHERE id_group = {int:admin_group} OR id_group > {int:old_group}',
+			array(
+				'admin_group' => 1,
+				'old_group' => 7,
+			)
+		);
+	}
+
+	while ($row = $db->fetch_row($request))
+	{
+		$member_groups[trim($row[0])] = $row[1];
+	}
+	$db->free_result($request);
+
+	return $member_groups;
 }
 
 /**
@@ -1588,7 +1591,8 @@ function fixRelativePath($path)
  */
 function parse_sql($filename)
 {
-	global $db_prefix, $boardurl, $command_line, $file_steps, $step_progress, $upcontext, $support_js, $is_debug;
+	global $db_prefix, $boardurl, $command_line, $file_steps, $step_progress;
+	global $upcontext, $support_js, $is_debug;
 
 	$replaces = array(
 		'{$db_prefix}' => $db_prefix,
@@ -1611,11 +1615,12 @@ function parse_sql($filename)
 	$install_instance = new $class_name($db_wrapper, $db_table_wrapper);
 
 	// All the methods (steps) in this upgrade file
-	$methods = array_filter(get_class_methods($install_instance), function ($method) {
-		return substr($method, 0, 2) !== '__' && substr($method, -6) !== '_title';
+	$methods = array_filter(get_class_methods($install_instance), static function ($method) {
+		return strpos($method, '__') !== 0 && substr($method, -6) !== '_title';
 	});
 
 	$substep = 0;
+	$last_step = '';
 
 	// Count the total number of steps within this file - for the progress bar.
 	$file_steps = countSteps($install_instance, $methods);
@@ -1631,7 +1636,6 @@ function parse_sql($filename)
 
 	$done_something = false;
 
-	// Start calling each method required to upgrade
 	foreach ($methods as $method)
 	{
 		$do_current = $substep >= $_GET['substep'];
@@ -1643,7 +1647,7 @@ function parse_sql($filename)
 		}
 
 		$upcontext['current_item_num']++;
-		$title = htmlspecialchars(rtrim($install_instance->{$method . '_title'}()), ENT_COMPAT);
+		$title = htmlspecialchars(rtrim($install_instance->{$method . '_title'}()), ENT_COMPAT, 'UTF-8');
 		$upcontext['current_item_name'] = $title;
 
 		if ($do_current)
@@ -1661,7 +1665,7 @@ function parse_sql($filename)
 		{
 			$upcontext['step_progress'] += (100 / $upcontext['file_count']) / $file_steps;
 			$upcontext['current_debug_item_num']++;
-			$upcontext['current_debug_item_name'] = htmlspecialchars(rtrim($action['debug_title']), ENT_COMPAT);
+			$upcontext['current_debug_item_name'] = htmlspecialchars(rtrim($action['debug_title']), ENT_COMPAT, 'UTF-8');
 
 			// Have we already done something?
 			if (isset($_GET['xml']) && $done_something)
@@ -1695,17 +1699,14 @@ function parse_sql($filename)
 			{
 				echo ' done.' . $endl;
 			}
-			else
+			elseif ($is_debug)
 			{
-				if ($is_debug)
-				{
-					$upcontext['actioned_items'][] = $upcontext['current_debug_item_name'];
-				}
+				$upcontext['actioned_items'][] = $upcontext['current_debug_item_name'];
 			}
 		}
 
-		// If this is xml based and we're just getting the item name then that's grand.
-		if ($support_js && !isset($_GET['xml']) && $upcontext['current_debug_item_name'] != '' && $do_current)
+		// If this is xml based, and we're just getting the item name then that's grand.
+		if ($support_js && !isset($_GET['xml']) && $upcontext['current_debug_item_name'] !== '' && $do_current)
 		{
 			restore_error_handler();
 
@@ -1743,7 +1744,8 @@ function parse_sql($filename)
  */
 function nextSubstep($substep)
 {
-	global $start_time, $timeLimitThreshold, $command_line, $custom_warning, $step_progress, $is_debug, $upcontext;
+	global $start_time, $timeLimitThreshold, $command_line, $custom_warning;
+	global $step_progress, $is_debug, $upcontext;
 
 	if ($_GET['substep'] < $substep)
 	{
@@ -1776,7 +1778,7 @@ function nextSubstep($substep)
 	if (!empty($step_progress))
 	{
 		$upcontext['substep_progress'] = 0;
-		$upcontext['substep_progress_name'] = $step_progress['name'] ?? '';
+		$upcontext['substep_progress_name'] = isset($step_progress['name']) ? $step_progress['name'] : '';
 		if ($step_progress['current'] > $step_progress['total'])
 		{
 			$upcontext['substep_progress'] = 99.9;
@@ -1802,7 +1804,7 @@ function nextSubstep($substep)
 	$upcontext['query_string'] = '';
 	foreach ($_GET as $k => $v)
 	{
-		if ($k != 'data' && $k != 'substep' && $k != 'step')
+		if ($k !== 'data' && $k !== 'substep' && $k !== 'step')
 		{
 			$upcontext['query_string'] .= ';' . $k . '=' . $v;
 		}
@@ -1818,7 +1820,7 @@ function nextSubstep($substep)
 }
 
 /**
- * Step 0 if running from the CLI, similar to welcome from the GUI
+ * Step 0 if running from the CLI
  *
  * Preforms several checks to make sure the appropriate files are available to do the updates
  * Validates php and db versions meet the minimum requirements
@@ -1827,10 +1829,7 @@ function nextSubstep($substep)
  */
 function cmdStep0()
 {
-	global $modSettings, $start_time, $db_type, $upcontext, $is_debug;
-
-	// Lots of access and existence checking is needed
-	$fileFunc = \ElkArte\FileFunctions::instance();
+	global $modSettings, $start_time, $databases, $db_type, $upcontext, $is_debug;
 
 	$start_time = time();
 
@@ -1866,7 +1865,7 @@ function cmdStep0()
 		{
 			$_POST['backup'] = 1;
 		}
-		elseif ($arg === '--template' && (file_exists(BOARDDIR . '/template.php') || file_exists(BOARDDIR . '/template.html') && !file_exists($modSettings['theme_dir'] . '/converted')))
+		elseif ($arg === '--template' && ((file_exists(BOARDDIR . '/template.php') || file_exists(BOARDDIR . '/template.html')) && !file_exists($modSettings['theme_dir'] . '/converted')))
 		{
 			$_GET['conv'] = 1;
 		}
@@ -1891,21 +1890,21 @@ Usage: /path/to/php -f ' . basename(__FILE__) . ' -- [OPTION]...
 
 	if (!db_version_check())
 	{
-		print_error('Error: ' . $GLOBALS['databases'][$db_type]['name'] . ' ' . $GLOBALS['databases'][$db_type]['version'] . ' does not match minimum requirements.', true);
+		print_error('Error: ' . $databases[$db_type]['name'] . ' ' . $databases[$db_type]['version'] . ' does not match minimum requirements.', true);
 	}
 
 	$db = load_database();
 
 	$db->skip_next_error();
-	if (!empty($GLOBALS['databases'][$db_type]['alter_support'])
+	if (!empty($databases[$db_type]['alter_support'])
 		&& $db->query('', '	ALTER TABLE {db_prefix}log_digest ORDER BY id_topic', array()) === false)
 	{
-		print_error('Error: The ' . $GLOBALS['databases'][$db_type]['name'] . ' account in Settings.php does not have sufficient privileges.', true);
+		print_error('Error: The ' . $databases[$db_type]['name'] . ' account in Settings.php does not have sufficient privileges.', true);
 	}
 
-	$check = $fileFunc->fileExists($modSettings['theme_dir'] . '/index.template.php')
-		&& $fileFunc->fileExists(SOURCEDIR . '/QueryString.php')
-		&& $fileFunc->fileExists(SOURCEDIR . '/ElkArte/AdminController/ManageBoards.controller.php');
+	$check = @file_exists($modSettings['theme_dir'] . '/index.template.php')
+		&& @file_exists(SOURCEDIR . '/QueryString.php')
+		&& @file_exists(SOURCEDIR . '/ManageBoards.controller.php');
 	if (!$check && !isset($modSettings['elkVersion']))
 	{
 		print_error('Error: Some files are missing or out-of-date.', true);
@@ -1914,64 +1913,96 @@ Usage: /path/to/php -f ' . basename(__FILE__) . ' -- [OPTION]...
 	// Do a quick version spot check.
 	$temp = substr(@implode('', @file(BOARDDIR . '/bootstrap.php')), 0, 4096);
 	preg_match('~\*\s@version\s+(.+)~i', $temp, $match);
-	if (empty($match[1]) || $match[1] != CURRENT_VERSION)
+	if (empty($match[1]) || $match[1] !== CURRENT_VERSION)
 	{
 		print_error('Error: Some files have not yet been updated properly.');
 	}
 
 	// Make sure Settings.php is writable.
-	if ($fileFunc->chmod(BOARDDIR . '/Settings.php') === false)
+	if (!is_writable(BOARDDIR . '/Settings.php'))
+	{
+		@chmod(BOARDDIR . '/Settings.php', 0777);
+	}
+
+	if (!is_writable(BOARDDIR . '/Settings.php'))
 	{
 		print_error('Error: Unable to obtain write access to "Settings.php".', true);
 	}
 
-	// Make sure Settings.bak.php is writable.
-	if ($fileFunc->chmod(BOARDDIR . '/Settings_bak.php') === false)
+	// Make sure Settings.php is writable.
+	if (!is_writable(BOARDDIR . '/Settings_bak.php'))
+	{
+		@chmod(BOARDDIR . '/Settings_bak.php', 0777);
+	}
+
+	if (!is_writable(BOARDDIR . '/Settings_bak.php'))
 	{
 		print_error('Error: Unable to obtain write access to "Settings_bak.php".');
 	}
 
+	if (isset($modSettings['agreement']) && (!is_writable(BOARDDIR) || file_exists(BOARDDIR . '/agreement.txt')) && !is_writable(BOARDDIR . '/agreement.txt'))
+	{
+		print_error('Error: Unable to obtain write access to "agreement.txt".');
+	}
+	elseif (isset($modSettings['agreement']))
+	{
+		$fp = fopen(BOARDDIR . '/agreement.txt', 'wb');
+		fwrite($fp, $modSettings['agreement']);
+		fclose($fp);
+	}
+
 	// Make sure themes is writable.
-	if ($fileFunc->chmod($modSettings['theme_dir']) === false)
+	if (!is_writable($modSettings['theme_dir']))
+	{
+		@chmod($modSettings['theme_dir'], 0777);
+	}
+
+	if (!isset($modSettings['elkVersion']) && !is_writable($modSettings['theme_dir']))
 	{
 		print_error('Error: Unable to obtain write access to "themes".');
 	}
 
 	// Make sure cache directory exists and is writable!
 	$CACHEDIR_temp = !defined('CACHEDIR') ? BOARDDIR . '/cache' : CACHEDIR;
-	if (!$fileFunc->createDirectory($CACHEDIR_temp))
+	if (!file_exists($CACHEDIR_temp))
+	{
+		if (!mkdir($CACHEDIR_temp) && !is_dir($CACHEDIR_temp))
+		{
+			return throw_error(sprintf('The cache directory "%s" could not be created.<br /><br />Please make sure you have a directory called &quot;cache&quot; in your forum directory before continuing.', $CACHEDIR_temp));
+		}
+	}
+
+	if (!is_writable($CACHEDIR_temp))
+	{
+		@chmod($CACHEDIR_temp, 0777);
+	}
+
+	if (!is_writable($CACHEDIR_temp))
 	{
 		print_error('Error: Unable to obtain write access to "cache".', true);
 	}
 
-	// Make sure the custom avatar directory exists and is writable!
-	$custom_avatar_dir = !empty($modSettings['custom_avatar_dir']) ? $modSettings['custom_avatar_dir'] : BOARDDIR . '/avatars_user';
-	if (!$fileFunc->createDirectory($custom_avatar_dir))
-	{
-		print_error('Error: Unable to obtain write access to "' . $custom_avatar_dir . '"', true);
-	}
-
-	if (!$fileFunc->fileExists(SOURCEDIR . '/ElkArte/Languages/Index/' . $upcontext['language'] . '.php') && !isset($modSettings['elkVersion'], $_GET['lang']))
+	if (!file_exists($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/index.' . $upcontext['language'] . '.php') && !isset($modSettings['elkVersion']) && !isset($_GET['lang']))
 	{
 		print_error('Error: Unable to find language files!', true);
 	}
 	else
 	{
-		$temp = substr(@implode('', @file(SOURCEDIR . '/ElkArte/Languages/Index/' . $upcontext['language'] . '.php')), 0, 4096);
+		$temp = substr(@implode('', @file($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/index.' . $upcontext['language'] . '.php')), 0, 4096);
 		preg_match('~(?://|/\*)\s*Version:\s+(.+?);\s*index(?:[\s]{2}|\*/)~i', $temp, $match);
 
-		if (empty($match[1]) || $match[1] != CURRENT_LANG_VERSION)
+		if (empty($match[1]) || $match[1] !== CURRENT_LANG_VERSION)
 		{
 			print_error('Error: Language files out of date.', true);
 		}
 
-		if (!$fileFunc->fileExists(SOURCEDIR . '/ElkArte/Languages/Install/' . $upcontext['language'] . '.php'))
+		if (!file_exists($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/Install.' . $upcontext['language'] . '.php'))
 		{
 			print_error('Error: Install language is missing for selected language.', true);
 		}
 
-		// Otherwise, include it!
-		require_once(SOURCEDIR . '/ElkArte/Languages/Install/' . $upcontext['language'] . '.php');
+		// Otherwise include it!
+		require_once($modSettings['theme_dir'] . '/languages/' . $upcontext['language'] . '/Install.' . $upcontext['language'] . '.php');
 	}
 
 	// Make sure we skip the HTML for login.
@@ -1982,8 +2013,8 @@ Usage: /path/to/php -f ' . basename(__FILE__) . ' -- [OPTION]...
 /**
  * Displays an error on standard out for cli viewing, optionally ends execution
  *
- * @param string $message
- * @param boolean $fatal
+ * @param string  $message
+ * @param bool $fatal
  */
 function print_error($message, $fatal = false)
 {
@@ -2034,7 +2065,7 @@ function loadEssentialFunctions()
 	{
 		function cache_put_data($val)
 		{
-
+			// Dummy function
 		}
 	}
 
@@ -2043,22 +2074,20 @@ function loadEssentialFunctions()
 		function un_htmlspecialchars($string)
 		{
 			$string = htmlspecialchars_decode($string, ENT_QUOTES);
+
 			return str_replace('&nbsp;', ' ', $string);
 		}
 	}
 
 	if (!function_exists('text2words'))
 	{
-		function text2words($text)
+		function text2words($text, $max_chars = 20)
 		{
-			// Step 0: prepare numbers, so they are good for search & index 1000.45 -> 1000_45
-			$words = preg_replace('~([\d]+)[.-/]+(?=[\d])~u', '$1_', $text);
-
 			// Step 1: Remove entities/things we don't consider words:
-			$words = preg_replace('~(?:[\x0B\0\x{A0}\t\r\s\n(){}\\[\\]<>!@$%^*.,:+=`\~\?/\\\\]+|&(?:amp|lt|gt|quot);)+~u', ' ', strtr($words, array('<br />' => ' ')));
+			$words = preg_replace('~(?:[\x0B\0\x{A0}\t\r\s\n(){}\\[\\]<>!@$%^*.,:+=`\~\?/\\\\]+|&(?:amp|lt|gt|quot);)+~u', ' ', strtr($text, array('<br />' => ' ')));
 
 			// Step 2: Entities we left to letters, where applicable, lowercase.
-			$words = un_htmlspecialchars(ElkArte\Util::strtolower($words));
+			$words = un_htmlspecialchars(Util::strtolower($words));
 
 			// Step 3: Ready to split apart and index!
 			$words = explode(' ', $words);
@@ -2069,7 +2098,7 @@ function loadEssentialFunctions()
 			{
 				if (($word = trim($word, '-_\'')) !== '')
 				{
-					$returned_words[] = substr($word, 0, 20);
+					$returned_words[] = $max_chars === null ? $word : substr($word, 0, $max_chars);
 				}
 			}
 
@@ -2093,7 +2122,7 @@ function loadEssentialFunctions()
 			$dh = opendir(CACHEDIR);
 			while ($file = readdir($dh))
 			{
-				if ($file !== '.' && $file !== '..' && $file !== 'index.php' && $file !== '.htaccess' && (!$type || substr($file, 0, strlen($type)) == $type))
+				if ($file !== '.' && $file !== '..' && $file !== 'index.php' && $file !== '.htaccess' && (!$type || strpos($file, $type) === 0))
 				{
 					@unlink(CACHEDIR . '/' . $file);
 				}
@@ -2102,7 +2131,7 @@ function loadEssentialFunctions()
 
 			// Invalidate cache, to be sure!
 			// ... as long as Load.php can be modified, anyway.
-			@touch(SOURCEDIR . '/index.php');
+			@touch(SOURCEDIR . '/Load.php');
 			clearstatcache();
 		}
 	}
@@ -2121,12 +2150,12 @@ function loadEssentialFunctions()
 
 function discoverCollation()
 {
-	global $db_type, $db_prefix;
+	global $databases, $db_type, $db_prefix, $db_connection;
 
 	$db_collation = '';
 
 	// If we're on MySQL supporting collations then let's find out what the members table uses and put it in a global var - to allow upgrade script to match collations!
-	if (!empty($GLOBALS['databases'][$db_type]['test_collation']))
+	if (!empty($databases[$db_type]['utf8_support']) && version_compare($databases[$db_type]['utf8_version'], $databases[$db_type]['utf8_version_check']($db_connection), '>'))
 	{
 		$db = load_database();
 
@@ -2138,12 +2167,13 @@ function discoverCollation()
 				'table_name' => "{$db_prefix}members",
 			)
 		);
-		if ($request->num_rows() == 0)
+		if ($db->num_rows($request) == 0)
 		{
 			die('Unable to find members table!');
 		}
-		$table_status = $request->fetch_assoc();
-		$request->free_result();
+
+		$table_status = $db->fetch_assoc($request);
+		$db->free_result($request);
 
 		if (!empty($table_status['Collation']))
 		{
@@ -2155,12 +2185,13 @@ function discoverCollation()
 					'collation' => $table_status['Collation'],
 				)
 			);
+
 			// Got something?
-			if ($request->num_rows() != 0)
+			if ($db->num_rows($request) != 0)
 			{
-				$collation_info = $request->fetch_assoc();
+				$collation_info = $db->fetch_assoc($request);
 			}
-			$request->free_result();
+			$db->free_result($request);
 
 			// Excellent!
 			if (!empty($collation_info['Collation']) && !empty($collation_info['Charset']))

--- a/release_tools/build.sh
+++ b/release_tools/build.sh
@@ -1,24 +1,26 @@
 #!/bin/bash
+
 #
 # Time to create an ElkArte build
 # Command example:
-#   sh release_tools/build.sh development 1.1 beta
-#   sh release_tools/build.sh development 1.1 beta2
+#  bash release_tools/build.sh development 2.0 beta
+#
+# @version 2.0 dev
 
 # First things first: check dependencies
 command -v git >/dev/null 2>&1 || { echo >&2 "git is required but it's not installed.  Aborting."; exit 1; }
 command -v zip >/dev/null 2>&1 || { echo >&2 "zip is required but it's not installed.  Aborting."; exit 1; }
 
-if [[ "$5" = "sec" ]]
+if [[ ! -z "$5" && "$5" = "sec" ]]
 	then
 		REPO="git@bitbucket.org:elkartesecurity/elkarte.git"
 	else
-		REPO="http://github.com/ElkArte/ElkArte.git"
+		REPO="https://github.com/ElkArte/ElkArte.git"
 fi
 
 BRANCH=$1
 VERSION=$2
-if [[ $4 && ${4-_} ]]
+if [[ ! -z $4 && ${4-_} ]]
 	then
 		SUBVERSION="$3-$4"
 	else
@@ -39,6 +41,7 @@ rm -rf ./release_tools
 rm -rf ./tests
 rm -rf ./.git
 rm -rf ./install/patch*
+rm -rf ./.github
 rm composer.json
 rm composer.lock
 rm CONTRIBUTING.md
@@ -48,7 +51,13 @@ rm .gitattributes
 rm .gitignore
 rm .scrutinizer.yml
 rm .travis.yml
+rm .jshintignore
+rm .jshintrc
+rm .stylelintignore
+rm .stylelintrc
+rm .codecov.yml
 
-zip "../ElkArte_v${VERSION//[.]/-}-$SUBVERSION""_install.zip" -r ./
+zip "../ElkArte_v${VERSION//./-}-${SUBVERSION}_install.zip" -r -q ./
+echo "Zip file created."
 cd ..
 rm -rf "./$VERSION""_""$SUBVERSION"

--- a/release_tools/generate_detailed-version.php
+++ b/release_tools/generate_detailed-version.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * @package   ElkArte Forum
+ * @name      ElkArte Forum
  * @copyright ElkArte Forum contributors
- * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause
  *
  * @version 2.0 dev
  *
@@ -12,7 +12,7 @@
 $output_file_name = 'detailed-version.js';
 if (empty($argv[1]) && empty($_GET['b']))
 {
-	echo "Please specify a branch to compare against master\n";
+	echo "Please specify a branch to compare against master, (for example: b=patch_1-1-9)\n";
 	die();
 }
 else
@@ -22,7 +22,7 @@ else
 
 if (empty($argv[2]) && empty($_GET['v']))
 {
-	echo "Please specify a version\n";
+	echo "Please specify a version to check (for example v=1.1.9)\n";
 	die();
 }
 else
@@ -32,8 +32,8 @@ else
 
 // Some constants and $settings needed to let getFileVersions do it's magic
 DEFINE('ELK', '1');
-DEFINE('BOARDDIR', dirname(__FILE__));
-DEFINE('LANGUAGEDIR', SOURCEDIR . '/ElkArte/Languages');
+DEFINE('BOARDDIR', __DIR__);
+DEFINE('LANGUAGEDIR', BOARDDIR . '/themes/default/languages');
 DEFINE('SOURCEDIR', BOARDDIR . '/sources');
 DEFINE('ADMINDIR', SOURCEDIR . '/admin');
 DEFINE('EXTDIR', SOURCEDIR . '/ext');
@@ -57,6 +57,7 @@ $versionOptions = array(
 $version_info = getFileVersions($versionOptions);
 
 // Use git to get our list of file changed by commit
+echo 'Getting changed files from branch ' . $new_release . ' compared to master branch<br>';
 $changed_files_list = getFilesChanged('master', $new_release);
 $update_files = array();
 
@@ -67,13 +68,15 @@ foreach ($index_lines as $line)
 {
 	if (strpos($line, 'define(\'FORUM_VERSION') !== false)
 	{
-		preg_match('~\'(ElkArte .*)\'\);$~', $line, $matches);
+		preg_match('~\'ElkArte (.*)\'\);$~', $line, $matches);
 		$forum_version = $matches[1];
 		break;
 	}
 }
 
-$handle = fopen($output_file_name, 'w');
+echo 'Checking Changed File headers match expected ' . $forum_version . '<br>';
+
+$handle = fopen($output_file_name, 'wb');
 
 // Start with the common thing
 fwrite($handle, 'window.ourVersions = {');
@@ -83,7 +86,7 @@ foreach (array('admin', 'controllers', 'database', 'subs') as $type)
 {
 	foreach ($version_info['file_versions_' . $type] as $file => $ver)
 	{
-		if ($new_version == $ver)
+		if ($new_version === $ver)
 		{
 			$update_files[] = str_replace('subssubs', 'subs', $type . $file);
 		}
@@ -93,7 +96,7 @@ foreach (array('admin', 'controllers', 'database', 'subs') as $type)
 
 foreach ($version_info['file_versions_modules'] as $file => $ver)
 {
-	if ($new_version == $ver)
+	if ($new_version === $ver)
 	{
 		$update_files[] = 'sources' . $file;
 	}
@@ -102,7 +105,7 @@ foreach ($version_info['file_versions_modules'] as $file => $ver)
 
 foreach ($version_info['file_versions'] as $file => $ver)
 {
-	if ($new_version == $ver)
+	if ($new_version === $ver)
 	{
 		$update_files[] = 'sources' . $file;
 	}
@@ -111,7 +114,7 @@ foreach ($version_info['file_versions'] as $file => $ver)
 
 foreach ($version_info['default_template_versions'] as $file => $ver)
 {
-	if ($new_version == $ver)
+	if ($new_version === $ver)
 	{
 		$update_files[] = 'default' . $file;
 	}
@@ -124,7 +127,7 @@ fwrite($handle, "\n\nourLanguageVersions = {\n");
 
 foreach ($version_info['default_language_versions'] as $lang => $files)
 {
-	if ($lang == 'english')
+	if ($lang === 'english')
 	{
 		foreach ($files as $file => $ver)
 		{
@@ -136,7 +139,6 @@ foreach ($version_info['default_language_versions'] as $lang => $files)
 
 // And that's all folks!
 fwrite($handle, '};');
-
 fclose($handle);
 if (count(array_diff($update_files, $changed_files_list)) !== 0)
 {
@@ -165,6 +167,10 @@ if (count(array_diff($changed_files_list, $update_files)) !== 0)
 		echo implode('<br>', array_diff($changed_files_list, $update_files));
 	}
 }
+else
+{
+	echo 'Successfully created detailed-version.js!';
+}
 
 /**
  * Get the listing of changed files between two releases
@@ -178,7 +184,9 @@ function getFilesChanged($from, $to)
 {
 	global $settings;
 
-	$output = shell_exec('git diff --name-only --pretty=oneline --full-index ' . $from . '..' . $to . ' | sort | uniq');
+	echo 'Running Command: git diff --name-only --pretty=oneline --full-index ElkArte/' . $from . '..ElkArte/' . $to . ' | sort | uniq<br>';
+
+	$output = shell_exec('git diff --name-only --pretty=oneline --full-index ElkArte/' . $from . '..ElkArte/' . $to . ' | sort | uniq');
 	if (empty($output))
 	{
 		echo "The git command failed to return any results\n";
@@ -200,6 +208,11 @@ function getFilesChanged($from, $to)
 	foreach ($files as $file)
 	{
 		if ($file[0] === '.')
+		{
+			continue;
+		}
+
+		if (strpos($file, 'README') !== false)
 		{
 			continue;
 		}
@@ -298,6 +311,8 @@ function getFilesChanged($from, $to)
 
 		$list[] = strtr($file, $dirs);
 	}
+
+	echo 'Found '. count($list) . ' Changed Files<br>';
 
 	return $list;
 }

--- a/sources/ElkArte/AdminController/ManageAttachments.php
+++ b/sources/ElkArte/AdminController/ManageAttachments.php
@@ -324,7 +324,13 @@ class ManageAttachments extends AbstractController
 		$image = new Image($settings['default_theme_dir'] . '/images/blank.png');
 		$testImg = Gd2::canUse() || Imagick::canUse();
 		$testImgRotate = Imagick::canUse() || (Gd2::canUse() && function_exists('exif_read_data'));
+
+		// Check on webp support, and correct if wrong
 		$testWebP = $image->hasWebpSupport();
+		if (!$testWebP && !empty($modSettings['attachment_webp_enable']))
+		{
+			updateSettings(['attachment_webp_enable' => 0]);
+		}
 
 		// Check if the server settings support these upload size values
 		$post_max_size = ini_get('post_max_size');
@@ -609,6 +615,7 @@ class ManageAttachments extends AbstractController
 			),
 			'list_menu' => array(
 				'show_on' => 'top',
+				'class' => 'flow_flex_right',
 				'links' => array(
 					array(
 						'href' => getUrl('admin', ['action' => 'admin', 'area' => 'manageattachments', 'sa' => 'browse']),

--- a/sources/ElkArte/AdminController/ManageBans.php
+++ b/sources/ElkArte/AdminController/ManageBans.php
@@ -238,7 +238,6 @@ class ManageBans extends AbstractController
 							{
 								return sprintf('<span class="error">%1$s</span>', $txt['ban_expired']);
 							}
-
 							// Still need to wait a few days for this ban to expire.
 							else
 							{
@@ -297,8 +296,8 @@ class ManageBans extends AbstractController
 			),
 			'additional_rows' => array(
 				array(
-					'class' => 'submitbutton',
-					'position' => 'bottom_of_list',
+					'class' => 'submitbutton flow_flex_additional_row',
+					'position' => 'below_table_data',
 					'value' => '<input type="submit" name="removeBans" value="' . $txt['ban_remove_selected'] . '" onclick="return confirm(\'' . $txt['ban_remove_selected_confirm'] . '\');" />',
 				),
 			),
@@ -1030,32 +1029,33 @@ class ManageBans extends AbstractController
 			),
 			'additional_rows' => array(
 				array(
-					'class' => 'submitbutton',
-					'position' => 'bottom_of_list',
+					'class' => 'submitbutton flow_flex_additional_row',
+					'position' => 'below_table_data',
 					'value' => '<input type="submit" name="remove_triggers" value="' . $txt['ban_remove_selected_triggers'] . '" onclick="return confirm(\'' . $txt['ban_remove_selected_triggers_confirm'] . '\');" />',
 				),
 			),
 			'list_menu' => array(
 				'show_on' => 'top',
+				'class' => 'flow_flex_right',
 				'links' => array(
 					array(
 						'href' => getUrl('admin', ['action' => 'admin', 'area' => 'ban', 'sa' => 'browse', 'entity' => 'ip']),
-						'is_selected' => $context['selected_entity'] == 'ip',
+						'is_selected' => $context['selected_entity'] === 'ip',
 						'label' => $txt['ip']
 					),
 					array(
 						'href' => getUrl('admin', ['action' => 'admin', 'area' => 'ban', 'sa' => 'browse', 'entity' => 'hostname']),
-						'is_selected' => $context['selected_entity'] == 'hostname',
+						'is_selected' => $context['selected_entity'] === 'hostname',
 						'label' => $txt['hostname']
 					),
 					array(
 						'href' => getUrl('admin', ['action' => 'admin', 'area' => 'ban', 'sa' => 'browse', 'entity' => 'email']),
-						'is_selected' => $context['selected_entity'] == 'email',
+						'is_selected' => $context['selected_entity'] === 'email',
 						'label' => $txt['email']
 					),
 					array(
 						'href' => getUrl('admin', ['action' => 'admin', 'area' => 'ban', 'sa' => 'browse', 'entity' => 'member']),
-						'is_selected' => $context['selected_entity'] == 'member',
+						'is_selected' => $context['selected_entity'] === 'member',
 						'label' => $txt['username']
 					)
 				),

--- a/sources/ElkArte/AdminController/ManageBoards.php
+++ b/sources/ElkArte/AdminController/ManageBoards.php
@@ -20,6 +20,7 @@ use BBC\ParserWrapper;
 use ElkArte\AbstractController;
 use ElkArte\Action;
 use ElkArte\BoardsTree;
+use ElkArte\Converters\Html2BBC;
 use ElkArte\Exceptions\Exception;
 use ElkArte\SettingsForm\SettingsForm;
 use ElkArte\Languages\Txt;
@@ -562,7 +563,9 @@ class ManageBoards extends AbstractController
 			// Change '1 & 2' to '1 &amp; 2', but not '&amp;' to '&amp;amp;'...
 			$boardOptions['board_name'] = preg_replace('~[&]([^;]{8}|[^;]{0,8}$)~', '&amp;$1', $this->_req->post->board_name);
 
-			$boardOptions['board_description'] = Util::htmlspecialchars($this->_req->post->desc);
+			// Convert any html to bbc
+			$parser = new Html2BBC($this->_req->post->desc);
+			$boardOptions['board_description'] = Util::htmlspecialchars($parser->get_bbc());
 			preparsecode($boardOptions['board_description']);
 
 			$boardOptions['moderator_string'] = $this->_req->post->moderators;
@@ -940,7 +943,7 @@ class ManageBoards extends AbstractController
 		$config_vars = array(
 			array('title', 'settings'),
 			// Inline permissions.
-			array('permissions', 'manage_boards', 'helptext' => $txt['permissionhelp_manage_boards']),
+			array('permissions', 'manage_boards', 'helptext' => $txt['permissionhelp_manage_boards'], 'collapsed' => true),
 			'',
 			// Other board settings.
 			array('check', 'countChildPosts'),

--- a/sources/ElkArte/AdminController/ManageMembers.php
+++ b/sources/ElkArte/AdminController/ManageMembers.php
@@ -147,15 +147,15 @@ class ManageMembers extends AbstractController
 					'label' => sprintf($txt['admin_browse_awaiting_approval'], $context['awaiting_approval']),
 					'description' => $txt['admin_browse_approve_desc'],
 					'url' => getUrl('admin', ['action' => 'admin', 'area' => 'viewmembers', 'sa' => 'browse', 'type' => 'approve']),
-					'disabled' => !$context['show_approve'] && ($subAction !== 'browse' || $this->_req->query->type !== 'approve'),
-					'selected' => ($subAction !== 'browse' || $this->_req->query->type === 'approve'),
+					'disabled' => !$context['show_approve'] && ($subAction !== 'browse' || $this->_req->getQuery('type') !== 'approve'),
+					'selected' => $subAction === 'browse' && $this->_req->getQuery('type') === 'approve',
 				],
 				'activate' => [
 					'label' => sprintf($txt['admin_browse_awaiting_activate'], $context['awaiting_activation']),
 					'description' => $txt['admin_browse_activate_desc'],
 					'url' => getUrl('admin', ['action' => 'admin', 'area' => 'viewmembers', 'sa' => 'browse', 'type' => 'activate']),
 					'disabled' => !$context['show_activate'] && ($subAction !== 'browse' || $this->_req->query->type !== 'activate'),
-					'selected' => ($subAction !== 'browse' || $this->_req->query->type === 'activate'),
+					'selected' => $subAction === 'browse' && $this->_req->getQuery('type') === 'activate',
 				],
 			]
 		]);

--- a/sources/ElkArte/AdminController/ManagePaid.php
+++ b/sources/ElkArte/AdminController/ManagePaid.php
@@ -91,6 +91,11 @@ class ManagePaid extends AbstractController
 			'title' => 'paid_subscriptions',
 			'description' => 'paid_subscriptions_desc',
 			'prefix' => 'paid_subs',
+			'tabs' => [
+				'view' => [
+					'disabled' => empty($modSettings['paid_currency_symbol']),
+				],
+			],
 		]);
 
 		// Call the right function for this sub-action.
@@ -123,7 +128,6 @@ class ManagePaid extends AbstractController
 		$context['page_title'] = $txt['settings'];
 		$context['sub_template'] = 'show_settings';
 		$context['settings_message'] = replaceBasicActionUrl($txt['paid_note']);
-		$context[$context['admin_menu_name']]['current_subsection'] = 'settings';
 
 		// Get the final touches in place.
 		$context['post_url'] = getUrl('admin', ['action' => 'admin', 'area' => 'paidsubscribe', 'save', 'sa' => 'settings']);

--- a/sources/ElkArte/AdminController/ManagePermissions.php
+++ b/sources/ElkArte/AdminController/ManagePermissions.php
@@ -1041,7 +1041,7 @@ class ManagePermissions extends AbstractController
 		$config_vars = array(
 			array('title', 'settings'),
 			// Inline permissions.
-			array('permissions', 'manage_permissions'),
+			array('permissions', 'manage_permissions', 'collapsed' => true),
 			'',
 			// A few useful settings
 			array('check', 'permission_enable_deny'),

--- a/sources/ElkArte/AdminController/ManageRegistration.php
+++ b/sources/ElkArte/AdminController/ManageRegistration.php
@@ -344,19 +344,19 @@ class ManageRegistration extends AbstractController
 		global $txt, $context, $modSettings;
 
 		// By default we look at Languages/PrivacyPolicy/English.txt.
-		$context['current_agreement'] = '';
+		$context['current_agreement'] = 'English';
 
 		// Is there more than one to edit?
 		$context['editable_agreements'] = array('' => $txt['admin_agreement_default']);
 
-		// Get our languages.
+		// Get our installed languages.
 		$languages = getLanguages();
 
 		// Try to figure out if we have more agreements.
 		$fileFunc = FileFunctions::instance();
 		foreach ($languages as $lang)
 		{
-			if ($fileFunc->fileExists(SOURCEDIR . '/ElkArte/Languages/PrivacyPolicy/' . $lang['filename'] . '.txt'))
+			if ($fileFunc->fileExists(SOURCEDIR . '/ElkArte/Languages/PrivacyPolicy/' . $lang['name'] . '.txt'))
 			{
 				$context['editable_agreements'][$lang['filename']] = $lang['name'];
 

--- a/sources/ElkArte/AdminController/ManageSearchEngines.php
+++ b/sources/ElkArte/AdminController/ManageSearchEngines.php
@@ -265,7 +265,7 @@ class ManageSearchEngines extends AbstractController
 					),
 					'data' => array(
 						'function' => function ($rowData) {
-							return sprintf('<a href=' . getUrl('admin', ['action' => 'admin', 'area' => 'sengines', 'sa' => 'editspiders', 'sid' => $rowData['id_spider']]) . '">%2$s</a>', htmlspecialchars($rowData['spider_name'], ENT_COMPAT, 'UTF-8'));
+							return sprintf('<a href=' . getUrl('admin', ['action' => 'admin', 'area' => 'sengines', 'sa' => 'editspiders', 'sid' => $rowData['id_spider']]) . '">%1$s</a>', htmlspecialchars($rowData['spider_name'], ENT_COMPAT, 'UTF-8'));
 						},
 					),
 					'sort' => array(

--- a/sources/ElkArte/AdminController/ManageServer.php
+++ b/sources/ElkArte/AdminController/ManageServer.php
@@ -295,7 +295,7 @@ class ManageServer extends AbstractController
 			call_integration_hook('integrate_save_cookie_settings');
 
 			// Its either local or global cookies
-			if (!empty($this->_req->post->localCookies) && empty($this->_req->post->globalCookies))
+			if (!empty($this->_req->post->localCookies) && !empty($this->_req->post->globalCookies))
 			{
 				unset($this->_req->post->globalCookies);
 			}
@@ -303,6 +303,11 @@ class ManageServer extends AbstractController
 			if (!empty($this->_req->post->globalCookiesDomain) && strpos($boardurl, $this->_req->post->globalCookiesDomain) === false)
 			{
 				throw new Exception('invalid_cookie_domain', false);
+			}
+
+			if ($this->_req->getPost('cookiename', 'trim', '') === '')
+			{
+				$this->_req->post->cookiename = $cookiename;
 			}
 
 			$settingsForm->setConfigValues((array) $this->_req->post);

--- a/sources/ElkArte/Agreement.php
+++ b/sources/ElkArte/Agreement.php
@@ -149,13 +149,19 @@ class Agreement
 	}
 
 	/**
-	 * Retrieves the BBC-parsed version of the agreement.
+	 * Checks to see if the file exists and is writable
 	 *
-	 * If the language passed to the class is empty, then it uses Agreement/English.txt.
+	 * If the file does not exist, attempts to create it.
 	 */
 	public function isWritable()
 	{
 		$filename = $this->buildName($this->_language);
+
+		if (!$this->fileFunc->fileExists($filename) && !$this->fileFunc->isDir($filename))
+		{
+			touch($this->fileFunc->fileExists($filename));
+			$this->fileFunc->chmod($filename);
+		}
 
 		return $this->fileFunc->fileExists($filename) && $this->fileFunc->isWritable($filename);
 	}
@@ -257,6 +263,12 @@ class Agreement
 		return true;
 	}
 
+	/**
+	 * Builds the name and location of the file
+	 *
+	 * @param string $language
+	 * @return string
+	 */
 	protected function buildName($language)
 	{
  		return SOURCEDIR . '/ElkArte/Languages/' . $this->_file_name . '/' . $language . '.txt';

--- a/sources/ElkArte/Controller/Display.php
+++ b/sources/ElkArte/Controller/Display.php
@@ -867,10 +867,10 @@ class Display extends AbstractController
 		}
 
 		// Cleanup all the permissions with extra stuff...
-		$context['can_mark_notify'] &= !$context['user']['is_guest'];
-		$context['can_reply'] &= empty($this->topicinfo['locked']) || allowedTo('moderate_board');
-		$context['can_reply_unapproved'] &= $modSettings['postmod_active'] && (empty($this->topicinfo['locked']) || allowedTo('moderate_board'));
-		$context['can_issue_warning'] &= featureEnabled('w') && !empty($modSettings['warning_enable']);
+		$context['can_mark_notify'] = $context['can_mark_notify'] && !$context['user']['is_guest'];
+		$context['can_reply'] = $context['can_reply'] && (empty($this->topicinfo['locked']) || allowedTo('moderate_board'));
+		$context['can_reply_unapproved'] = $context['can_reply_unapproved'] && $modSettings['postmod_active'] && (empty($this->topicinfo['locked']) || allowedTo('moderate_board'));
+		$context['can_issue_warning'] = $context['can_issue_warning']  && featureEnabled('w') && !empty($modSettings['warning_enable']);
 
 		// Handle approval flags...
 		$context['can_reply_approved'] = $context['can_reply'];
@@ -881,7 +881,7 @@ class Display extends AbstractController
 			$context['can_reply_approved'] = false;
 		}
 
-		$context['can_reply'] |= $context['can_reply_unapproved'];
+		$context['can_reply'] = $context['can_reply'] || $context['can_reply_unapproved'];
 		$context['can_quote'] = $context['can_reply'] && (empty($modSettings['disabledBBC']) || !in_array('quote', explode(',', $modSettings['disabledBBC'])));
 		$context['can_mark_unread'] = $this->user->is_guest === false && $settings['show_mark_read'];
 		$context['can_unwatch'] = $this->user->is_guest === false && $modSettings['enable_unwatch'];
@@ -892,8 +892,8 @@ class Display extends AbstractController
 		$context['can_remove_post'] = allowedTo('delete_any') || (allowedTo('delete_replies') && $this->didThisUserStart());
 
 		// Can restore topic?  That's if the topic is in the recycle board and has a previous restore state.
-		$context['can_restore_topic'] &= !empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] == $board && !empty($this->topicinfo['id_previous_board']);
-		$context['can_restore_msg'] &= !empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] == $board && !empty($this->topicinfo['id_previous_topic']);
+		$context['can_restore_topic'] = $context['can_restore_topic'] && !empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] == $board && !empty($this->topicinfo['id_previous_board']);
+		$context['can_restore_msg'] = $context['can_restore_msg'] && !empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] == $board && !empty($this->topicinfo['id_previous_topic']);
 	}
 
 	/**

--- a/sources/ElkArte/Controller/PersonalMessage.php
+++ b/sources/ElkArte/Controller/PersonalMessage.php
@@ -1252,7 +1252,7 @@ class PersonalMessage extends AbstractController
 			$recipientList[$recipientType] = array_unique($recipientList[$recipientType]);
 		}
 
-		// Are we changing the recipients some how?
+		// Are we changing the recipients somehow?
 		$is_recipient_change = !empty($this->_req->post->delete_recipient) || !empty($this->_req->post->to_submit) || !empty($this->_req->post->bcc_submit);
 
 		// Check if there's at least one recipient.
@@ -2638,7 +2638,7 @@ class PersonalMessage extends AbstractController
 
 		// Drop any non-enabled ones
 		return array_filter($pmButtons, static function ($button) {
-			return !isset($button['enabled']) || $button['enabled'] !== false;
+			return !isset($button['enabled']) || (bool) $button['enabled'] !== false;
 		});
 	}
 

--- a/sources/ElkArte/Controller/Post.php
+++ b/sources/ElkArte/Controller/Post.php
@@ -466,7 +466,7 @@ class Post extends AbstractController
 		// In order to keep the approval status flowing through, we have to pass it through the form...
 		$context['becomes_approved'] = $not_approved;
 		$context['show_approval'] = isset($this->_req->post->approve) ? ($this->_req->post->approve ? 2 : 1) : 0;
-		$context['can_announce'] &= $context['becomes_approved'];
+		$context['can_announce'] = $context['can_announce'] && $context['becomes_approved'];
 
 		// Set up the inputs for the form.
 		$this->_form_subject = strtr(Util::htmlspecialchars($subject), array("\r" => '', "\n" => '', "\t" => ''));

--- a/sources/ElkArte/Converters/Html2BBC.php
+++ b/sources/ElkArte/Converters/Html2BBC.php
@@ -741,7 +741,7 @@ class Html2BBC extends AbstractDomParser
 
 		if (!empty($size))
 		{
-			$bbc = str_replace('[img', '[img ' . $size, $bbc);
+			$bbc = str_replace('[img', '[img ' . trim($size), $bbc);
 		}
 
 		return $bbc;

--- a/sources/ElkArte/Database/AbstractQuery.php
+++ b/sources/ElkArte/Database/AbstractQuery.php
@@ -773,6 +773,7 @@ abstract class AbstractQuery implements QueryInterface
 		{
 			$insertRows[] = $this->quote($insertData, $this->_array_combine($indexed_columns, $dataRow));
 		}
+
 		return [$table, $indexed_columns, $insertRows];
 	}
 

--- a/sources/ElkArte/Database/Mysqli/Connection.php
+++ b/sources/ElkArte/Database/Mysqli/Connection.php
@@ -38,9 +38,6 @@ class Connection implements ConnectionInterface
 
 		$db_server = (!empty($db_options['persist']) ? 'p:' : '') . $db_server;
 
-		// PHP 8.1 default is to throw exceptions, this reverts it to the <=php8 semantics
-		mysqli_report(MYSQLI_REPORT_OFF);
-
 		$connection = @mysqli_connect($db_server, $db_user, $db_passwd, $db_name, $db_port);
 
 		// Something's wrong, show an error if its fatal (which we assume it is)
@@ -54,6 +51,9 @@ class Connection implements ConnectionInterface
 				throw new \Exception('Db initialization failed');
 			}
 		}
+
+		// PHP 8.1 default is to throw exceptions, this reverts it to the <=php8 semantics
+		mysqli_report(MYSQLI_REPORT_OFF);
 
 		$query = new Query($db_prefix, $connection);
 

--- a/sources/ElkArte/GenericList.php
+++ b/sources/ElkArte/GenericList.php
@@ -163,7 +163,7 @@ class GenericList
 			$this->descVar = $this->listOptions['request_vars']['desc'] ?? 'desc';
 			$sortReq = $this->req->getQuery($this->sortVar);
 
-			if (isset($this->listOptions['columns'][$sortReq], $this->listOptions['columns'][$sortReq]['sort']))
+			if (isset($this->listOptions['columns'][$sortReq]['sort']))
 			{
 				$this->context['sort'] = array(
 					'id' => $sortReq,

--- a/sources/ElkArte/Graphics/Image.php
+++ b/sources/ElkArte/Graphics/Image.php
@@ -210,7 +210,7 @@ class Image
 	 */
 	protected function isWebAddress()
 	{
-		return substr($this->_fileName, 0, 7) === 'http://' || substr($this->_fileName, 0, 8) === 'https://';
+		return strpos($this->_fileName, 'http://') === 0 || strpos($this->_fileName, 'https://') === 0;
 	}
 
 	/**
@@ -248,7 +248,7 @@ class Image
 	 */
 	public function isImage()
 	{
-		return substr($this->getMimeType(), 0, 5) === 'image';
+		return strpos($this->getMimeType(), 'image') === 0;
 	}
 
 	/**
@@ -275,7 +275,7 @@ class Image
 		$max_height = max(16, $max_height);
 
 		// Do the actual resize, thumbnails by default strip EXIF data to save space
-		$success = $this->resizeImage($max_width, $max_height, true, $force ?? true);
+		$success = $this->resizeImage($max_width, $max_height, true, $force ?? true, true);
 
 		// Save our work
 		if ($success)
@@ -388,10 +388,11 @@ class Image
 	 * @param int $max_height The maximum allowed height
 	 * @param bool $strip Allow IM to remove exif data as GD always will
 	 * @param bool $force_resize Always resize the image (force scale up)
+	 * @param bool $thumbnail If the image is a small thumbnail version
 	 *
 	 * @return bool Whether the thumbnail creation was successful.
 	 */
-	public function resizeImage($max_width, $max_height, $strip = false, $force_resize = true)
+	public function resizeImage($max_width, $max_height, $strip = false, $force_resize = true, $thumbnail = false)
 	{
 		// Nothing to do without GD or IM or an Image
 		if ($this->_manipulator === null)
@@ -401,7 +402,7 @@ class Image
 
 		try
 		{
-			return $this->_manipulator->resizeImage($max_width, $max_height, $strip, $force_resize);
+			return $this->_manipulator->resizeImage($max_width, $max_height, $strip, $force_resize, $thumbnail);
 		}
 		catch (\Exception $e)
 		{

--- a/sources/ElkArte/Graphics/Manipulators/AbstractManipulator.php
+++ b/sources/ElkArte/Graphics/Manipulators/AbstractManipulator.php
@@ -221,4 +221,28 @@ abstract class AbstractManipulator
 
 		return [round($dst_width), round($dst_height)];
 	}
+
+	/**
+	 * Scale an image to a maximum dimension, maintaining the aspect ratio
+	 *
+	 * @param int $limit max width or height, based on current aspect ratio
+	 * @return int[]
+	 */
+	function imageScaleFactor($limit = 800)
+	{
+		$thumb_w = $limit;
+		$thumb_h = $limit;
+
+		if ($this->_width > $this->_height)
+		{
+			$thumb_h = max (1, $this->_height * ($limit / $this->_width));
+		}
+		// Portrait
+		elseif ($this->_width < $this->_height)
+		{
+			$thumb_w = max(1, $this->_width * ($limit / $this->_height));
+		}
+
+		return [(int) $thumb_w, (int) $thumb_h];
+	}
 }

--- a/sources/ElkArte/Graphics/Manipulators/AbstractManipulator.php
+++ b/sources/ElkArte/Graphics/Manipulators/AbstractManipulator.php
@@ -61,8 +61,9 @@ abstract class AbstractManipulator
 	 * @param int|null $max_height The maximum allowed height
 	 * @param bool $strip Whether to have IM strip EXIF data as GD will
 	 * @param bool $force_resize = false Whether to override defaults and resize it
+	 * @param bool $thumbnail True if creating a simple thumbnail
 	 */
-	abstract public function resizeImage($max_width = null, $max_height = null, $strip = false, $force_resize = true);
+	abstract public function resizeImage($max_width = null, $max_height = null, $strip = false, $force_resize = true, $thumbnail = false);
 
 	/**
 	 * Rotate an image based on its EXIF flag, used to correct for smart phone pictures.

--- a/sources/ElkArte/Graphics/TextImage.php
+++ b/sources/ElkArte/Graphics/TextImage.php
@@ -148,7 +148,7 @@ class TextImage extends Image
 	 *
 	 * @return bool Always returns true.
 	 */
-	public function resizeImage($max_width, $max_height, $strip = false, $force_resize = true)
+	public function resizeImage($max_width, $max_height, $strip = false, $force_resize = true, $thumbnail = false)
 	{
 		return true;
 	}

--- a/sources/ElkArte/Languages/Help/English.php
+++ b/sources/ElkArte/Languages/Help/English.php
@@ -306,7 +306,6 @@ $helptxt['attachment_image_resize_enabled'] = 'Master on/off switch for this fun
 	resize attachment images (.jpg, .png, .gif, .bmp, .webp) to fit within the specified bounds.  The image format 
 	will be maintained unless the resized image is over the specified max allowed file size.  In this event, if 
 	change format is enabled, the system may convert the image to WebP or JPEG for better compression.';
-$helptxt['attachment_image_resize_enabled_size'] = 'or larger than %s KB.';
 $helptxt['attachment_image_resize_reformat'] = '
 	Selecting this option will allow the system to change images into WebP, if available, or JPEG ONLY
 	when necessary.  The system will try to maintain the existing format unless the resized image is in

--- a/sources/ElkArte/Languages/Index/English.php
+++ b/sources/ElkArte/Languages/Index/English.php
@@ -539,6 +539,7 @@ $txt['topic_derived_from'] = 'Topic derived from %1$s';
 $txt['edit'] = 'Edit';
 $txt['quick_edit'] = 'Quick Edit';
 $txt['post_options'] = 'More...';
+$txt['quote_expand'] = 'Show Quote';
 
 $txt['set_sticky'] = 'Pin';
 $txt['set_nonsticky'] = 'Unpin';

--- a/sources/ElkArte/Mail/Mail.php
+++ b/sources/ElkArte/Mail/Mail.php
@@ -274,7 +274,20 @@ class Mail extends BaseMail
 		global $txt;
 
 		// Try to connect to the SMTP server... if it doesn't exist, only wait three seconds.
-		$socket = fsockopen($smtp_host, $smtp_port, $errno, $errstr, 3);
+		set_error_handler(static function () { /* ignore errors */ });
+		try
+		{
+			$socket = fsockopen($smtp_host, $smtp_port, $errno, $errstr, 3);
+		}
+		catch (\Exception $e)
+		{
+			$socket = false;
+		}
+		finally
+		{
+			restore_error_handler();
+		}
+
 		if (!is_resource($socket))
 		{
 			// Maybe we can still save this?  The port might be wrong.

--- a/sources/ElkArte/MessagesCallback/DisplayRenderer.php
+++ b/sources/ElkArte/MessagesCallback/DisplayRenderer.php
@@ -272,7 +272,7 @@ class DisplayRenderer extends Renderer
 
 		// Drop any non-enabled ones
 		$postButtons = array_filter($postButtons, static function ($button) {
-			return !isset($button['enabled']) || $button['enabled'] !== false;
+			return !isset($button['enabled']) || (bool) $button['enabled'] !== false;
 		});
 
 		return ['postbuttons' => $postButtons];

--- a/sources/ElkArte/MessagesCallback/PmRenderer.php
+++ b/sources/ElkArte/MessagesCallback/PmRenderer.php
@@ -212,7 +212,7 @@ class PmRenderer extends Renderer
 
 		// Drop any non-enabled ones
 		$pmButtons = array_filter($pmButtons, static function ($button) {
-			return !isset($button['enabled']) || $button['enabled'] !== false;
+			return !isset($button['enabled']) || (bool) $button['enabled'] !== false;
 		});
 
 		return ['pmbuttons' => $pmButtons];

--- a/sources/ElkArte/MessagesCallback/SearchRenderer.php
+++ b/sources/ElkArte/MessagesCallback/SearchRenderer.php
@@ -247,7 +247,7 @@ class SearchRenderer extends Renderer
 
 		// Drop any non-enabled ones
 		return array_filter($searchButtons, static function ($button) {
-			return !isset($button['enabled']) || $button['enabled'] !== false;
+			return !isset($button['enabled']) || (bool) $button['enabled'] !== false;
 		});
 	}
 

--- a/sources/ElkArte/Modules/Calendar/Display.php
+++ b/sources/ElkArte/Modules/Calendar/Display.php
@@ -61,7 +61,7 @@ class Display extends AbstractModule
 			'url' => getUrl('action', ['action' => 'post', 'calendar', 'msg' => $context['topic_first_message'], 'topic' => $context['current_topic'] . '.0'])
 		];
 
-		$context['calendar_post'] &= allowedTo('modify_any') || ($context['user']['started'] && allowedTo('modify_own'));
+		$context['calendar_post'] = $context['calendar_post'] && (allowedTo('modify_any') || ($context['user']['started'] && allowedTo('modify_own')));
 	}
 
 	/**

--- a/sources/ElkArte/Modules/Poll/Display.php
+++ b/sources/ElkArte/Modules/Poll/Display.php
@@ -73,8 +73,8 @@ class Display extends AbstractModule
 			$context[$contextual] = allowedTo($perm . '_any') || ($userStarted && allowedTo($perm . '_own'));
 		}
 
-		$context['can_add_poll'] &= self::$_enabled && $topicinfo['id_poll'] <= 0;
-		$context['can_remove_poll'] &= self::$_enabled && $topicinfo['id_poll'] > 0;
+		$context['can_add_poll'] = $context['can_add_poll'] && self::$_enabled && $topicinfo['id_poll'] <= 0;
+		$context['can_remove_poll'] = $context['can_remove_poll'] && self::$_enabled && $topicinfo['id_poll'] > 0;
 	}
 
 	/**

--- a/sources/ElkArte/ScheduledTasks/Tasks/DailyDigest.php
+++ b/sources/ElkArte/ScheduledTasks/Tasks/DailyDigest.php
@@ -244,7 +244,7 @@ class DailyDigest implements ScheduledTaskInterface
 		}
 
 		// Fix the last reply message so its suitable for previewing
-		if ($maillist)
+		if ($maillist && !empty($types['reply']))
 		{
 			foreach ($types['reply'] as $id => $board)
 			{

--- a/sources/ElkArte/SiteCombiner.php
+++ b/sources/ElkArte/SiteCombiner.php
@@ -589,7 +589,7 @@ class SiteCombiner
 
 		foreach ($glob as $file)
 		{
-			$return &= $fileFunc->delete($file->getPathname());
+			$return = $return && $fileFunc->delete($file->getPathname());
 		}
 
 		return $return;

--- a/sources/ElkArte/VerificationControls/VerificationControl/reCaptcha.php
+++ b/sources/ElkArte/VerificationControls/VerificationControl/reCaptcha.php
@@ -44,6 +44,10 @@ class reCaptcha implements ControlInterface
 	{
 		global $modSettings;
 
+		// for development testing ONLY, compliments of a Google search for captcha keys
+		// site key of 6Ld-KCcTAAAAAJTLqpKC3yba2tZZlytk0gtSxy0_
+		// secret key of 6Ld-KCcTAAAAAOeMYwZdoI8QW4Pr_h0ZhW5WFHno
+		// @todo remove at release
 		$this->_site_key = !empty($modSettings['recaptcha_site_key']) ? $modSettings['recaptcha_site_key'] : '6Ld-KCcTAAAAAJTLqpKC3yba2tZZlytk0gtSxy0_';
 		$this->_secret_key = !empty($modSettings['recaptcha_secret_key']) ? $modSettings['recaptcha_secret_key'] : '6Ld-KCcTAAAAAOeMYwZdoI8QW4Pr_h0ZhW5WFHno';
 		$this->_userIP = User::$info->ip;

--- a/sources/Security.php
+++ b/sources/Security.php
@@ -1202,7 +1202,7 @@ function allowedTo($permission, $boards = null)
 	$result = true;
 	while (($row = $request->fetch_assoc()))
 	{
-		$result &= !empty($row['add_deny']);
+		$result = $result && !empty($row['add_deny']);
 	}
 	$request->free_result();
 

--- a/sources/subs/Auth.subs.php
+++ b/sources/subs/Auth.subs.php
@@ -50,7 +50,7 @@ function setLoginCookie($cookie_length, $id, $password = '')
 
 	if (isset($_COOKIE[$cookiename]))
 	{
-		$array = serializeToJson($_COOKIE[$cookiename], function ($array_from) use ($cookiename) {
+		$array = serializeToJson($_COOKIE[$cookiename], static function ($array_from) use ($cookiename) {
 			global $modSettings;
 
 			require_once(SUBSDIR . '/Auth.subs.php');
@@ -76,7 +76,7 @@ function setLoginCookie($cookie_length, $id, $password = '')
 	// If subdomain-independent cookies are on, unset the subdomain-dependent cookie too.
 	if (empty($id) && !empty($modSettings['globalCookies']))
 	{
-		elk_setcookie($cookiename, $data, time() + $cookie_length, $cookie_url[1], '');
+		elk_setcookie($cookiename, $data, time() + $cookie_length, $cookie_url[1]);
 	}
 
 	// Any alias URLs?  This is mainly for use with frames, etc.
@@ -294,7 +294,7 @@ function adminLogin_outputPostVars($k, $v)
 /**
  * Properly urlencodes a string to be used in a query
  *
- * @param mixed[] $get associative array from $_GET
+ * @param array $get associative array from $_GET
  * @return string query string
  * @package Authorization
  */
@@ -318,7 +318,7 @@ function construct_query_string($get)
 				$query_string .= urlencode($k) . '=' . urlencode($v) . ';';
 			}
 			// If it changed, put it out there, but with an ampersand.
-			elseif ($temp[$k] != $get[$k])
+			elseif ($temp[$k] != $v)
 			{
 				$query_string .= urlencode($k) . '=' . urlencode($v) . '&amp;';
 			}
@@ -630,10 +630,10 @@ function validatePassword($password, $username, $restrict_in = array())
 	}
 
 	// Otherwise, hard test next, check for numbers and letters, uppercase too.
-	$good = preg_match('~(\D\d|\d\D)~', $password) != 0;
-	$good &= Util::strtolower($password) !== $password;
+	$good = preg_match('~(\D\d|\d\D)~', $password) === 1;
+	$good = $good && Util::strtolower($password) !== $password;
 
-	return $good !== 0 ? null : 'chars';
+	return $good ? null : 'chars';
 }
 
 /**
@@ -713,7 +713,7 @@ function rebuildModCache()
 
 	if ($board_query === '0=1')
 	{
-		$boards = boardsAllowedTo('moderate_board', true);
+		$boards = boardsAllowedTo('moderate_board');
 
 		$board_query = empty($boards) ? '0=1' : 'id_board IN (' . implode(',', $boards) . ')';
 	}
@@ -825,10 +825,10 @@ function isFirstLogin($id_member)
  * Search for a member by given criteria
  *
  * @param string $where
- * @param mixed[] $where_params array of values to used in the where statement
+ * @param array $where_params array of values to used in the where statement
  * @param bool $fatal
  *
- * @return mixed[]|bool array of members data or false on failure
+ * @return array|bool array of members data or false on failure
  * @throws \ElkArte\Exceptions\Exception no_user_with_email
  * @package Authorization
  *
@@ -936,7 +936,7 @@ function generateValidationCode($length = 10)
  *
  * @param string $name
  * @param bool $is_id if true it treats $name as a member ID and try to load the data for that ID
- * @return mixed[]|false false if nothing is found
+ * @return array|false false if nothing is found
  * @package Authorization
  */
 function loadExistingMember($name, $is_id = false)

--- a/tests/sources/admin/ManageBoardsSettingsTest.php
+++ b/tests/sources/admin/ManageBoardsSettingsTest.php
@@ -37,8 +37,8 @@ class TestManageBoardsSettings extends ElkArteCommonSetupTest
 
 		// Lets see some hardcoded setting for boards management...
 		$this->assertNotNull($settings);
-		$this->assertTrue(in_array(array('title', 'settings'), $settings));
-		$this->assertTrue(in_array(array('permissions', 'manage_boards', 'helptext' => $txt['permissionhelp_manage_boards']), $settings));
-		$this->assertTrue(in_array(array('check', 'countChildPosts'), $settings));
+		$this->assertContains(array('title', 'settings'), $settings);
+		$this->assertContains(array('permissions', 'manage_boards', 'helptext' => $txt['permissionhelp_manage_boards'], 'collapsed' => true), $settings);
+		$this->assertContains(array('check', 'countChildPosts'), $settings);
 	}
 }

--- a/tests/sources/subs/Graphics.class.Test.php
+++ b/tests/sources/subs/Graphics.class.Test.php
@@ -25,7 +25,7 @@ class TestGraphics extends TestCase
 				'format' => IMAGETYPE_JPEG
 			),
 			array(
-				'url' => 'http://weblogs.us/images/weblogs.us.png',
+				'url' => 'https://weblogs.us/wp-content/uploads/2023/02/weblogs.us-logo.png',
 				'width' => 432,
 				'height' => 78,
 				'format' => IMAGETYPE_PNG

--- a/themes/default/GenericList.template.php
+++ b/themes/default/GenericList.template.php
@@ -257,8 +257,8 @@ function template_additional_rows($row_position, $cur_list)
  * Used this if you want your generic lists to have navigation menus.
  *
  * $cur_list['list_menu'] = array(
- *    // The position of the tabs/buttons.  Left or Right.  By default is set to left.
- *    'position' => 'left',
+ *    'style' => '',
+ *    'class' => '',
  *    // Links.  This is the core of the array.  It has all the info that we need.
  *    'links' => array(
  *      'name' => array(

--- a/themes/default/Maintenance.template.php
+++ b/themes/default/Maintenance.template.php
@@ -187,13 +187,17 @@ function template_maintain_members()
 				<p><strong>', $txt['reattribute_guest_posts'], '</strong></p>
 				<dl class="settings">
 					<dt>
-						<label for="type_email"><input type="radio" name="type" id="type_email" value="email" checked="checked" />', $txt['reattribute_email'], '</label>
+						<label for="type_email">
+							<input type="radio" name="type" id="type_email" value="email" checked="checked" />', $txt['reattribute_email'], '
+						</label>
 					</dt>
 					<dd>
 						<input type="text" name="from_email" id="from_email" value="" onclick="document.getElementById(\'type_email\').checked = \'checked\'; document.getElementById(\'from_name\').value = \'\';" />
 					</dd>
 					<dt>
-						<label for="type_name"><input type="radio" name="type" id="type_name" value="name" />', $txt['reattribute_username'], '</label>
+						<label for="type_name">
+							<input type="radio" name="type" id="type_name" value="name" />', $txt['reattribute_username'], '
+						</label>
 					</dt>
 					<dd>
 						<input type="text" name="from_name" id="from_name" value="" onclick="document.getElementById(\'type_name\').checked = \'checked\'; document.getElementById(\'from_email\').value = \'\';" class="input_text" />
@@ -235,15 +239,20 @@ function template_maintain_members()
 
 	echo '
 			<fieldset id="membersPanel">
-				<legend data-collapsed="true">', $txt['maintain_members_all'], '</legend>';
+				<legend data-collapsed="true">', $txt['maintain_members_all'], '</legend>
+				<ul style="column-count: 2"';
 
 	foreach ($context['membergroups'] as $group)
 	{
 		echo '
-				<label for="groups', $group['id'], '"><input type="checkbox" name="groups[', $group['id'], ']" id="groups', $group['id'], '" checked="checked" /> ', $group['name'], '</label><br />';
+					<label for="groups', $group['id'], '">
+						<input type="checkbox" name="groups[', $group['id'], ']" id="groups', $group['id'], '" checked="checked" /> ', $group['name'], '
+					</label>
+					<br />';
 	}
 
-	echo '
+	echo '	
+			</ul>
 			</fieldset>
 			<div class="submitbutton">
 				<input type="submit" value="', $txt['maintain_old_remove'], '" onclick="return confirm(\'', $txt['maintain_members_confirm'], '\');" />

--- a/themes/default/ManagePermissions.template.php
+++ b/themes/default/ManagePermissions.template.php
@@ -268,7 +268,7 @@ function template_by_board()
 	foreach ($context['categories'] as $category)
 	{
 		echo '
-			<h2 class="category_header"><strong>', $category['name'], '</strong></h2>';
+			<h2 class="category_header">', $category['name'], '</h2>';
 
 		if (!empty($category['boards']))
 		{

--- a/themes/default/Register.template.php
+++ b/themes/default/Register.template.php
@@ -545,28 +545,40 @@ function template_admin_register()
 	}
 
 	echo '
-					<div class="form_container">
-						<div class="form_field" id="admin_register_form">
-							<input type="text" name="user" id="user_input" tabindex="', $context['tabindex']++, '" size="30" maxlength="25" class="input_text" />
-							<label for="user_input">', $txt['admin_register_username'], '</label>
+					<input type="password" name="autofill_honey_pot" class="hide" />
+					<div class="flow_auto">
+					<dl class="settings" id="admin_register_form">
+						<dt>
+							<label for="user_input">', $txt['admin_register_username'], ':</label>
 							<span class="smalltext">', $txt['admin_register_username_desc'], '</span>
-						</div>
-						<div class="form_field">
-							<input type="email" name="email" id="email_input" tabindex="', $context['tabindex']++, '" size="30" class="input_text" />
-							<label for="email_input">', $txt['admin_register_email'], '</label>
+						</dt>
+						<dd>
+							<input type="text" name="user" id="user_input" tabindex="', $context['tabindex']++, '" size="30" maxlength="25" class="input_text" />
+						</dd>
+						<dt>
+							<label for="email_input">', $txt['admin_register_email'], ':</label>
 							<span class="smalltext">', $txt['admin_register_email_desc'], '</span>
+						</dt>
+						<dd>
+							<input type="email" name="email" id="email_input" tabindex="', $context['tabindex']++, '" size="30" class="input_text" />
 							<span id="suggestion" class="smalltext"></span>
-						</div>
-						<div class="form_field">
-							<input type="password" name="password" id="password_input" tabindex="', $context['tabindex']++, '" size="30" class="input_password" onchange="onCheckChange();" />
-							<label for="password_input">', $txt['admin_register_password'], '</label>
+						</dd>
+						<dt>
+							<label for="password_input">', $txt['admin_register_password'], ':</label>
 							<span class="smalltext">', $txt['admin_register_password_desc'], '</span>
-						</div>';
+						</dt>
+						<dd>
+							<input type="password" name="password" id="password_input" tabindex="', $context['tabindex']++, '" size="30" class="input_password" onchange="onCheckChange();" />
+						</dd>';
 
 	if (!empty($context['member_groups']))
 	{
 		echo '
-						<div class="form_field_select">
+						<dt>
+							<label for="group_select">', $txt['admin_register_group'], ':</label>
+							<span class="smalltext">', $txt['admin_register_group_desc'], '</span>
+						</dt>
+						<dd>
 							<select name="group" id="group_select" tabindex="', $context['tabindex']++, '">';
 
 		foreach ($context['member_groups'] as $id => $name)
@@ -577,24 +589,27 @@ function template_admin_register()
 
 		echo '
 							</select>
-							<label for="group_select">', $txt['admin_register_group'], '</label>
-							<p class="smalltext">', $txt['admin_register_group_desc'], '</p>
-						</div>';
+						</dd>';
 	}
 
 	echo '
-						<div class="form_field_checkbox">
-							<input type="checkbox" name="emailPassword" id="emailPassword_check" tabindex="', $context['tabindex']++, '" checked="checked" disabled="disabled" />
-							<label for="emailPassword_check">', $txt['admin_register_email_detail'], '</label>
+						<dt>
+							<label for="emailPassword_check">', $txt['admin_register_email_detail'], ':</label>
 							<span class="smalltext">', $txt['admin_register_email_detail_desc'], '</span>
-						</div>
-						<div class="form_field_checkbox">
+						</dt>
+						<dd>
+							<input type="checkbox" name="emailPassword" id="emailPassword_check" tabindex="', $context['tabindex']++, '" checked="checked" disabled="disabled" />
+						</dd>
+						<dt>
+							<label for="emailActivate_check">', $txt['admin_register_email_activate'], ':</label>
+						</dt>
+						<dd>
 							<input type="checkbox" name="emailActivate" id="emailActivate_check" tabindex="', $context['tabindex']++, '"', !empty($modSettings['registration_method']) && $modSettings['registration_method'] == 1 ? ' checked="checked"' : '', ' onclick="onCheckChange();" />
-							<label for="emailActivate_check">', $txt['admin_register_email_activate'], '</label>
-						</div>
+						</dd>
+					</dl>
 					</div>
-					<div class="submitbutton centertext">
-						<input type="submit" id="regSubmit" name="regSubmit" value="', $txt['register'], '" tabindex="', $context['tabindex']++, '" class="right_submit" />
+					<div class="submitbutton">
+						<input type="submit" name="regSubmit" value="', $txt['register'], '" tabindex="', $context['tabindex']++, '" class="right_submit" />
 						<input type="hidden" name="sa" value="register" />
 						<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
 						<input type="hidden" name="', $context['admin-regc_token_var'], '" value="', $context['admin-regc_token'], '" />
@@ -621,7 +636,7 @@ function template_edit_agreement()
 	if (!empty($context['warning']))
 	{
 		echo '
-			<p class="error">', $context['warning'], '</p>';
+			<p class="warningbox">', $context['warning'], '</p>';
 	}
 
 	echo '

--- a/themes/default/Stats.template.php
+++ b/themes/default/Stats.template.php
@@ -460,9 +460,10 @@ function showBarChart($id, $data, $labels, $tooltips)
  */
 function getChartData($stats, $num = 'num_posts', $usePercent = false)
 {
-	$labels = [];
-	$data = [];
-	$tooltips = [];
+	// Just so we always have, at least, 10 bars to plot
+	$labels = array_fill(0, 10, "' '");
+	$data = array_fill(0, 10, '0');
+	$tooltips = array_fill(0, 10, null);
 
 	foreach ($stats as $value)
 	{

--- a/themes/default/Theme.php
+++ b/themes/default/Theme.php
@@ -385,7 +385,7 @@ class Theme extends BaseTheme
 		// Localization for the show more quote and its container height
 		$quote_height = !empty($modSettings['heightBeforeShowMore']) ? $modSettings['heightBeforeShowMore'] . 'px' : 'none';
 		$this->addCSSRules('
-		input[type=checkbox].quote-show-more:after {content: "' . $txt['post_options'] . '";}
+		input[type=checkbox].quote-show-more:after {content: "' . $txt['quote_expand'] . '";}
 		.quote-read-more > .bbc_quote {--quote_height: ' . $quote_height . ';}'
 		);
 	}

--- a/themes/default/css/admin.css
+++ b/themes/default/css/admin.css
@@ -626,6 +626,10 @@ ul.package_servers li {
 	border-bottom: 1px solid;
 }
 
+#manage_maintenance .content fieldset {
+	border-bottom: none;
+}
+
 /* Styles for the add holidays manage calendar section. */
 .settings dt.small_caption {
 	width: 20%;
@@ -865,6 +869,11 @@ dl.themes_list dd {
 #agreement, #reserved {
 	width: 99%;
 	padding: 0 .25em;
+}
+
+#admin_register_form dt span {
+	display: block;
+	padding: 0;
 }
 
 /* Styles for the moderation center. */

--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -78,6 +78,7 @@
 	--font29: 1.9333rem;
 	--font30: 2.0rem;
 	--quote_height: 12em;
+	--max_width: 1600px;
 }
 
 /* -------------------------------------------------------
@@ -125,7 +126,7 @@ html, body {
 	/* Next controls forum width, when it is not set in admin. */
 	width: 90%;
 	/* Next limits maximum width on wide screens. */
-	max-width: 98%;
+	max-width: var(--max_width);
 	margin: 0 auto;
 }
 
@@ -5809,10 +5810,6 @@ div.labels {
 @media screen and (max-width: 50em) {
 	#logobox img {
 		max-width: 95%;
-	}
-
-	.wrapper {
-		min-width: 98%;
 	}
 
 	#password_login select {

--- a/themes/default/css/jquery.ui.tabs.css
+++ b/themes/default/css/jquery.ui.tabs.css
@@ -18,7 +18,7 @@
 }
 
 .ui-tabs .ui-tabs-nav .ui-state-active > a, .ui-tabs .ui-tabs-nav .ui-state-active {
-	font-family: "Segoe UI Semibold", "Segoe UI", "Helvetica Neue Medium", "Helvetica Neue", serif;
+	font-family: "Segoe UI Semibold", "Helvetica Neue Medium", system-ui, -apple-system, BlinkMacSystemFont, "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif;
 	font-weight: 600;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;

--- a/themes/default/scripts/dropAttachments.js
+++ b/themes/default/scripts/dropAttachments.js
@@ -303,7 +303,7 @@
 			 * @returns {boolean}
 			 */
 			isFileImage = function(file) {
-				return file && file['type'].split('/')[0] === 'image';
+				return file && file.type.split('/')[0] === 'image';
 			},
 
 			/**

--- a/themes/default/scripts/dropAttachments.js
+++ b/themes/default/scripts/dropAttachments.js
@@ -65,7 +65,7 @@
 				totalSizeAllowed = params.totalSizeAllowed || 0;
 				individualSizeAllowed = params.individualSizeAllowed || 0;
 				numOfAttachmentAllowed = params.numOfAttachmentAllowed || 0;
-				totalAttachSizeUploaded = totalAttachSizeUploaded || 0;
+				totalAttachSizeUploaded = params.totalAttachSizeUploaded || 0;
 				numAttachUploaded = params.numAttachUploaded || 0;
 				resizeImageEnabled = params.resizeImageEnabled;
 				filesUploadedSuccessfully = [];
@@ -180,6 +180,11 @@
 						filesUploadedSuccessfully.push(data);
 						data.curFileNum = curFileNum;
 						status.onUploadSuccess(data);
+
+						// Correct the upload size
+						if (resizeImageEnabled && fileSize !== data.size) {
+							totalAttachSizeUploaded -= fileSize - data.size;
+						}
 					}
 					else
 					{
@@ -287,6 +292,18 @@
 
 					bytes /= 1024;
 				}
+			},
+
+			/**
+			 * private function
+			 *
+			 * Checks if the type is one of image/xyz
+			 *
+			 * @param file
+			 * @returns {boolean}
+			 */
+			isFileImage = function(file) {
+				return file && file['type'].split('/')[0] === 'image';
 			},
 
 			/**
@@ -516,9 +533,9 @@
 					}
 
 					// Make sure the file is not larger than the server will accept
-					if (individualSizeAllowed !== 0 && fileSize > individualSizeAllowed && !resizeImageEnabled)
+					if (individualSizeAllowed !== 0 && fileSize > individualSizeAllowed && !resizeImageEnabled && isFileImage(files[i]))
 					{
-						errorMsgs.individualSizeErr = '(' + parseInt(String(fileSize / 1024), 10) + ' KB) ' + oTxt.individualSizeAllowed;
+						errorMsgs.individualSizeErr = '(' + formatBytes(fileSize) + ' ) ' + oTxt.individualSizeAllowed;
 						sizeErrorFiles.push(files[i].name);
 						errorFlag = true;
 					}


### PR DESCRIPTION
Another compilation of random fixes.

I can't believe how many tests got broken in since the last PR , what a pain in the arse and a senseless waste of time.
- The chrome browser we used in the headless testing was not longer available on the google stable channel, that broke all of the web tests.  I updated that BUT that generally comes with problems with the selenium driver
- Current stylelint dropped support for node.js < 14 so that broke all the linters.  I moved to a newer version of node.js but there are depreciation notices as they are moving some code "pretty" rules to another linter ... so more pain to come.
- The regular test all failed as one of the images used to check fetching etc had been moved to a new url
- And then there were some actual issues due to the updates.
- Codecov bot is changing and needs new setup / credentials