### PR TITLE
Use a promise (as in 2.0) to ensure this is ready

### DIFF
--- a/themes/default/GenericControls.template.php
+++ b/themes/default/GenericControls.template.php
@@ -159,9 +159,21 @@ function template_control_richedit($editor_id, $smileyContainer = null, $bbcCont
 			// Other Editor startup options, css, smiley box, validate wizzy, move into view
 			$.sceditor.plugins.moveTo = function() {
 				var base = this;
+				const isEditorLoaded = async selector => {
+					while (document.querySelector(selector) === null) {
+						await new Promise(resolve =>requestAnimationFrame(resolve));
+					}
+					return true;
+				};
 
 				base.signalReady = function() {
 					let editor = this;
+					
+					// signalReady can be called before the extensionMethods are available
+					isEditorLoaded(".sceditor-toolbar").then((selector) => {
+						editor.createPermanentDropDown();
+						editor.css("code {white-space: pre;}");
+					});
 
 					if ($.sceditor.isWysiwygSupported === false)
 					{
@@ -173,16 +185,12 @@ function template_control_richedit($editor_id, $smileyContainer = null, $bbcCont
 					{
 						document.getElementById("skipnav").scrollIntoView();
 					}
-
-					editor.css("code {white-space: pre;}");
-					editor.createPermanentDropDown();
 				};
 			}
 	
 			$(function() {
 				elk_editor();
 			});
-
 		</script>';
 }
 


### PR DESCRIPTION
Newer version of SCE seem to trigger this event earlier, so use a promise to be sure its loaded "enough" before we call the permanent DD function. I've not seen this occur on 1.1.x (with sce 1.5) but sce 2.5/3.0 on 2.0.x will trigger the issue.