### PR TITLE
Custom field check exception with wrong value count sent to vsprintf

### DIFF
--- a/sources/controllers/Register.controller.php
+++ b/sources/controllers/Register.controller.php
@@ -13,7 +13,7 @@
  * copyright:	2011 Simple Machines (http://www.simplemachines.org)
  * license:		BSD, See included LICENSE.TXT for terms and conditions.
  *
- * @version 1.1.9
+ * @version 1.1.10
  *
  */
 
@@ -470,7 +470,7 @@ class Register_Controller extends Action_Controller
 				if ($is_valid !== true)
 				{
 					$err_params = array($row['name']);
-					if ($is_valid === 'custom_field_not_number')
+					if ($is_valid === 'custom_field_too_long')
 						$err_params[] = $row['field_length'];
 
 					$reg_errors->addError(array($is_valid, $err_params));


### PR DESCRIPTION
Exception: The arguments array must contain 2 items, 1 given, php 8+  We need to pass the allowed length to the language string for the custom_field_too_long error not the custom_field_not_number.