### PR TITLE
Admin Controller Freshen

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -1836,7 +1836,7 @@ function ssi_boardNews($board = null, $limit = null, $start = null, $length = nu
 			'blank_redirect' => '',
 		)
 	);
-	if ($request->num_rows() == 0)
+	if ($request->num_rows() === 0)
 	{
 		if ($output_method === 'echo')
 		{

--- a/sources/ElkArte/AdminController/AddonSettings.php
+++ b/sources/ElkArte/AdminController/AddonSettings.php
@@ -37,7 +37,7 @@ class AddonSettings extends AbstractController
 	/**
 	 * This, my friend, is for all the authors of addons out there.
 	 *
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -50,11 +50,8 @@ class AddonSettings extends AbstractController
 			'general' => array($this, 'action_addonSettings_display', 'permission' => 'admin_forum'),
 		);
 
-		// @FIXME
-		// $this->loadGeneralSettingParameters($subActions, 'general');
 		$context['page_title'] = $txt['admin_modifications'];
 		$context['sub_template'] = 'show_settings';
-		// END $this->loadGeneralSettingParameters();
 
 		// Load up all the tabs...
 		$context[$context['admin_menu_name']]['object']->prepareTabData([
@@ -137,36 +134,5 @@ class AddonSettings extends AbstractController
 	public function settings_search()
 	{
 		return $this->_settings();
-	}
-
-	/**
-	 * This function makes sure the requested subaction does exist,
-	 * if it doesn't, it sets a default action or.
-	 *
-	 * @param array $subActions An array containing all possible subactions.
-	 * @param string $defaultAction the default action to be called if no valid subaction was found.
-	 *
-	 * @throws \ElkArte\Exceptions\Exception
-	 */
-	public function loadGeneralSettingParameters($subActions = [], $defaultAction = '')
-	{
-		global $context;
-
-		// You need to be an admin to edit settings!
-		isAllowedTo('admin_forum');
-
-		Txt::load('Help+ManageSettings');
-
-		$context['sub_template'] = 'show_settings';
-
-		// By default do the basic settings.
-		$subAction = $this->_req->getQuery('sa', 'trim|strval', $defaultAction);
-		if (empty($subAction) || empty($subActions[$subAction]))
-		{
-			$keys = array_keys($subActions);
-			$subAction = array_pop($keys);
-		}
-
-		$context['sub_action'] = $subAction;
 	}
 }

--- a/sources/ElkArte/AdminController/Admin.php
+++ b/sources/ElkArte/AdminController/Admin.php
@@ -24,6 +24,8 @@ use ElkArte\Exceptions\Exception;
 use ElkArte\Hooks;
 use ElkArte\Languages\Txt;
 use ElkArte\Menu\Menu;
+use ElkArte\Packages\Packages;
+use ElkArte\Packages\PackageServers;
 use ElkArte\User;
 use ElkArte\XmlArray;
 
@@ -43,7 +45,7 @@ class Admin extends AbstractController
 	 * @var string[] areas to find current installed status and installed version
 	 */
 	private $_checkFor = array('gd', 'imagick', 'db_server', 'php', 'server',
-							   'zend', 'apc', 'memcache', 'memcached', 'opcache');
+		'zend', 'apc', 'memcache', 'memcached', 'opcache');
 
 	/**
 	 * Pre Dispatch, called before other methods.
@@ -127,19 +129,19 @@ class Admin extends AbstractController
 				'areas' => array(
 					'index' => array(
 						'label' => $txt['admin_center'],
-						'controller' => '\\ElkArte\\AdminController\\Admin',
+						'controller' => Admin::class,
 						'function' => 'action_home',
 						'class' => 'i-home i-admin',
 					),
 					'credits' => array(
 						'label' => $txt['support_credits_title'],
-						'controller' => '\\ElkArte\\AdminController\\Admin',
+						'controller' => Admin::class,
 						'function' => 'action_credits',
 						'class' => 'i-support i-admin',
 					),
 					'maillist' => array(
 						'label' => $txt['mail_center'],
-						'controller' => '\\ElkArte\\AdminController\\ManageMaillist',
+						'controller' => ManageMaillist::class,
 						'function' => 'action_index',
 						'class' => 'i-envelope-blank i-admin',
 						'permission' => array('approve_emails', 'admin_forum'),
@@ -154,7 +156,7 @@ class Admin extends AbstractController
 					),
 					'news' => array(
 						'label' => $txt['news_title'],
-						'controller' => '\\ElkArte\\AdminController\\ManageNews',
+						'controller' => ManageNews::class,
 						'function' => 'action_index',
 						'class' => 'i-post-text i-admin',
 						'permission' => array('edit_news', 'send_mail', 'admin_forum'),
@@ -166,7 +168,7 @@ class Admin extends AbstractController
 					),
 					'packages' => array(
 						'label' => $txt['package'],
-						'controller' => '\\ElkArte\\Packages\\Packages',
+						'controller' => Packages::class,
 						'function' => 'action_index',
 						'permission' => array('admin_forum'),
 						'class' => 'i-package i-admin',
@@ -178,14 +180,14 @@ class Admin extends AbstractController
 					),
 					'packageservers' => array(
 						'label' => $txt['package_servers'],
-						'controller' => '\\ElkArte\\Packages\\PackageServers',
+						'controller' => PackageServers::class,
 						'function' => 'action_index',
 						'permission' => array('admin_forum'),
 						'class' => 'i-package i-admin',
 						'hidden' => true,
 					),
 					'search' => array(
-						'controller' => '\\ElkArte\\AdminController\\Admin',
+						'controller' => Admin::class,
 						'function' => 'action_search',
 						'permission' => array('admin_forum'),
 						'class' => 'i-search i-admin',
@@ -193,7 +195,7 @@ class Admin extends AbstractController
 						'hidden' => true,
 					),
 					'adminlogoff' => array(
-						'controller' => '\\ElkArte\\AdminController\\Admin',
+						'controller' => Admin::class,
 						'function' => 'action_endsession',
 						'label' => $txt['admin_logoff'],
 						'enabled' => empty($modSettings['securityDisable']),
@@ -207,13 +209,13 @@ class Admin extends AbstractController
 				'areas' => array(
 					'corefeatures' => array(
 						'label' => $txt['core_settings_title'],
-						'controller' => '\\ElkArte\\AdminController\\CoreFeatures',
+						'controller' => CoreFeatures::class,
 						'function' => 'action_index',
 						'class' => 'i-cog i-admin',
 					),
 					'featuresettings' => array(
 						'label' => $txt['modSettings_title'],
-						'controller' => '\\ElkArte\\AdminController\\ManageFeatures',
+						'controller' => ManageFeatures::class,
 						'function' => 'action_index',
 						'class' => 'i-switch-on i-admin',
 						'subsections' => array(
@@ -229,7 +231,7 @@ class Admin extends AbstractController
 					),
 					'serversettings' => array(
 						'label' => $txt['admin_server_settings'],
-						'controller' => '\\ElkArte\\AdminController\\ManageServer',
+						'controller' => ManageServer::class,
 						'function' => 'action_index',
 						'class' => 'i-menu i-admin',
 						'subsections' => array(
@@ -243,7 +245,7 @@ class Admin extends AbstractController
 					),
 					'securitysettings' => array(
 						'label' => $txt['admin_security_moderation'],
-						'controller' => '\\ElkArte\\AdminController\\ManageSecurity',
+						'controller' => ManageSecurity::class,
 						'function' => 'action_index',
 						'class' => 'i-key i-admin',
 						'subsections' => array(
@@ -254,7 +256,7 @@ class Admin extends AbstractController
 					),
 					'theme' => array(
 						'label' => $txt['theme_admin'],
-						'controller' => '\\ElkArte\\AdminController\\ManageThemes',
+						'controller' => ManageThemes::class,
 						'function' => 'action_index',
 						'custom_url' => getUrl('admin', ['action' => 'admin', 'area' => 'theme']),
 						'class' => 'i-modify i-admin',
@@ -266,14 +268,14 @@ class Admin extends AbstractController
 					),
 					'current_theme' => array(
 						'label' => $txt['theme_current_settings'],
-						'controller' => '\\ElkArte\\AdminController\\ManageThemes',
+						'controller' => ManageThemes::class,
 						'function' => 'action_index',
 						'custom_url' => getUrl('admin', ['action' => 'admin', 'area' => 'theme', 'sa' => 'list', 'th' => $settings['theme_id']]),
 						'class' => 'i-paint i-admin',
 					),
 					'languages' => array(
 						'label' => $txt['language_configuration'],
-						'controller' => '\\ElkArte\\AdminController\\ManageLanguages',
+						'controller' => ManageLanguages::class,
 						'function' => 'action_index',
 						'class' => 'i-language i-admin',
 						'subsections' => array(
@@ -284,7 +286,7 @@ class Admin extends AbstractController
 					),
 					'addonsettings' => array(
 						'label' => $txt['admin_modifications'],
-						'controller' => '\\ElkArte\\AdminController\\AddonSettings',
+						'controller' => AddonSettings::class,
 						'function' => 'action_index',
 						'class' => 'i-puzzle i-admin',
 						'subsections' => array(
@@ -299,7 +301,7 @@ class Admin extends AbstractController
 				'areas' => array(
 					'manageboards' => array(
 						'label' => $txt['admin_boards'],
-						'controller' => '\\ElkArte\\AdminController\\ManageBoards',
+						'controller' => ManageBoards::class,
 						'function' => 'action_index',
 						'class' => 'i-directory i-admin',
 						'permission' => array('manage_boards'),
@@ -311,7 +313,7 @@ class Admin extends AbstractController
 					),
 					'postsettings' => array(
 						'label' => $txt['manageposts'],
-						'controller' => '\\ElkArte\\AdminController\\ManagePosts',
+						'controller' => ManagePosts::class,
 						'function' => 'action_index',
 						'permission' => array('admin_forum'),
 						'class' => 'i-post-text i-admin',
@@ -323,14 +325,14 @@ class Admin extends AbstractController
 					),
 					'editor' => array(
 						'label' => $txt['editor_manage'],
-						'controller' => '\\ElkArte\\AdminController\\ManageEditor',
+						'controller' => ManageEditor::class,
 						'function' => 'action_index',
 						'class' => 'i-modify i-admin',
 						'permission' => array('manage_bbc'),
 					),
 					'smileys' => array(
 						'label' => $txt['smileys_manage'],
-						'controller' => '\\ElkArte\\AdminController\\ManageSmileys',
+						'controller' => ManageSmileys::class,
 						'function' => 'action_index',
 						'class' => 'i-smiley-blank i-admin',
 						'permission' => array('manage_smileys'),
@@ -345,7 +347,7 @@ class Admin extends AbstractController
 					),
 					'manageattachments' => array(
 						'label' => $txt['attachments_avatars'],
-						'controller' => '\\ElkArte\\AdminController\\ManageAttachments',
+						'controller' => ManageAttachments::class,
 						'function' => 'action_index',
 						'class' => 'i-paperclip i-admin',
 						'permission' => array('manage_attachments'),
@@ -359,7 +361,7 @@ class Admin extends AbstractController
 					),
 					'managesearch' => array(
 						'label' => $txt['manage_search'],
-						'controller' => '\\ElkArte\\AdminController\\ManageSearch',
+						'controller' => ManageSearch::class,
 						'function' => 'action_index',
 						'class' => 'i-search i-admin',
 						'permission' => array('admin_forum'),
@@ -378,14 +380,14 @@ class Admin extends AbstractController
 				'areas' => array(
 					'viewmembers' => array(
 						'label' => $txt['admin_users'],
-						'controller' => '\\ElkArte\\AdminController\\ManageMembers',
+						'controller' => ManageMembers::class,
 						'function' => 'action_index',
 						'class' => 'i-user i-admin',
 						'permission' => array('moderate_forum'),
 					),
 					'membergroups' => array(
 						'label' => $txt['admin_groups'],
-						'controller' => '\\ElkArte\\AdminController\\ManageMembergroups',
+						'controller' => ManageMembergroups::class,
 						'function' => 'action_index',
 						'class' => 'i-users',
 						'permission' => array('manage_membergroups'),
@@ -397,7 +399,7 @@ class Admin extends AbstractController
 					),
 					'permissions' => array(
 						'label' => $txt['edit_permissions'],
-						'controller' => '\\ElkArte\\AdminController\\ManagePermissions',
+						'controller' => ManagePermissions::class,
 						'function' => 'action_index',
 						'class' => 'i-key i-admin',
 						'permission' => array('manage_permissions'),
@@ -411,7 +413,7 @@ class Admin extends AbstractController
 					),
 					'ban' => array(
 						'label' => $txt['ban_title'],
-						'controller' => '\\ElkArte\\AdminController\\ManageBans',
+						'controller' => ManageBans::class,
 						'function' => 'action_index',
 						'class' => 'i-thumbdown i-admin',
 						'permission' => 'manage_bans',
@@ -424,7 +426,7 @@ class Admin extends AbstractController
 					),
 					'regcenter' => array(
 						'label' => $txt['registration_center'],
-						'controller' => '\\ElkArte\\AdminController\\ManageRegistration',
+						'controller' => ManageRegistration::class,
 						'function' => 'action_index',
 						'class' => 'i-user-plus i-admin',
 						'permission' => array('admin_forum', 'moderate_forum'),
@@ -439,7 +441,7 @@ class Admin extends AbstractController
 					'sengines' => array(
 						'label' => $txt['search_engines'],
 						'enabled' => featureEnabled('sp'),
-						'controller' => '\\ElkArte\\AdminController\\ManageSearchEngines',
+						'controller' => ManageSearchEngines::class,
 						'function' => 'action_index',
 						'class' => 'i-website i-admin',
 						'permission' => 'admin_forum',
@@ -453,7 +455,7 @@ class Admin extends AbstractController
 					'paidsubscribe' => array(
 						'label' => $txt['paid_subscriptions'],
 						'enabled' => featureEnabled('ps'),
-						'controller' => '\\ElkArte\\AdminController\\ManagePaid',
+						'controller' => ManagePaid::class,
 						'class' => 'i-credit i-admin',
 						'function' => 'action_index',
 						'permission' => 'admin_forum',
@@ -470,7 +472,7 @@ class Admin extends AbstractController
 				'areas' => array(
 					'maintain' => array(
 						'label' => $txt['maintain_title'],
-						'controller' => '\\ElkArte\\AdminController\\Maintenance',
+						'controller' => Maintenance::class,
 						'function' => 'action_index',
 						'class' => 'i-cog i-admin',
 						'subsections' => array(
@@ -484,7 +486,7 @@ class Admin extends AbstractController
 					),
 					'logs' => array(
 						'label' => $txt['logs'],
-						'controller' => '\\ElkArte\\AdminController\\AdminLog',
+						'controller' => AdminLog::class,
 						'function' => 'action_index',
 						'class' => 'i-comments i-admin',
 						'subsections' => array(
@@ -499,7 +501,7 @@ class Admin extends AbstractController
 					),
 					'scheduledtasks' => array(
 						'label' => $txt['maintain_tasks'],
-						'controller' => '\\ElkArte\\AdminController\\ManageScheduledTasks',
+						'controller' => ManageScheduledTasks::class,
 						'function' => 'action_index',
 						'class' => 'i-calendar i-admin',
 						'subsections' => array(
@@ -509,7 +511,7 @@ class Admin extends AbstractController
 					),
 					'mailqueue' => array(
 						'label' => $txt['mailqueue_title'],
-						'controller' => '\\ElkArte\\AdminController\\ManageMail',
+						'controller' => ManageMail::class,
 						'function' => 'action_index',
 						'class' => 'i-envelope-blank i-admin',
 						'subsections' => array(
@@ -520,13 +522,13 @@ class Admin extends AbstractController
 					'reports' => array(
 						'enabled' => featureEnabled('rg'),
 						'label' => $txt['generate_reports'],
-						'controller' => '\\ElkArte\\AdminController\\Reports',
+						'controller' => Reports::class,
 						'function' => 'action_index',
 						'class' => 'i-pie-chart i-admin',
 					),
 					'repairboards' => array(
 						'label' => $txt['admin_repair'],
-						'controller' => '\\ElkArte\\AdminController\\RepairBoards',
+						'controller' => RepairBoards::class,
 						'function' => 'action_repairboards',
 						'select' => 'maintain',
 						'hidden' => true,
@@ -579,7 +581,7 @@ class Admin extends AbstractController
 			'name' => $txt['admin_center'],
 		);
 
-		if (isset($admin_include_data['current_area']) && $admin_include_data['current_area'] != 'index')
+		if (isset($admin_include_data['current_area']) && $admin_include_data['current_area'] !== 'index')
 		{
 			$context['linktree'][] = array(
 				'url' => getUrl('admin', ['action' => 'admin', 'area' => $admin_include_data['current_area'], '{session_data}']),
@@ -587,14 +589,20 @@ class Admin extends AbstractController
 			);
 		}
 
-		if (isset($admin_include_data['current_subsection'], $admin_include_data['subsections'][$admin_include_data['current_subsection']])
-			&& $admin_include_data['subsections'][$admin_include_data['current_subsection']]['label'] != $admin_include_data['label'])
+		if (!isset($admin_include_data['current_subsection'], $admin_include_data['subsections'][$admin_include_data['current_subsection']]))
 		{
-			$context['linktree'][] = array(
-				'url' => getUrl('admin', ['action' => 'admin', 'area' => $admin_include_data['current_area'], 'sa' => $admin_include_data['current_subsection'], '{session_data}']),
-				'name' => $admin_include_data['subsections'][$admin_include_data['current_subsection']]['label'],
-			);
+			return;
 		}
+
+		if ($admin_include_data['subsections'][$admin_include_data['current_subsection']]['label'] === $admin_include_data['label'])
+		{
+			return;
+		}
+
+		$context['linktree'][] = array(
+			'url' => getUrl('admin', ['action' => 'admin', 'area' => $admin_include_data['current_area'], 'sa' => $admin_include_data['current_subsection'], '{session_data}']),
+			'name' => $admin_include_data['subsections'][$admin_include_data['current_subsection']]['label'],
+		);
 	}
 
 	/**
@@ -793,40 +801,40 @@ class Admin extends AbstractController
 		// This is a special array of functions that contain setting data
 		// - we query all these to simply pull all setting bits!
 		$settings_search = array(
-			array('settings_search', 'area=logs;sa=pruning', '\\ElkArte\\AdminController\\AdminLog'),
-			array('config_vars', 'area=corefeatures', '\\ElkArte\\AdminController\\CoreFeatures'),
-			array('basicSettings_search', 'area=featuresettings;sa=basic', '\\ElkArte\\AdminController\\ManageFeatures'),
-			array('layoutSettings_search', 'area=featuresettings;sa=layout', '\\ElkArte\\AdminController\\ManageFeatures'),
-			array('karmaSettings_search', 'area=featuresettings;sa=karma', '\\ElkArte\\AdminController\\ManageFeatures'),
-			array('likesSettings_search', 'area=featuresettings;sa=likes', '\\ElkArte\\AdminController\\ManageFeatures'),
-			array('mentionSettings_search', 'area=featuresettings;sa=mention', '\\ElkArte\\AdminController\\ManageFeatures'),
-			array('signatureSettings_search', 'area=featuresettings;sa=sig', '\\ElkArte\\AdminController\\ManageFeatures'),
-			array('settings_search', 'area=addonsettings;sa=general', '\\ElkArte\\AdminController\\AddonSettings'),
-			array('settings_search', 'area=manageattachments;sa=attachments', '\\ElkArte\\AdminController\\ManageAttachments'),
-			array('settings_search', 'area=manageattachments;sa=avatars', '\\ElkArte\\AdminController\\ManageAvatars'),
-			array('settings_search', 'area=postsettings;sa=bbc', '\\ElkArte\\AdminController\\ManageEditor'),
-			array('settings_search', 'area=manageboards;sa=settings', '\\ElkArte\\AdminController\\ManageBoards'),
-			array('settings_search', 'area=languages;sa=settings', '\\ElkArte\\AdminController\\ManageLanguages'),
-			array('settings_search', 'area=mailqueue;sa=settings', '\\ElkArte\\AdminController\\ManageMail'),
-			array('settings_search', 'area=maillist;sa=emailsettings', '\\ElkArte\\AdminController\\ManageMaillist'),
-			array('settings_search', 'area=membergroups;sa=settings', '\\ElkArte\\AdminController\\ManageMembergroups'),
-			array('settings_search', 'area=news;sa=settings', '\\ElkArte\\AdminController\\ManageNews'),
-			array('settings_search', 'area=paidsubscribe;sa=settings', '\\ElkArte\\AdminController\\ManagePaid'),
-			array('settings_search', 'area=permissions;sa=settings', '\\ElkArte\\AdminController\\ManagePermissions'),
-			array('settings_search', 'area=postsettings;sa=posts', '\\ElkArte\\AdminController\\ManagePosts'),
-			array('settings_search', 'area=regcenter;sa=settings', '\\ElkArte\\AdminController\\ManageRegistration'),
-			array('settings_search', 'area=managesearch;sa=settings', '\\ElkArte\\AdminController\\ManageSearch'),
-			array('settings_search', 'area=sengines;sa=settings', '\\ElkArte\\AdminController\\ManageSearchEngines'),
-			array('securitySettings_search', 'area=securitysettings;sa=general', '\\ElkArte\\AdminController\\ManageSecurity'),
-			array('spamSettings_search', 'area=securitysettings;sa=spam', '\\ElkArte\\AdminController\\ManageSecurity'),
-			array('moderationSettings_search', 'area=securitysettings;sa=moderation', '\\ElkArte\\AdminController\\ManageSecurity'),
-			array('generalSettings_search', 'area=serversettings;sa=general', '\\ElkArte\\AdminController\\ManageServer'),
-			array('databaseSettings_search', 'area=serversettings;sa=database', '\\ElkArte\\AdminController\\ManageServer'),
-			array('cookieSettings_search', 'area=serversettings;sa=cookie', '\\ElkArte\\AdminController\\ManageServer'),
-			array('cacheSettings_search', 'area=serversettings;sa=cache', '\\ElkArte\\AdminController\\ManageServer'),
-			array('balancingSettings_search', 'area=serversettings;sa=loads', '\\ElkArte\\AdminController\\ManageServer'),
-			array('settings_search', 'area=smileys;sa=settings', '\\ElkArte\\AdminController\\ManageSmileys'),
-			array('settings_search', 'area=postsettings;sa=topics', '\\ElkArte\\AdminController\\ManageTopics'),
+			array('settings_search', 'area=logs;sa=pruning', AdminLog::class),
+			array('config_vars', 'area=corefeatures', CoreFeatures::class),
+			array('basicSettings_search', 'area=featuresettings;sa=basic', ManageFeatures::class),
+			array('layoutSettings_search', 'area=featuresettings;sa=layout', ManageFeatures::class),
+			array('karmaSettings_search', 'area=featuresettings;sa=karma', ManageFeatures::class),
+			array('likesSettings_search', 'area=featuresettings;sa=likes', ManageFeatures::class),
+			array('mentionSettings_search', 'area=featuresettings;sa=mention', ManageFeatures::class),
+			array('signatureSettings_search', 'area=featuresettings;sa=sig', ManageFeatures::class),
+			array('settings_search', 'area=addonsettings;sa=general', AddonSettings::class),
+			array('settings_search', 'area=manageattachments;sa=attachments', ManageAttachments::class),
+			array('settings_search', 'area=manageattachments;sa=avatars', ManageAvatars::class),
+			array('settings_search', 'area=postsettings;sa=bbc', ManageEditor::class),
+			array('settings_search', 'area=manageboards;sa=settings', ManageBoards::class),
+			array('settings_search', 'area=languages;sa=settings', ManageLanguages::class),
+			array('settings_search', 'area=mailqueue;sa=settings', ManageMail::class),
+			array('settings_search', 'area=maillist;sa=emailsettings', ManageMaillist::class),
+			array('settings_search', 'area=membergroups;sa=settings', ManageMembergroups::class),
+			array('settings_search', 'area=news;sa=settings', ManageNews::class),
+			array('settings_search', 'area=paidsubscribe;sa=settings', ManagePaid::class),
+			array('settings_search', 'area=permissions;sa=settings', ManagePermissions::class),
+			array('settings_search', 'area=postsettings;sa=posts', ManagePosts::class),
+			array('settings_search', 'area=regcenter;sa=settings', ManageRegistration::class),
+			array('settings_search', 'area=managesearch;sa=settings', ManageSearch::class),
+			array('settings_search', 'area=sengines;sa=settings', ManageSearchEngines::class),
+			array('securitySettings_search', 'area=securitysettings;sa=general', ManageSecurity::class),
+			array('spamSettings_search', 'area=securitysettings;sa=spam', ManageSecurity::class),
+			array('moderationSettings_search', 'area=securitysettings;sa=moderation', ManageSecurity::class),
+			array('generalSettings_search', 'area=serversettings;sa=general', ManageServer::class),
+			array('databaseSettings_search', 'area=serversettings;sa=database', ManageServer::class),
+			array('cookieSettings_search', 'area=serversettings;sa=cookie', ManageServer::class),
+			array('cacheSettings_search', 'area=serversettings;sa=cache', ManageServer::class),
+			array('balancingSettings_search', 'area=serversettings;sa=loads', ManageServer::class),
+			array('settings_search', 'area=smileys;sa=settings', ManageSmileys::class),
+			array('settings_search', 'area=postsettings;sa=topics', ManageTopics::class),
 		);
 
 		// Allow integration to add settings to search
@@ -866,10 +874,10 @@ class Admin extends AbstractController
 		$this->_req->post->membername = un_htmlspecialchars($context['search_term']);
 		$this->_req->post->types = '';
 
-		$managemembers = new ManageMembers(new EventManager());
-		$managemembers->setUser(User::$info);
-		$managemembers->pre_dispatch();
-		$managemembers->action_index();
+		$manageMembers = new ManageMembers(new EventManager());
+		$manageMembers->setUser(User::$info);
+		$manageMembers->pre_dispatch();
+		$manageMembers->action_index();
 	}
 
 	/**
@@ -907,12 +915,12 @@ class Admin extends AbstractController
 		$search_results = fetch_web_data($context['doc_apiurl'] . '?action=query&list=search&srprop=timestamp|snippet&format=xml&srwhat=text&srsearch=' . $postVars);
 
 		// If we didn't get any xml back we are in trouble - perhaps the doc site is overloaded?
-		if (!$search_results || preg_match('~<' . '\?xml\sversion="\d+\.\d+"\?' . '>\s*(<api>.+?</api>)~is', $search_results, $matches) !== 1)
+		if (!$search_results || preg_match('~<\?xml\sversion="\d+\.\d+"\?>\s*(<api>.+?</api>)~is', $search_results, $matches) !== 1)
 		{
 			throw new Exception('cannot_connect_doc_site');
 		}
 
-		$search_results = !empty($matches[1]) ? $matches[1] : '';
+		$search_results = empty($matches[1]) ? '' : $matches[1];
 
 		// Otherwise we simply walk through the XML and stick it in context for display.
 		$context['search_results'] = array();
@@ -936,7 +944,7 @@ class Admin extends AbstractController
 				$context['search_results'][$title] = array(
 					'title' => $title,
 					'relevance' => $relevance++,
-					'snippet' => str_replace('class=\'searchmatch\'', 'class="highlight"', un_htmlspecialchars($result->fetch('@snippet'))),
+					'snippet' => str_replace("class='searchmatch'", 'class="highlight"', un_htmlspecialchars($result->fetch('@snippet'))),
 				);
 			}
 		}

--- a/sources/ElkArte/AdminController/AdminDebug.php
+++ b/sources/ElkArte/AdminController/AdminDebug.php
@@ -36,7 +36,7 @@ class AdminDebug extends AbstractController
 	/**
 	 * Main dispatcher.
 	 *
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{

--- a/sources/ElkArte/AdminController/AdminLog.php
+++ b/sources/ElkArte/AdminController/AdminLog.php
@@ -23,10 +23,8 @@ use ElkArte\Languages\Txt;
  *
  * What it does:
  *
- * - This class manages logs, and forwards to display, pruning,
- * and other actions on logs.
+ * - This class manages logs, and forwards to display, pruning, and other actions on logs.
  *
- * @package AdminLog
  */
 class AdminLog extends AbstractController
 {
@@ -45,24 +43,24 @@ class AdminLog extends AbstractController
 		$subActions = array(
 			'errorlog' => array(
 				'function' => 'action_index',
-				'controller' => '\\ElkArte\\AdminController\\ManageErrors'),
+				'controller' => ManageErrors::class),
 				'disabled' => empty($modSettings['enableErrorLogging']),
 			'adminlog' => array(
 				'function' => 'action_log',
-				'controller' => '\\ElkArte\\AdminController\\Modlog'),
+				'controller' => Modlog::class),
 			'modlog' => array(
 				'function' => 'action_log',
-				'controller' => '\\ElkArte\\AdminController\\Modlog',
+				'controller' => Modlog::class,
 				'disabled' => !featureEnabled('ml') || empty($modSettings['modlog_enabled'])),
 			'banlog' => array(
 				'function' => 'action_log',
-				'controller' => '\\ElkArte\\AdminController\\ManageBans'),
+				'controller' => ManageBans::class),
 			'spiderlog' => array(
 				'function' => 'action_logs',
-				'controller' => '\\ElkArte\\AdminController\\ManageSearchEngines'),
+				'controller' => ManageSearchEngines::class),
 			'tasklog' => array(
 				'function' => 'action_log',
-				'controller' => '\\ElkArte\\AdminController\\ManageScheduledTasks'),
+				'controller' => ManageScheduledTasks::class),
 			'pruning' => array(
 				'controller' => $this,
 				'function' => 'action_pruningSettings_display'),
@@ -178,7 +176,7 @@ class AdminLog extends AbstractController
 			}
 
 			$settingsForm->setConfigVars($savevar);
-			$settingsForm->setConfigValues((array) $_POST);
+			$settingsForm->setConfigValues($_POST);
 			$settingsForm->save();
 			redirectexit('action=admin;area=logs;sa=pruning');
 		}
@@ -190,7 +188,7 @@ class AdminLog extends AbstractController
 		// Get the actual values
 		if (!empty($modSettings['pruningOptions']))
 		{
-			list ($modSettings['pruneErrorLog'], $modSettings['pruneModLog'], $modSettings['pruneBanLog'], $modSettings['pruneReportLog'], $modSettings['pruneScheduledTaskLog'], $modSettings['pruneSpiderHitLog']) = array_pad(explode(',', $modSettings['pruningOptions']), 7, 0);
+			[$modSettings['pruneErrorLog'], $modSettings['pruneModLog'], $modSettings['pruneBanLog'], $modSettings['pruneReportLog'], $modSettings['pruneScheduledTaskLog'], $modSettings['pruneSpiderHitLog']] = array_pad(explode(',', $modSettings['pruningOptions']), 7, 0);
 		}
 		else
 		{
@@ -213,10 +211,8 @@ class AdminLog extends AbstractController
 			['check', 'enableErrorQueryLogging'],
 			// Moderation logging is a Core feature, it enables Admin, Moderation and Profile Edit logging.  This
 			// allows some fine-tuning of that features, e.g. only allow admin logging
-			featureEnabled('ml') ?
-			['check', 'modlog_enabled'] : '',
-			featureEnabled('ml') ?
-			['check', 'userlog_enabled'] : '',
+			featureEnabled('ml') ? ['check', 'modlog_enabled'] : '',
+			featureEnabled('ml') ? ['check', 'userlog_enabled'] : '',
 			// Even do the pruning?
 			['title', 'pruning_title', 'force_div_id' => 'pruning_title'],
 			// The array indexes are here so, we can remove/change them before saving.

--- a/sources/ElkArte/AdminController/CoreFeatures.php
+++ b/sources/ElkArte/AdminController/CoreFeatures.php
@@ -33,14 +33,13 @@ use GlobIterator;
  * - updates the settings for enabled/disabled core features as requested.
  * - loads in module core features
  *
- * @package CoreFeatures
  */
 class CoreFeatures extends AbstractController
 {
 	/**
 	 * Default handler.
 	 *
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -157,7 +156,7 @@ class CoreFeatures extends AbstractController
 			'cp' => array(
 				'url' => getUrl('admin', ['action' => 'admin', 'area' => 'featuresettings', 'sa' => 'profile', '{session_data}']),
 				'save_callback' => 'custom_profiles_toggle_callback',
-				'setting_callback' => function ($value) {
+				'setting_callback' => static function ($value) {
 					if (!$value)
 					{
 						return array(
@@ -166,10 +165,8 @@ class CoreFeatures extends AbstractController
 							'displayFields' => '',
 						);
 					}
-					else
-					{
-						return array();
-					}
+
+					return array();
 				},
 			),
 			// k = karma.
@@ -185,7 +182,7 @@ class CoreFeatures extends AbstractController
 				'settings' => array(
 					'likes_enabled' => 1,
 				),
-				'setting_callback' => function ($value) {
+				'setting_callback' => static function ($value) {
 					global $modSettings;
 
 					require_once(SUBSDIR . '/Mentions.subs.php');
@@ -193,17 +190,13 @@ class CoreFeatures extends AbstractController
 					// Makes all the like/rlike mentions invisible (or visible)
 					toggleMentionsVisibility('likemsg', !empty($value));
 					toggleMentionsVisibility('rlikemsg', !empty($value));
-
-					$current = !empty($modSettings['enabled_mentions']) ? explode(',', $modSettings['enabled_mentions']) : array();
-
+					$current = empty($modSettings['enabled_mentions']) ? array() : explode(',', $modSettings['enabled_mentions']);
 					if (!empty($value))
 					{
 						return array('enabled_mentions' => implode(',', array_unique(array_merge($current, array('likemsg', 'rlikemsg')))));
 					}
-					else
-					{
-						return array('enabled_mentions' => implode(',', array_unique(array_diff($current, array('likemsg', 'rlikemsg')))));
-					}
+
+					return array('enabled_mentions' => implode(',', array_unique(array_diff($current, array('likemsg', 'rlikemsg')))));
 				},
 			),
 			// ml = moderation log.
@@ -227,7 +220,7 @@ class CoreFeatures extends AbstractController
 			// pm = post moderation.
 			'pm' => array(
 				'url' => getUrl('admin', ['action' => 'admin', 'area' => 'permissions', 'sa' => 'postmod', '{session_data}']),
-				'setting_callback' => function ($value) {
+				'setting_callback' => static function ($value) {
 					// Cannot use warning post moderation if disabled!
 					if (!$value)
 					{
@@ -236,10 +229,8 @@ class CoreFeatures extends AbstractController
 
 						return array('warning_moderate' => 0);
 					}
-					else
-					{
-						return array();
-					}
+
+					return array();
 				},
 			),
 			// ps = Paid Subscriptions.
@@ -257,10 +248,10 @@ class CoreFeatures extends AbstractController
 			// w = warning.
 			'w' => array(
 				'url' => getUrl('admin', ['action' => 'admin', 'area' => 'securitysettings', 'sa' => 'moderation']),
-				'setting_callback' => function ($value) {
+				'setting_callback' => static function ($value) {
 					global $modSettings;
 
-					list ($modSettings['warning_enable'], $modSettings['user_limit'], $modSettings['warning_decrement']) = explode(',', $modSettings['warning_settings']);
+					[$modSettings['warning_enable'], $modSettings['user_limit'], $modSettings['warning_decrement']] = explode(',', $modSettings['warning_settings']);
 					$warning_settings = ($value ? 1 : 0) . ',' . $modSettings['user_limit'] . ',' . $modSettings['warning_decrement'];
 					if (!$value)
 					{
@@ -284,7 +275,6 @@ class CoreFeatures extends AbstractController
 					}
 
 					$returnSettings['warning_settings'] = $warning_settings;
-
 					return $returnSettings;
 				},
 			),
@@ -294,14 +284,14 @@ class CoreFeatures extends AbstractController
 				'settings' => array(
 					'spider_mode' => 1,
 				),
-				'setting_callback' => function ($value) {
+				'setting_callback' => static function ($value) {
 					// Turn off the spider group if disabling.
 					if (!$value)
 					{
 						return array('spider_group' => 0, 'show_spider_online' => 0, 'spider_no_guest' => 0);
 					}
 				},
-				'on_save' => function () {
+				'on_save' => static function () {
 					require_once(SUBSDIR . '/SearchEngines.subs.php');
 				},
 			),
@@ -319,7 +309,7 @@ class CoreFeatures extends AbstractController
 	 * Searches the ADMINDIR looking for module managers and load the "Core Feature"
 	 * if existing.
 	 *
-	 * @param mixed[] $core_features The core features array
+	 * @param array $core_features The core features array
 	 */
 	protected function _getModulesConfig(&$core_features)
 	{
@@ -347,14 +337,14 @@ class CoreFeatures extends AbstractController
 
 			if (method_exists($integration['class'], 'setting_callback'))
 			{
-				$core_features[$integration['id']]['setting_callback'] = function ($value) use ($integration) {
+				$core_features[$integration['id']]['setting_callback'] = static function ($value) use ($integration) {
 					$integration['class']::setting_callback($value);
 				};
 			}
 
 			if (method_exists($integration['class'], 'on_save'))
 			{
-				$core_features[$integration['id']]['on_save'] = function () use ($integration) {
+				$core_features[$integration['id']]['on_save'] = static function () use ($integration) {
 					$integration['class']::on_save();
 				};
 			}
@@ -365,7 +355,7 @@ class CoreFeatures extends AbstractController
 	 * This function makes sure the requested subaction does exists, if it
 	 * doesn't, it sets a default action.
 	 *
-	 * @param mixed[] $subActions = array() An array containing all possible subactions.
+	 * @param array $subActions = array() An array containing all possible subactions.
 	 * @param string $defaultAction = '' the default action to be called if no valid subaction was found.
 	 */
 	public function loadGeneralSettingParameters($subActions = array(), $defaultAction = '')
@@ -391,7 +381,7 @@ class CoreFeatures extends AbstractController
 	/**
 	 * Takes care os saving the core features status (enabled/disabled)
 	 *
-	 * @param mixed[] $core_features - The array of all the core features, as
+	 * @param array $core_features - The array of all the core features, as
 	 *                returned by $this->settings()
 	 */
 	private function _save_core_features($core_features)
@@ -418,7 +408,7 @@ class CoreFeatures extends AbstractController
 				{
 					if (empty($feature_id) || (!empty($feature_id) && ($value < 2 || empty($modSettings[$key]))))
 					{
-						$setting_changes[$key] = !empty($feature_id) ? $value : !$value;
+						$setting_changes[$key] = empty($feature_id) ? !$value : $value;
 					}
 				}
 			}
@@ -467,8 +457,7 @@ class CoreFeatures extends AbstractController
 	/**
 	 * Puts the core features data into a format usable by the template
 	 *
-	 * @param mixed[] $core_features - The array of all the core features, as
-	 *                returned by $this->settings()
+	 * @param array $core_features - The array of all the core features, as returned by $this->settings()
 	 *
 	 * @return array
 	 */
@@ -490,9 +479,7 @@ class CoreFeatures extends AbstractController
 		}
 
 		// Sort by title attribute
-		uasort($features, static function ($a, $b) {
-			return strcmp(strtolower($a['title']), strtolower($b['title']));
-		});
+		uasort($features, static fn($a, $b) => strcmp(strtolower($a['title']), strtolower($b['title'])));
 
 		return $features;
 	}
@@ -502,7 +489,7 @@ class CoreFeatures extends AbstractController
 	 *
 	 * - Callback for admin internal search.
 	 *
-	 * @return mixed[] array in a config_var format
+	 * @return array array in a config_var format
 	 */
 	public function config_vars()
 	{

--- a/sources/ElkArte/AdminController/ManageAttachments.php
+++ b/sources/ElkArte/AdminController/ManageAttachments.php
@@ -1483,7 +1483,10 @@ class ManageAttachments extends AbstractController
 			$update = array('currentAttachmentUploadDir' => $current_dir, 'attachmentUploadDir' => serialize($new_dirs),);
 		}
 
-		updateSettings($update);
+		if (!empty($update))
+		{
+			updateSettings($update);
+		}
 
 		if (!empty($errors))
 		{
@@ -1576,7 +1579,7 @@ class ManageAttachments extends AbstractController
 			$update = ['attachment_basedirectories' => serialize($attachmentBaseDirectories), 'basedirectory_for_attachments' => $new_base_dir, 'currentAttachmentUploadDir' => $current_dir,];
 		}
 
-		$_SESSION['errors']['base'] = $errors;
+		$_SESSION['errors']['base'] = $errors ?? null;
 
 		if (!empty($update))
 		{

--- a/sources/ElkArte/AdminController/ManageAvatars.php
+++ b/sources/ElkArte/AdminController/ManageAvatars.php
@@ -40,7 +40,7 @@ class ManageAvatars extends AbstractController
 	 * - requires manage_attachments permissions
 	 *
 	 * @event integrate_sa_manage_avatars
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -105,7 +105,7 @@ class ManageAvatars extends AbstractController
 		}
 
 		// Attempt to figure out if the admin is trying to break things.
-		$context['settings_save_onclick'] = 'return (document.getElementById(\'custom_avatar_dir\').value == \'\' || document.getElementById(\'custom_avatar_url\').value == \'\') ? confirm(\'' . $txt['custom_avatar_check_empty'] . '\') : true;';
+		$context['settings_save_onclick'] = "return (document.getElementById('custom_avatar_dir').value == '' || document.getElementById('custom_avatar_url').value == '') ? confirm('" . $txt['custom_avatar_check_empty'] . "') : true;";
 
 		// Prepare the context.
 		$context['post_url'] = getUrl('admin', ['action' => 'admin', 'area' => 'manageattachments', 'sa' => 'avatars', 'save']);
@@ -147,7 +147,7 @@ class ManageAvatars extends AbstractController
 			array('permissions', 'profile_set_avatar', 0, $txt['profile_set_avatar']),
 			// Server stored avatars!
 			array('title', 'avatar_server_stored'),
-			array('warning', empty($testImg) ? 'avatar_img_enc_warning' : ''),
+			array('warning', $testImg === false ? 'avatar_img_enc_warning' : ''),
 			array('check', 'avatar_stored_enabled'),
 			array('text', 'avatar_directory', 40, 'invalid' => !$context['valid_avatar_dir']),
 			array('text', 'avatar_url', 40),

--- a/sources/ElkArte/AdminController/ManageBoards.php
+++ b/sources/ElkArte/AdminController/ManageBoards.php
@@ -34,18 +34,10 @@ use ElkArte\Util;
  */
 class ManageBoards extends AbstractController
 {
-	/**
-	 * Category being worked on
-	 *
-	 * @var int
-	 */
+	/** @var int Category being worked on */
 	public $cat;
 
-	/**
-	 * Current board id being modified
-	 *
-	 * @var int
-	 */
+	/** @var int Current board id being modified */
 	public $boardid;
 
 	/**
@@ -61,7 +53,7 @@ class ManageBoards extends AbstractController
 	 */
 	public function action_index()
 	{
-		global $context, $txt;
+		global $context;
 
 		// Everything's gonna need this.
 		Txt::load('ManageBoards');
@@ -228,7 +220,7 @@ class ManageBoards extends AbstractController
 					{
 						$context['categories'][$catid]['move_link'] = array(
 							'child_level' => 0,
-							'label' => $txt['mboards_order_before'] . ' \'' . htmlspecialchars($boards[$boardid]['name'], ENT_COMPAT, 'UTF-8') . '\'',
+							'label' => $txt['mboards_order_before'] . " '" . htmlspecialchars($boards[$boardid]['name'], ENT_COMPAT, 'UTF-8') . "'",
 							'href' => getUrl('admin', ['action' => 'admin', 'area' => 'manageboards', 'sa' => 'move', 'src_board' => $context['move_board'], 'target_board' => $boardid, 'move_to' => 'before', '{session_data}', $security_token]),
 						);
 					}
@@ -238,21 +230,21 @@ class ManageBoards extends AbstractController
 						$context['categories'][$catid]['boards'][$boardid]['move_links'] = array(
 							array(
 								'child_level' => $boards[$boardid]['level'],
-								'label' => $txt['mboards_order_after'] . '\'' . htmlspecialchars($boards[$boardid]['name'], ENT_COMPAT, 'UTF-8') . '\'',
+								'label' => $txt['mboards_order_after'] . "'" . htmlspecialchars($boards[$boardid]['name'], ENT_COMPAT, 'UTF-8') . "'",
 								'href' => getUrl('admin', ['action' => 'admin', 'area' => 'manageboards', 'sa' => 'move', 'src_board' => $context['move_board'], 'target_board' => $boardid, 'move_to' => 'after', '{session_data}', $security_token]),
 							),
 							array(
 								'child_level' => $boards[$boardid]['level'] + 1,
-								'label' => $txt['mboards_order_child_of'] . ' \'' . htmlspecialchars($boards[$boardid]['name'], ENT_COMPAT, 'UTF-8') . '\'',
+								'label' => $txt['mboards_order_child_of'] . " '" . htmlspecialchars($boards[$boardid]['name'], ENT_COMPAT, 'UTF-8') . "'",
 								'href' => getUrl('admin', ['action' => 'admin', 'area' => 'manageboards', 'sa' => 'move', 'src_board' => $context['move_board'], 'target_board' => $boardid, 'move_to' => 'child', '{session_data}', $security_token]),
 							),
 						);
 					}
 
 					$difference = $boards[$boardid]['level'] - $prev_child_level;
-					if ($difference == 1)
+					if ($difference === 1)
 					{
-						$stack[] = !empty($context['categories'][$catid]['boards'][$prev_board]['move_links']) ? array_shift($context['categories'][$catid]['boards'][$prev_board]['move_links']) : null;
+						$stack[] = empty($context['categories'][$catid]['boards'][$prev_board]['move_links']) ? null : array_shift($context['categories'][$catid]['boards'][$prev_board]['move_links']);
 					}
 					elseif ($difference < 0)
 					{
@@ -287,7 +279,7 @@ class ManageBoards extends AbstractController
 				{
 					$context['categories'][$catid]['move_link'] = array(
 						'child_level' => 0,
-						'label' => $txt['mboards_order_before'] . ' \'' . htmlspecialchars($tree['node']['name'], ENT_COMPAT, 'UTF-8') . '\'',
+						'label' => $txt['mboards_order_before'] . " '" . htmlspecialchars($tree['node']['name'], ENT_COMPAT, 'UTF-8') . "'",
 						'href' => getUrl('admin', ['action' => 'admin', 'area' => 'manageboards', 'sa' => 'move', 'src_board' => $context['move_board'], 'target_cat' => $catid, 'move_to' => 'top', '{session_data}', $security_token]),
 					);
 				}
@@ -333,7 +325,6 @@ class ManageBoards extends AbstractController
 
 			// Change "This & That" to "This &amp; That" but don't change "&cent" to "&amp;cent;"...
 			$catOptions['cat_name'] = preg_replace('~[&]([^;]{8}|[^;]{0,8}$)~', '&amp;$1', $this->_req->post->cat_name);
-
 			$catOptions['is_collapsible'] = isset($this->_req->post->collapse);
 
 			if (isset($this->_req->post->add))
@@ -582,11 +573,11 @@ class ManageBoards extends AbstractController
 			}
 
 			// Are they doing redirection?
-			$boardOptions['redirect'] = !$this->_req->comparePost('redirect_address', '', 'trim') ? $this->_req->get('redirect_address') : '';
+			$boardOptions['redirect'] = $this->_req->comparePost('redirect_address', '', 'trim') ? '' : $this->_req->get('redirect_address');
 
 			// Profiles...
 			$boardOptions['profile'] = $this->_req->post->profile;
-			$boardOptions['inherit_permissions'] = $this->_req->post->profile == -1;
+			$boardOptions['inherit_permissions'] = (int) $this->_req->post->profile === -1;
 
 			// We need to know what used to be case in terms of redirection.
 			if (!empty($board_id))
@@ -620,6 +611,7 @@ class ManageBoards extends AbstractController
 				{
 					$boardOptions['target_category'] = $this->_req->getPost('cur_cat', 'intval', 0);
 				}
+
 				if (!isset($boardOptions['move_to']))
 				{
 					$boardOptions['move_to'] = 'bottom';
@@ -639,30 +631,26 @@ class ManageBoards extends AbstractController
 			{
 				throw new Exception('mboards_delete_board_has_posts');
 			}
-			else
-			{
-				$this->action_board();
-			}
+			$this->action_board();
 
 			return;
 		}
 		elseif (isset($this->_req->post->delete))
 		{
 			$boardTree = new BoardsTree(database());
-
 			// First, check if our board still has posts or topics.
 			if ($posts)
 			{
 				throw new Exception('mboards_delete_board_has_posts');
 			}
-			elseif ($this->_req->comparePost('delete_action', 1, 'intval'))
+
+			if ($this->_req->comparePost('delete_action', 1, 'intval'))
 			{
 				// Check if we are moving all the current sub-boards first - before we start deleting!
 				if (empty($this->_req->post->board_to))
 				{
 					throw new Exception('mboards_delete_board_error');
 				}
-
 				$boardTree->deleteBoards(array($board_id), $this->_req->getPost('board_to', 'intval'));
 			}
 			else
@@ -797,7 +785,7 @@ class ManageBoards extends AbstractController
 		foreach ($catBoards as $boardid)
 		{
 			$thisBoard = $boardTree->getBoardById($boardid);
-			if ($boardid == $this->boardid)
+			if ($boardid === $this->boardid)
 			{
 				$context['board_order'][] = array(
 					'id' => $boardid,
@@ -813,7 +801,7 @@ class ManageBoards extends AbstractController
 				$context['board_order'][] = array(
 					'id' => $boardid,
 					'name' => str_repeat('-', $thisBoard['level']) . ' ' . $thisBoard['name'],
-					'is_child' => empty($this->boardid) ? false : $boardTree->isChildOf($boardid, $this->boardid),
+					'is_child' => !empty($this->boardid) && $boardTree->isChildOf($boardid, $this->boardid),
 					'selected' => false
 				);
 			}
@@ -826,10 +814,17 @@ class ManageBoards extends AbstractController
 			$context['children'] = $curBoard['tree']['children'];
 			foreach ($context['board_order'] as $board)
 			{
-				if ($board['is_child'] === false && $board['selected'] === false)
+				if ($board['is_child'] !== false)
 				{
-					$context['can_move_children'] = true;
+					continue;
 				}
+
+				if ($board['selected'] !== false)
+				{
+					continue;
+				}
+
+				$context['can_move_children'] = true;
 			}
 		}
 
@@ -850,7 +845,7 @@ class ManageBoards extends AbstractController
 
 		if (!empty($context['board']['moderators']))
 		{
-			list ($context['board']['last_moderator_id']) = array_slice(array_keys($context['board']['moderators']), -1);
+			[$context['board']['last_moderator_id']] = array_slice(array_keys($context['board']['moderators']), -1);
 		}
 
 		$context['themes'] = getAllThemes();
@@ -900,7 +895,7 @@ class ManageBoards extends AbstractController
 		$context['post_url'] = getUrl('admin', ['action' => 'admin', 'area' => 'manageboards', 'sa' => 'settings', 'save']);
 
 		// Warn the admin against selecting the recycle topic without selecting a board.
-		$context['force_form_onsubmit'] = 'if(document.getElementById(\'recycle_enable\').checked && document.getElementById(\'recycle_board\').value == 0) { return confirm(\'' . $txt['recycle_board_unselected_notice'] . '\');} return true;';
+		$context['force_form_onsubmit'] = "if(document.getElementById('recycle_enable').checked && document.getElementById('recycle_board').value == 0) { return confirm('" . $txt['recycle_board_unselected_notice'] . "');} return true;";
 
 		// Doing a save?
 		if (isset($this->_req->query->save))
@@ -947,7 +942,7 @@ class ManageBoards extends AbstractController
 			'',
 			// Other board settings.
 			array('check', 'countChildPosts'),
-			array('check', 'recycle_enable', 'onclick' => 'document.getElementById(\'recycle_board\').disabled = !this.checked;'),
+			array('check', 'recycle_enable', 'onclick' => "document.getElementById('recycle_board').disabled = !this.checked;"),
 			array('select', 'recycle_board', $recycle_boards),
 			array('check', 'allow_ignore_boards'),
 			array('check', 'deny_boards_access'),

--- a/sources/ElkArte/AdminController/ManageCalendarModule.php
+++ b/sources/ElkArte/AdminController/ManageCalendarModule.php
@@ -33,7 +33,7 @@ class ManageCalendarModule extends AbstractController
 	/**
 	 * Used to add the Calendar entry to the Core Features list.
 	 *
-	 * @param mixed[] $core_features The core features array
+	 * @param array $core_features The core features array
 	 */
 	public static function addCoreFeature(&$core_features)
 	{
@@ -42,7 +42,7 @@ class ManageCalendarModule extends AbstractController
 			'settings' => array(
 				'cal_enabled' => 1,
 			),
-			'setting_callback' => function ($value) {
+			'setting_callback' => static function ($value) {
 				if ($value)
 				{
 					enableModules('calendar', array('admin', 'post', 'boardindex', 'display'));
@@ -164,11 +164,11 @@ class ManageCalendarModule extends AbstractController
 						'value' => $txt['date'],
 					),
 					'data' => array(
-						'function' => function ($rowData) {
+						'function' => static function ($rowData) {
 							global $txt;
 
 							// Recurring every year or just a single year?
-							$year = $rowData['year'] == '0004' ? sprintf('(%1$s)', $txt['every_year']) : $rowData['year'];
+							$year = $rowData['year'] === '0004' ? sprintf('(%1$s)', $txt['every_year']) : $rowData['year'];
 
 							// Construct the date.
 							return sprintf('%1$d %2$s %3$s', $rowData['day'], $txt['months'][(int) $rowData['month']], $year);
@@ -232,7 +232,7 @@ class ManageCalendarModule extends AbstractController
 
 		$context['is_new'] = !isset($this->_req->query->holiday);
 		$context['cal_minyear'] = $modSettings['cal_minyear'];
-		$context['cal_maxyear'] = date('Y') + $modSettings['cal_limityear'];
+		$context['cal_maxyear'] = (int) date('Y') + (int) $modSettings['cal_limityear'];
 		$context['page_title'] = $context['is_new'] ? $txt['holidays_add'] : $txt['holidays_edit'];
 		$context['sub_template'] = 'edit_holiday';
 
@@ -288,9 +288,9 @@ class ManageCalendarModule extends AbstractController
 		// Last day for the drop down?
 		$context['holiday']['last_day'] = (int) Util::strftime('%d', mktime(0, 0, 0, $context['holiday']['month'] == 12
 			? 1
-			: $context['holiday']['month'] + 1, 0, $context['holiday']['month'] == 12
-				? $context['holiday']['year'] + 1
-				: $context['holiday']['year']));
+			: $context['holiday']['month'] + 1, 0, $context['holiday']['month'] === 12
+			? $context['holiday']['year'] + 1
+			: $context['holiday']['year']));
 	}
 
 	/**

--- a/sources/ElkArte/AdminController/ManageDraftsModule.php
+++ b/sources/ElkArte/AdminController/ManageDraftsModule.php
@@ -13,11 +13,13 @@
 namespace ElkArte\AdminController;
 
 use ElkArte\AbstractController;
+use ElkArte\DraftsIntegrate;
 use ElkArte\EventManager;
 use ElkArte\Hooks;
-use ElkArte\SettingsForm\SettingsForm;
 use ElkArte\Languages\Txt;
+use ElkArte\SettingsForm\SettingsForm;
 use ElkArte\User;
+use Exception;
 
 /**
  * Drafts administration controller.
@@ -43,10 +45,9 @@ class ManageDraftsModule extends AbstractController
 				'drafts_autosave_enabled' => 2,
 				'drafts_show_saved_enabled' => 2,
 			),
-			'setting_callback' => function ($value) {
+			'setting_callback' => static function ($value) {
 				require_once(SUBSDIR . '/ScheduledTasks.subs.php');
 				toggleTaskStatusByName('remove_old_drafts', $value);
-
 				$modules = array('admin', 'post', 'display', 'profile', 'personalmessage');
 
 				// Enabling, let's register the modules and prepare the scheduled task
@@ -54,13 +55,13 @@ class ManageDraftsModule extends AbstractController
 				{
 					enableModules('drafts', $modules);
 					calculateNextTrigger('remove_old_drafts');
-					Hooks::instance()->enableIntegration('\\ElkArte\\DraftsIntegrate');
+					Hooks::instance()->enableIntegration(DraftsIntegrate::class);
 				}
 				// Disabling, just forget about the modules
 				else
 				{
 					disableModules('drafts', $modules);
-					Hooks::instance()->disableIntegration('\\ElkArte\\DraftsIntegrate');
+					Hooks::instance()->disableIntegration(DraftsIntegrate::class);
 				}
 			},
 		);
@@ -70,7 +71,7 @@ class ManageDraftsModule extends AbstractController
 	 * Integrate drafts in to the delete member chain
 	 *
 	 * @param int[] $users
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public static function integrate_delete_members($users)
 	{
@@ -146,7 +147,7 @@ class ManageDraftsModule extends AbstractController
 	 */
 	public static function integrate_sa_manage_maintenance(&$subActions)
 	{
-		$subActions['topics']['activities']['olddrafts'] = function () {
+		$subActions['topics']['activities']['olddrafts'] = static function () {
 			$controller = new ManageDraftsModule(new EventManager());
 			$controller->setUser(User::$info);
 			$controller->pre_dispatch();

--- a/sources/ElkArte/AdminController/ManageEditor.php
+++ b/sources/ElkArte/AdminController/ManageEditor.php
@@ -35,7 +35,7 @@ class ManageEditor extends AbstractController
 	 * - requires admin_forum permissions
 	 *
 	 * @event integrate_sa_manage_editor Used to add more sub actions
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -133,7 +133,7 @@ class ManageEditor extends AbstractController
 	{
 		$config_vars = array(
 			array('check', 'enableBBC'),
-			array('check', 'enableBBC', 0, 'onchange' => 'toggleBBCDisabled(\'disabledBBC\', !this.checked);'),
+			array('check', 'enableBBC', 0, 'onchange' => "toggleBBCDisabled('disabledBBC', !this.checked);"),
 			array('bbc', 'disabledBBC'),
 
 			array('title', 'editorSettings'),

--- a/sources/ElkArte/AdminController/ManageEmojiModule.php
+++ b/sources/ElkArte/AdminController/ManageEmojiModule.php
@@ -17,6 +17,9 @@ use ElkArte\FileFunctions;
 use ElkArte\HttpReq;
 use ElkArte\Languages\Txt;
 use ElkArte\UnZip;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  * Emoji administration controller.
@@ -66,13 +69,11 @@ abstract class ManageEmojiModule extends AbstractController
 		}
 
 		// An emoji group was selected, unzip them if required
-		if (!FileFunctions::instance()->fileExists(BOARDDIR . '/smileys/' . $req->post->emoji_selection . '\1f44d.svg'))
+		if (!FileFunctions::instance()->fileExists(BOARDDIR . '/smileys/' . $req->post->emoji_selection . '\1f44d.svg')
+			&& self::unZipEmoji($req))
 		{
-			if (self::unZipEmoji($req))
-			{
-				self::removeEmoji($req);
-				self::copyEmojiToSmiley($req);
-			}
+			self::removeEmoji($req);
+			self::copyEmojiToSmiley($req);
 		}
 	}
 
@@ -116,10 +117,10 @@ abstract class ManageEmojiModule extends AbstractController
 		$fileFunc = FileFunctions::instance();
 		if ($fileFunc->isDir($source))
 		{
-			$iterator = new \RecursiveDirectoryIterator($source, \FilesystemIterator::SKIP_DOTS);
-			$files = new \RecursiveIteratorIterator($iterator, \RecursiveIteratorIterator::CHILD_FIRST, \RecursiveIteratorIterator::CATCH_GET_CHILD);
+			$iterator = new RecursiveDirectoryIterator($source, FilesystemIterator::SKIP_DOTS);
+			$files = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::CHILD_FIRST, RecursiveIteratorIterator::CATCH_GET_CHILD);
 
-			/** @var \FilesystemIterator $file */
+			/** @var FilesystemIterator $file */
 			foreach ($files as $file)
 			{
 				if ($file->getExtension() === 'svg')

--- a/sources/ElkArte/AdminController/ManageErrors.php
+++ b/sources/ElkArte/AdminController/ManageErrors.php
@@ -19,8 +19,8 @@ namespace ElkArte\AdminController;
 
 use ElkArte\AbstractController;
 use ElkArte\Errors\Log;
-use ElkArte\MembersList;
 use ElkArte\Languages\Txt;
+use ElkArte\MembersList;
 
 /**
  * ManageErrors controller, administration of error log.
@@ -34,7 +34,7 @@ class ManageErrors extends AbstractController
 	 * Calls the right handler.
 	 * Requires admin_forum permission.
 	 *
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -144,7 +144,7 @@ class ManageErrors extends AbstractController
 			// Go back to where we were.
 			if ($type === 'delete')
 			{
-				redirectexit('action=admin;area=logs;sa=errorlog' . (isset($this->_req->query->desc) ? ';desc' : '') . ';start=' . $this->_req->query->start . (!empty($filter) ? ';filter=' . $this->_req->query->filter . ';value=' . $this->_req->query->value : ''));
+				redirectexit('action=admin;area=logs;sa=errorlog' . (isset($this->_req->query->desc) ? ';desc' : '') . ';start=' . $this->_req->query->start . (empty($filter) ? '' : ';filter=' . $this->_req->query->filter . ';value=' . $this->_req->query->value));
 			}
 
 			redirectexit('action=admin;area=logs;sa=errorlog' . (isset($this->_req->query->desc) ? ';desc' : ''));
@@ -196,7 +196,7 @@ class ManageErrors extends AbstractController
 		$context['error_types']['all'] = array(
 			'label' => $txt['errortype_all'],
 			'description' => $txt['errortype_all_desc'] ?? '',
-			'url' => getUrl('admin', ['action' => 'admin', 'area' => 'logs', 'sa' => 'errorlog', $context['sort_direction'] == 'down' ? 'desc' : '']),
+			'url' => getUrl('admin', ['action' => 'admin', 'area' => 'logs', 'sa' => 'errorlog', $context['sort_direction'] === 'down' ? 'desc' : '']),
 			'is_selected' => empty($filter),
 		);
 
@@ -245,11 +245,10 @@ class ManageErrors extends AbstractController
 
 		$filter = $this->_req->getQuery('filter', 'trim', null);
 		$value = $this->_req->getQuery('value', 'trim', null);
-
 		// Set up the filtering...
 		if (isset($value, $filters[$filter]))
 		{
-			$filter = array(
+			return array(
 				'variable' => $filter,
 				'value' => array(
 					'sql' => in_array($filter, array('message', 'url', 'file'))
@@ -260,17 +259,13 @@ class ManageErrors extends AbstractController
 				'entity' => $filters[$filter]
 			);
 		}
-		else
-		{
-			if (isset($filter, $value))
-			{
-				unset($this->_req->query->filter, $this->_req->query->value);
-			}
 
-			$filter = [];
+		if (isset($filter, $value))
+		{
+			unset($this->_req->query->filter, $this->_req->query->value);
 		}
 
-		return $filter;
+		return [];
 	}
 
 	/**
@@ -323,14 +318,14 @@ class ManageErrors extends AbstractController
 					$context['filter']['value']['html'] = '<a href="' . getUrl('profile', ['action' => 'profile', 'u' => $id, 'name' => $name]) . '">' . $name . '</a>';
 					break;
 				case 'url':
-					$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars((substr($filter['value']['sql'], 0, 1) === '?' ? $scripturl : '') . $filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array('\_' => '_')) . '\'';
+					$context['filter']['value']['html'] = "'" . strtr(htmlspecialchars((substr($filter['value']['sql'], 0, 1) === '?' ? $scripturl : '') . $filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array('\_' => '_')) . "'";
 					break;
 				case 'message':
-					$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars($filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array("\n" => '<br />', '&lt;br /&gt;' => '<br />', "\t" => '&nbsp;&nbsp;&nbsp;', '\_' => '_', '\\%' => '%', '\\\\' => '\\')) . '\'';
+					$context['filter']['value']['html'] = "'" . strtr(htmlspecialchars($filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array("\n" => '<br />', '&lt;br /&gt;' => '<br />', "\t" => '&nbsp;&nbsp;&nbsp;', '\_' => '_', '\\%' => '%', '\\\\' => '\\')) . "'";
 					$context['filter']['value']['html'] = preg_replace('~&amp;lt;span class=&amp;quot;remove&amp;quot;&amp;gt;(.+?)&amp;lt;/span&amp;gt;~', '$1', $context['filter']['value']['html']);
 					break;
 				case 'error_type':
-					$context['filter']['value']['html'] = '\'' . strtr(htmlspecialchars($filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array("\n" => '<br />', '&lt;br /&gt;' => '<br />', "\t" => '&nbsp;&nbsp;&nbsp;', '\_' => '_', '\\%' => '%', '\\\\' => '\\')) . '\'';
+					$context['filter']['value']['html'] = "'" . strtr(htmlspecialchars($filter['value']['sql'], ENT_COMPAT, 'UTF-8'), array("\n" => '<br />', '&lt;br /&gt;' => '<br />', "\t" => '&nbsp;&nbsp;&nbsp;', '\_' => '_', '\\%' => '%', '\\\\' => '\\')) . "'";
 					break;
 				default:
 					$context['filter']['value']['html'] = &$filter['value']['sql'];

--- a/sources/ElkArte/AdminController/ManagePosts.php
+++ b/sources/ElkArte/AdminController/ManagePosts.php
@@ -40,7 +40,7 @@ class ManagePosts extends AbstractController
 	 * - Requires (and checks for) the admin_forum permission.
 	 *
 	 * @event integrate_sa_manage_posts used to add new subactions
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -53,7 +53,7 @@ class ManagePosts extends AbstractController
 				$this, 'action_censor', 'permission' => 'admin_forum'),
 			'topics' => array(
 				'function' => 'action_index',
-				'controller' => '\\ElkArte\\AdminController\\ManageTopics',
+				'controller' => ManageTopics::class,
 				'permission' => 'admin_forum'),
 		);
 
@@ -121,7 +121,7 @@ class ManagePosts extends AbstractController
 
 				foreach ($this->_req->post->censortext as $c)
 				{
-					list ($censored_vulgar[], $censored_proper[]) = array_pad(explode('=', trim($c)), 2, '');
+					[$censored_vulgar[], $censored_proper[]] = array_pad(explode('=', trim($c)), 2, '');
 				}
 			}
 			elseif (isset($this->_req->post->censor_vulgar, $this->_req->post->censor_proper))
@@ -178,7 +178,7 @@ class ManagePosts extends AbstractController
 		$context['censored_words'] = array();
 		foreach ($censor_vulgar as $i => $censor_vulgar_i)
 		{
-			if (empty($censor_vulgar_i))
+			if ($censor_vulgar_i === '' || $censor_vulgar_i === '0')
 			{
 				continue;
 			}
@@ -279,7 +279,7 @@ class ManagePosts extends AbstractController
 			// Set a min quote length of 3 lines of text (@ default font size)
 			if (!empty($this->_req->post->heightBeforeShowMore))
 			{
-				$this->_req->post->heightBeforeShowMore = (int) max((int) $this->_req->post->heightBeforeShowMore, 155);
+				$this->_req->post->heightBeforeShowMore = max((int) $this->_req->post->heightBeforeShowMore, 155);
 			}
 
 			call_integration_hook('integrate_save_post_settings');

--- a/sources/ElkArte/AdminController/ManageRegistration.php
+++ b/sources/ElkArte/AdminController/ManageRegistration.php
@@ -23,9 +23,9 @@ use ElkArte\Agreement;
 use ElkArte\Errors\ErrorContext;
 use ElkArte\Exceptions\Exception;
 use ElkArte\FileFunctions;
+use ElkArte\Languages\Txt;
 use ElkArte\PrivacyPolicy;
 use ElkArte\SettingsForm\SettingsForm;
-use ElkArte\Languages\Txt;
 use ElkArte\TokenHash;
 use ElkArte\Util;
 
@@ -51,7 +51,7 @@ class ManageRegistration extends AbstractController
 	 * @event integrate_sa_manage_registrations add new registration sub actions
 	 * @uses Login language file
 	 * @uses Register template.
-	 * @see  \ElkArte\AbstractController::action_index()
+	 * @see  AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -515,7 +515,7 @@ class ManageRegistration extends AbstractController
 			checkCoppa();', true);
 
 		// Turn the postal address into something suitable for a textbox.
-		$modSettings['coppaPost'] = !empty($modSettings['coppaPost']) ? preg_replace('~<br ?/?' . '>~', "\n", $modSettings['coppaPost']) : '';
+		$modSettings['coppaPost'] = empty($modSettings['coppaPost']) ? '' : preg_replace('~<br ?/?>~', "\n", $modSettings['coppaPost']);
 
 		$settingsForm->prepare();
 	}

--- a/sources/ElkArte/AdminController/ManageScheduledTasks.php
+++ b/sources/ElkArte/AdminController/ManageScheduledTasks.php
@@ -40,7 +40,7 @@ class ManageScheduledTasks extends AbstractController
 	 * @uses ManageScheduledTasks template file
 	 * @uses ManageScheduledTasks language file
 	 *
-	 * @see  \ElkArte\AbstractController::action_index()
+	 * @see  AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -160,9 +160,7 @@ class ManageScheduledTasks extends AbstractController
 			'title' => $txt['maintain_tasks'],
 			'base_href' => getUrl('admin', ['action' => 'admin', 'area' => 'scheduledtasks']),
 			'get_items' => array(
-				'function' => function () {
-					return $this->list_getScheduledTasks();
-				},
+				'function' => fn() => $this->list_getScheduledTasks(),
 			),
 			'columns' => array(
 				'name' => array(
@@ -297,6 +295,7 @@ class ManageScheduledTasks extends AbstractController
 		{
 			throw new Exception('no_access', false);
 		}
+
 		$this->_req->query->tid = (int) $this->_req->query->tid;
 
 		// Saving?
@@ -313,6 +312,7 @@ class ManageScheduledTasks extends AbstractController
 			{
 				$matches[2] = 0;
 			}
+
 			if (!isset($matches[1]) || $matches[1] > 23)
 			{
 				$matches[1] = 0;
@@ -332,7 +332,7 @@ class ManageScheduledTasks extends AbstractController
 			}
 
 			// Is it disabled?
-			$disabled = !isset($this->_req->post->enabled) ? 1 : 0;
+			$disabled = isset($this->_req->post->enabled) ? 0 : 1;
 
 			// Do the update!
 			$this->_req->query->tid = (int) $this->_req->query->tid;
@@ -384,14 +384,10 @@ class ManageScheduledTasks extends AbstractController
 			'base_href' => $context['admin_area'] === 'scheduledtasks' ? getUrl('admin', ['action' => 'admin', 'area' => 'scheduledtasks', 'sa' => 'tasklog']) : getUrl('admin', ['action' => 'admin', 'area' => 'logs', 'sa' => 'tasklog']),
 			'default_sort_col' => 'date',
 			'get_items' => array(
-				'function' => function ($start, $items_per_page, $sort) {
-					return $this->list_getTaskLogEntries($start, $items_per_page, $sort);
-				},
+				'function' => fn($start, $items_per_page, $sort) => $this->list_getTaskLogEntries($start, $items_per_page, $sort),
 			),
 			'get_count' => array(
-				'function' => function () {
-					return $this->list_getNumTaskLogEntries();
-				},
+				'function' => fn() => $this->list_getNumTaskLogEntries(),
 			),
 			'columns' => array(
 				'name' => array(
@@ -407,9 +403,7 @@ class ManageScheduledTasks extends AbstractController
 						'value' => $txt['scheduled_log_time_run'],
 					),
 					'data' => array(
-						'function' => function ($rowData) {
-							return standardTime($rowData['time_run'], true);
-						},
+						'function' => static fn($rowData) => standardTime($rowData['time_run'], true),
 					),
 					'sort' => array(
 						'default' => 'lst.id_log DESC',
@@ -438,7 +432,7 @@ class ManageScheduledTasks extends AbstractController
 						'value' => $txt['scheduled_log_completed'],
 					),
 					'data' => array(
-						'function' => function ($rowData) {
+						'function' => static function ($rowData) {
 							global $txt;
 
 							return '<i class="icon ' . ($rowData['task_completed'] ? 'i-check' : 'i-fail') . '" title="' . sprintf($txt[$rowData['task_completed'] ? 'maintain_done' : 'maintain_fail'], $rowData['name']) . '" />';

--- a/sources/ElkArte/AdminController/ManageSearch.php
+++ b/sources/ElkArte/AdminController/ManageSearch.php
@@ -17,7 +17,6 @@
 
 namespace ElkArte\AdminController;
 
-use Elk_Exception;
 use ElkArte\AbstractController;
 use ElkArte\Action;
 use ElkArte\FileFunctions;

--- a/sources/ElkArte/AdminController/ManageSearch.php
+++ b/sources/ElkArte/AdminController/ManageSearch.php
@@ -17,13 +17,19 @@
 
 namespace ElkArte\AdminController;
 
+use Elk_Exception;
 use ElkArte\AbstractController;
 use ElkArte\Action;
 use ElkArte\FileFunctions;
+use ElkArte\Languages\Txt;
 use ElkArte\Search\SearchApiWrapper;
 use ElkArte\SettingsForm\SettingsForm;
-use ElkArte\Languages\Txt;
 use ElkArte\Util;
+use Exception;
+use FilesystemIterator;
+use GlobIterator;
+use SphinxClient;
+use UnexpectedValueException;
 
 /**
  * ManageSearch controller admin class.
@@ -46,7 +52,7 @@ class ManageSearch extends AbstractController
 	 * @event integrate_sa_manage_search add new search actions
 	 * @uses ManageSearch template.
 	 * @uses Search language file.
-	 * @see  \ElkArte\AbstractController::action_index()
+	 * @see  AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -135,7 +141,7 @@ class ManageSearch extends AbstractController
 
 			if (empty($this->_req->post->search_results_per_page))
 			{
-				$this->_req->post->search_results_per_page = !empty($modSettings['search_results_per_page']) ? $modSettings['search_results_per_page'] : $modSettings['defaultMaxMessages'];
+				$this->_req->post->search_results_per_page = empty($modSettings['search_results_per_page']) ? $modSettings['defaultMaxMessages'] : $modSettings['search_results_per_page'];
 			}
 
 			$new_engines = array();
@@ -143,17 +149,30 @@ class ManageSearch extends AbstractController
 			{
 				$url = trim(str_replace(array('"', '<', '>'), array('&quot;', '&lt;', '&gt;'), $this->_req->post->engine_url[$id]));
 				// If no url, forget it
-				if (!empty($searchengine) && !empty($url) && filter_var($url, FILTER_VALIDATE_URL))
+				if (empty($searchengine))
 				{
-					$new_engines[] = array(
-						'name' => trim(Util::htmlspecialchars($searchengine, ENT_COMPAT)),
-						'url' => $url,
-						'separator' => trim(Util::htmlspecialchars(!empty($this->_req->post->engine_separator[$id]) ? $this->_req->post->engine_separator[$id] : '+', ENT_COMPAT)),
-					);
+					continue;
 				}
+
+				if (empty($url))
+				{
+					continue;
+				}
+
+				if (!filter_var($url, FILTER_VALIDATE_URL))
+				{
+					continue;
+				}
+
+				$new_engines[] = array(
+					'name' => trim(Util::htmlspecialchars($searchengine, ENT_COMPAT)),
+					'url' => $url,
+					'separator' => trim(Util::htmlspecialchars(empty($this->_req->post->engine_separator[$id]) ? '+' : $this->_req->post->engine_separator[$id], ENT_COMPAT)),
+				);
 			}
+
 			updateSettings(array(
-				'additional_search_engines' => !empty($new_engines) ? serialize($new_engines) : ''
+				'additional_search_engines' => $new_engines === [] ? '' : serialize($new_engines)
 			));
 
 			$settingsForm->setConfigValues((array) $this->_req->post);
@@ -192,7 +211,7 @@ class ManageSearch extends AbstractController
 		);
 
 		// Perhaps the search method wants to add some settings?
-		$searchAPI = new SearchApiWrapper(!empty($modSettings['search_index']) ? $modSettings['search_index'] : '');
+		$searchAPI = new SearchApiWrapper(empty($modSettings['search_index']) ? '' : $modSettings['search_index']);
 		$searchAPI->searchSettings($config_vars);
 
 		// Add new settings with a nice hook, makes them available for admin settings search as well
@@ -421,7 +440,7 @@ class ManageSearch extends AbstractController
 		$apis = array();
 		try
 		{
-			$files = new \GlobIterator(SOURCEDIR . '/ElkArte/Search/API/*.php', \FilesystemIterator::SKIP_DOTS);
+			$files = new GlobIterator(SOURCEDIR . '/ElkArte/Search/API/*.php', FilesystemIterator::SKIP_DOTS);
 			foreach ($files as $file)
 			{
 				if ($file->isFile())
@@ -444,7 +463,7 @@ class ManageSearch extends AbstractController
 				}
 			}
 		}
-		catch (\UnexpectedValueException $e)
+		catch (UnexpectedValueException)
 		{
 			// @todo for now just passthrough
 		}
@@ -508,13 +527,13 @@ class ManageSearch extends AbstractController
 		if ($context['step'] === 1)
 		{
 			$context['sub_template'] = 'create_index_progress';
-			list ($context['start'], $context['step'], $context['percentage']) = createSearchIndex($context['start'], $messages_per_batch);
+			[$context['start'], $context['step'], $context['percentage']] = createSearchIndex($context['start'], $messages_per_batch);
 		}
 
 		// Step 2: removing the words that occur too often and are of no use.
 		if ($context['step'] === 2)
 		{
-			list ($context['start'], $complete, $context['percentage']) = removeCommonWordsFromIndex($context['start']);
+			[$context['start'], $complete, $context['percentage']] = removeCommonWordsFromIndex($context['start']);
 			if ($complete)
 			{
 				$context['step'] = 3;
@@ -599,8 +618,6 @@ class ManageSearch extends AbstractController
 
 	/**
 	 * Save the form values in modsettings
-	 *
-	 * @throws \Elk_Exception
 	 */
 	private function _saveSphinxConfig()
 	{
@@ -628,14 +645,14 @@ class ManageSearch extends AbstractController
 		if (FileFunctions::instance()->fileExists(SOURCEDIR . '/sphinxapi.php'))
 		{
 			include_once(SOURCEDIR . '/sphinxapi.php');
-			$server = !empty($modSettings['sphinx_searchd_server']) ? $modSettings['sphinx_searchd_server'] : 'localhost';
-			$port = !empty($modSettings['sphinx_searchd_port']) ? $modSettings['sphinx_searchd_port'] : 9312;
+			$server = empty($modSettings['sphinx_searchd_server']) ? 'localhost' : $modSettings['sphinx_searchd_server'];
+			$port = empty($modSettings['sphinx_searchd_port']) ? 9312 : $modSettings['sphinx_searchd_port'];
 
-			$mySphinx = new \SphinxClient();
+			$mySphinx = new SphinxClient();
 			$mySphinx->SetServer($server, (int) $port);
 			$mySphinx->SetLimits(0, 25, 1);
 
-			$index = (!empty($modSettings['sphinx_index_prefix']) ? $modSettings['sphinx_index_prefix'] : 'elkarte') . '_index';
+			$index = (empty($modSettings['sphinx_index_prefix']) ? 'elkarte' : $modSettings['sphinx_index_prefix']) . '_index';
 			$request = $mySphinx->Query('ElkArte', $index);
 
 			if ($request === false)
@@ -663,16 +680,16 @@ class ManageSearch extends AbstractController
 	{
 		global $txt, $modSettings, $context;
 
-		$server = !empty($modSettings['sphinx_searchd_server']) ? $modSettings['sphinx_searchd_server'] : 'localhost';
+		$server = empty($modSettings['sphinx_searchd_server']) ? 'localhost' : $modSettings['sphinx_searchd_server'];
 		$server = $server === 'localhost' ? '127.0.0.1' : $server;
-		$port = !empty($modSettings['sphinxql_searchd_port']) ? $modSettings['sphinxql_searchd_port'] : '9306';
+		$port = empty($modSettings['sphinxql_searchd_port']) ? '9306' : $modSettings['sphinxql_searchd_port'];
 
 		set_error_handler(static function () { /* ignore errors */ });
 		try
 		{
 			$result = mysqli_connect($server, '', '', '', (int) $port);
 		}
-		catch (\Exception $e)
+		catch (Exception)
 		{
 			$result = false;
 		}

--- a/sources/ElkArte/AdminController/ManageSearchEngines.php
+++ b/sources/ElkArte/AdminController/ManageSearchEngines.php
@@ -19,8 +19,8 @@ namespace ElkArte\AdminController;
 use ElkArte\AbstractController;
 use ElkArte\Action;
 use ElkArte\Cache\Cache;
-use ElkArte\SettingsForm\SettingsForm;
 use ElkArte\Languages\Txt;
+use ElkArte\SettingsForm\SettingsForm;
 
 /**
  * ManageSearchEngines admin controller. This class handles all search engines
@@ -34,7 +34,7 @@ class ManageSearchEngines extends AbstractController
 	 * Entry point for this section.
 	 *
 	 * @event integrate_sa_manage_search_engines add additonal search engine actions
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -136,7 +136,7 @@ class ManageSearchEngines extends AbstractController
 			{
 				$javascript_function .= '
 				if (document.getElementById(\'' . $variable[1] . '\'))
-					document.getElementById(\'' . $variable[1] . '\').disabled = disabledState;';
+					document.getElementById(\'' . $variable[1] . "').disabled = disabledState;";
 			}
 		}
 
@@ -222,8 +222,9 @@ class ManageSearchEngines extends AbstractController
 			$this->action_editspiders();
 			return;
 		}
+
 		// User pressed the 'remove selection button'.
-		elseif (!empty($this->_req->post->removeSpiders) && !empty($this->_req->post->remove) && is_array($this->_req->post->remove))
+		if (!empty($this->_req->post->removeSpiders) && !empty($this->_req->post->remove) && is_array($this->_req->post->remove))
 		{
 			checkSession();
 			validateToken('admin-ser');
@@ -233,7 +234,6 @@ class ManageSearchEngines extends AbstractController
 
 			// Delete them all!
 			removeSpiders($toRemove);
-
 			Cache::instance()->remove('spider_search');
 			recacheSpiderNames();
 		}
@@ -265,9 +265,7 @@ class ManageSearchEngines extends AbstractController
 						'value' => $txt['spider_name'],
 					),
 					'data' => array(
-						'function' => function ($rowData) {
-							return sprintf('<a href=' . getUrl('admin', ['action' => 'admin', 'area' => 'sengines', 'sa' => 'editspiders', 'sid' => $rowData['id_spider']]) . '">%1$s</a>', htmlspecialchars($rowData['spider_name'], ENT_COMPAT, 'UTF-8'));
-						},
+						'function' => static fn($rowData) => sprintf('<a href=' . getUrl('admin', ['action' => 'admin', 'area' => 'sengines', 'sa' => 'editspiders', 'sid' => $rowData['id_spider']]) . '">%1$s</a>', htmlspecialchars($rowData['spider_name'], ENT_COMPAT, 'UTF-8')),
 					),
 					'sort' => array(
 						'default' => 'spider_name',
@@ -279,7 +277,7 @@ class ManageSearchEngines extends AbstractController
 						'value' => $txt['spider_last_seen'],
 					),
 					'data' => array(
-						'function' => function ($rowData) {
+						'function' => static function ($rowData) {
 							global $context, $txt;
 
 							return isset($context['spider_last_seen'][$rowData['id_spider']]) ? standardTime($context['spider_last_seen'][$rowData['id_spider']]) : $txt['spider_last_never'];
@@ -379,6 +377,7 @@ class ManageSearchEngines extends AbstractController
 					$ips[] = $set;
 				}
 			}
+
 			$ips = implode(',', $ips);
 
 			// Goes in as it is...
@@ -440,7 +439,7 @@ class ManageSearchEngines extends AbstractController
 			'items_per_page' => 20,
 			'title' => $txt['spider_logs'],
 			'no_items_label' => $txt['spider_logs_empty'],
-			'base_href' => $context['admin_area'] == 'sengines' ? getUrl('admin', ['action' => 'admin', 'area' => 'sengines', 'sa' => 'logs']) : getUrl('admin', ['action' => 'admin', 'area' => 'logs', 'sa' => 'spiderlog']),
+			'base_href' => $context['admin_area'] === 'sengines' ? getUrl('admin', ['action' => 'admin', 'area' => 'sengines', 'sa' => 'logs']) : getUrl('admin', ['action' => 'admin', 'area' => 'logs', 'sa' => 'spiderlog']),
 			'default_sort_col' => 'log_time',
 			'get_items' => array(
 				'function' => 'getSpiderLogs',
@@ -467,9 +466,7 @@ class ManageSearchEngines extends AbstractController
 						'value' => $txt['spider_time'],
 					),
 					'data' => array(
-						'function' => function ($rowData) {
-							return standardTime($rowData['log_time']);
-						},
+						'function' => static fn($rowData) => standardTime($rowData['log_time']),
 					),
 					'sort' => array(
 						'default' => 'sl.id_hit DESC',
@@ -508,6 +505,7 @@ class ManageSearchEngines extends AbstractController
 		if (!empty($context['spider_logs']['rows']))
 		{
 			$urls = array();
+
 			// Grab the current /url.
 			foreach ($context['spider_logs']['rows'] as $k => $row)
 			{
@@ -568,8 +566,7 @@ class ManageSearchEngines extends AbstractController
 
 		// Prepare the dates for the drop down.
 		$date_choices = spidersStatsDates();
-		end($date_choices);
-		$max_date = key($date_choices);
+		$max_date = array_key_last($date_choices);
 
 		// What are we currently viewing?
 		$current_date = isset($this->_req->post->new_date, $date_choices[$this->_req->post->new_date]) ? $this->_req->post->new_date : $max_date;
@@ -660,7 +657,7 @@ class ManageSearchEngines extends AbstractController
 				),
 			),
 			'form' => array(
-				'href' =>getUrl('admin', ['action' => 'admin', 'area' => 'sengines', 'sa' => 'stats']),
+				'href' => getUrl('admin', ['action' => 'admin', 'area' => 'sengines', 'sa' => 'stats']),
 				'name' => 'spider_stat_list',
 			),
 			'additional_rows' => array(

--- a/sources/ElkArte/AdminController/ManageSecurity.php
+++ b/sources/ElkArte/AdminController/ManageSecurity.php
@@ -20,8 +20,8 @@ namespace ElkArte\AdminController;
 use ElkArte\AbstractController;
 use ElkArte\Action;
 use ElkArte\Cache\Cache;
-use ElkArte\SettingsForm\SettingsForm;
 use ElkArte\Languages\Txt;
+use ElkArte\SettingsForm\SettingsForm;
 
 /**
  * ManageSecurity controller handles the Security and Moderation
@@ -35,7 +35,7 @@ class ManageSecurity extends AbstractController
 	 * This function passes control through to the relevant security tab.
 	 *
 	 * @event integrate_sa_modify_security
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -205,7 +205,7 @@ class ManageSecurity extends AbstractController
 		}
 
 		// We actually store lots of these together - for efficiency.
-		list ($modSettings['warning_enable'], $modSettings['user_limit'], $modSettings['warning_decrement']) = explode(',', $modSettings['warning_settings']);
+		[$modSettings['warning_enable'], $modSettings['user_limit'], $modSettings['warning_decrement']] = explode(',', $modSettings['warning_settings']);
 
 		$context['post_url'] = getUrl('admin', ['action' => 'admin', 'area' => 'securitysettings', 'save', 'sa' => 'moderation']);
 		$context['settings_title'] = $txt['moderation_settings'];
@@ -284,7 +284,7 @@ class ManageSecurity extends AbstractController
 		}
 
 		// Add in PM spam settings on the fly
-		list ($modSettings['max_pm_recipients'], $modSettings['pm_posts_verification'], $modSettings['pm_posts_per_hour']) = explode(',', $modSettings['pm_spam_settings']);
+		[$modSettings['max_pm_recipients'], $modSettings['pm_posts_verification'], $modSettings['pm_posts_per_hour']] = explode(',', $modSettings['pm_spam_settings']);
 
 		// And the same for guests requiring verification.
 		$modSettings['guests_require_captcha'] = !empty($modSettings['posts_require_captcha']);
@@ -293,7 +293,7 @@ class ManageSecurity extends AbstractController
 		// Some minor javascript for the guest post setting.
 		if ($modSettings['posts_require_captcha'])
 		{
-			theme()->addInlineJavascript('document.getElementById(\'guests_require_captcha\').disabled = true;', true);
+			theme()->addInlineJavascript("document.getElementById('guests_require_captcha').disabled = true;", true);
 		}
 
 		$context['post_url'] = getUrl('admin', ['action' => 'admin', 'area' => 'securitysettings', 'save', 'sa' => 'spam']);
@@ -316,7 +316,7 @@ class ManageSecurity extends AbstractController
 			array('check', 'search_enable_captcha'),
 			// This, my friend, is a cheat :p
 			'guest_verify' => array('check', 'guests_require_captcha', 'postinput' => $txt['setting_guests_require_captcha_desc']),
-			array('int', 'posts_require_captcha', 'postinput' => $txt['posts_require_captcha_desc'], 'onchange' => 'if (this.value > 0){ document.getElementById(\'guests_require_captcha\').checked = true; document.getElementById(\'guests_require_captcha\').disabled = true;} else {document.getElementById(\'guests_require_captcha\').disabled = false;}'),
+			array('int', 'posts_require_captcha', 'postinput' => $txt['posts_require_captcha_desc'], 'onchange' => "if (this.value > 0){ document.getElementById('guests_require_captcha').checked = true; document.getElementById('guests_require_captcha').disabled = true;} else {document.getElementById('guests_require_captcha').disabled = false;}"),
 			array('check', 'guests_report_require_captcha'),
 			// PM Settings
 			array('title', 'antispam_PM'),

--- a/sources/ElkArte/AdminController/ManageServer.php
+++ b/sources/ElkArte/AdminController/ManageServer.php
@@ -45,7 +45,7 @@ class ManageServer extends AbstractController
 	 *
 	 * @event integrate_sa_server_settings
 	 * @uses edit_settings adminIndex.
-	 * @see  \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -150,7 +150,7 @@ class ManageServer extends AbstractController
 
 			$settingsForm->setConfigValues((array) $this->_req->post);
 			$settingsForm->save();
-			redirectexit('action=admin;area=serversettings;sa=general;' . $context['session_var'] . '=' . $context['session_id'] . ';msg=' . (!empty($context['settings_message']) ? $context['settings_message'] : 'core_settings_saved'));
+			redirectexit('action=admin;area=serversettings;sa=general;' . $context['session_var'] . '=' . $context['session_id'] . ';msg=' . (empty($context['settings_message']) ? 'core_settings_saved' : $context['settings_message']));
 		}
 
 		// Fill the config array for the template and all that.
@@ -225,7 +225,7 @@ class ManageServer extends AbstractController
 
 			$settingsForm->setConfigValues((array) $this->_req->post);
 			$settingsForm->save();
-			redirectexit('action=admin;area=serversettings;sa=database;' . $context['session_var'] . '=' . $context['session_id'] . ';msg=' . (!empty($context['settings_message']) ? $context['settings_message'] : 'core_settings_saved'));
+			redirectexit('action=admin;area=serversettings;sa=database;' . $context['session_var'] . '=' . $context['session_id'] . ';msg=' . (empty($context['settings_message']) ? 'core_settings_saved' : $context['settings_message']));
 		}
 
 		// Fill the config array for the template.
@@ -300,7 +300,7 @@ class ManageServer extends AbstractController
 				unset($this->_req->post->globalCookies);
 			}
 
-			if (!empty($this->_req->post->globalCookiesDomain) && strpos($boardurl, $this->_req->post->globalCookiesDomain) === false)
+			if (!empty($this->_req->post->globalCookiesDomain) && strpos($boardurl, (string) $this->_req->post->globalCookiesDomain) === false)
 			{
 				throw new Exception('invalid_cookie_domain', false);
 			}
@@ -330,7 +330,7 @@ class ManageServer extends AbstractController
 				redirectexit('action=admin;area=serversettings;sa=cookie;' . $context['session_var'] . '=' . $original_session_id);
 			}
 
-			redirectexit('action=admin;area=serversettings;sa=cookie;' . $context['session_var'] . '=' . $context['session_id'] . ';msg=' . (!empty($context['settings_message']) ? $context['settings_message'] : 'core_settings_saved'));
+			redirectexit('action=admin;area=serversettings;sa=cookie;' . $context['session_var'] . '=' . $context['session_id'] . ';msg=' . (empty($context['settings_message']) ? 'core_settings_saved' : $context['settings_message']));
 		}
 
 		theme()->addInlineJavascript('
@@ -363,7 +363,7 @@ class ManageServer extends AbstractController
 			array('localCookies', $txt['localCookies'], 'subtext' => $txt['localCookies_note'], 'db', 'check', false, 'localCookies'),
 			array('globalCookies', $txt['globalCookies'], 'subtext' => $txt['globalCookies_note'], 'db', 'check', false, 'globalCookies'),
 			array('globalCookiesDomain', $txt['globalCookiesDomain'], 'subtext' => $txt['globalCookiesDomain_note'], 'db', 'text', false, 'globalCookiesDomain'),
-			array('secureCookies', $txt['secureCookies'], 'subtext' => $txt['secureCookies_note'], 'db', 'check', false, 'secureCookies', 'disabled' => !isset($_SERVER['HTTPS']) || !(strtolower($_SERVER['HTTPS']) === 'on' || strtolower($_SERVER['HTTPS']) == '1')),
+			array('secureCookies', $txt['secureCookies'], 'subtext' => $txt['secureCookies_note'], 'db', 'check', false, 'secureCookies', 'disabled' => !isset($_SERVER['HTTPS']) || strtolower($_SERVER['HTTPS']) !== 'on' && strtolower($_SERVER['HTTPS']) != '1'),
 			array('httponlyCookies', $txt['httponlyCookies'], 'subtext' => $txt['httponlyCookies_note'], 'db', 'check', false, 'httponlyCookies'),
 			'',
 			// Sessions
@@ -475,7 +475,7 @@ class ManageServer extends AbstractController
 		);
 
 		// If the cache engine has specific settings, add them in
-		foreach ($detected as $key => $value)
+		foreach ($detected as $value)
 		{
 			if ($value->isAvailable())
 			{

--- a/sources/ElkArte/AdminController/ManageTopics.php
+++ b/sources/ElkArte/AdminController/ManageTopics.php
@@ -26,7 +26,7 @@ class ManageTopics extends AbstractController
 	 * Check permissions and forward to the right method.
 	 *
 	 * @event integrate_sa_manage_topics
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{

--- a/sources/ElkArte/AdminController/Modlog.php
+++ b/sources/ElkArte/AdminController/Modlog.php
@@ -30,7 +30,7 @@ class Modlog extends AbstractController
 	/**
 	 * Default method for this controller.
 	 *
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -63,7 +63,7 @@ class Modlog extends AbstractController
 		}
 
 		// These change dependant on whether we are viewing the moderation or admin log.
-		if ($context['log_type'] == 3 || $this->_req->query->action === 'admin')
+		if ($context['log_type'] === 3 || $this->_req->query->action === 'admin')
 		{
 			$context['url_start'] = getUrl('admin', ['action' => 'admin', 'area' => 'logs', 'sa' => ($context['log_type'] == 3 ? 'adminlog' : 'modlog'), 'type' => $context['log_type']]);
 		}
@@ -76,7 +76,7 @@ class Modlog extends AbstractController
 
 		Txt::load('Modlog');
 
-		$context['page_title'] = $context['log_type'] == 3 ? $txt['modlog_admin_log'] : $txt['modlog_view'];
+		$context['page_title'] = $context['log_type'] === 3 ? $txt['modlog_admin_log'] : $txt['modlog_view'];
 
 		// The number of entries to show per page of log file.
 		$context['displaypage'] = 30;
@@ -185,21 +185,17 @@ class Modlog extends AbstractController
 			'base_href' => $context['url_start'],
 			'default_sort_col' => 'time',
 			'get_items' => array(
-				'function' => function ($start, $items_per_page, $sort, $query_string, $query_params, $log_type) {
-					return $this->getModLogEntries($start, $items_per_page, $sort, $query_string, $query_params, $log_type);
-				},
+				'function' => fn($start, $items_per_page, $sort, $query_string, $query_params, $log_type) => $this->getModLogEntries($start, $items_per_page, $sort, $query_string, $query_params, $log_type),
 				'params' => array(
-					(!empty($search_params['string']) ? ' INSTR({raw:sql_type}, {string:search_string})' : ''),
+					(empty($search_params['string']) ? '' : ' INSTR({raw:sql_type}, {string:search_string})'),
 					array('sql_type' => $search_params_column, 'search_string' => $search_params['string']),
 					$context['log_type'],
 				),
 			),
 			'get_count' => array(
-				'function' => function ($query_string, $query_params, $log_type) {
-					return $this->getModLogEntryCount($query_string, $query_params, $log_type);
-				},
+				'function' => fn($query_string, $query_params, $log_type) => $this->getModLogEntryCount($query_string, $query_params, $log_type),
 				'params' => array(
-					(!empty($search_params['string']) ? ' INSTR({raw:sql_type}, {string:search_string})' : ''),
+					(empty($search_params['string']) ? '' : ' INSTR({raw:sql_type}, {string:search_string})'),
 					array('sql_type' => $search_params_column, 'search_string' => $search_params['string']),
 					$context['log_type'],
 				),
@@ -281,9 +277,7 @@ class Modlog extends AbstractController
 						'class' => 'centertext',
 					),
 					'data' => array(
-						'function' => function ($entry) {
-							return '<input type="checkbox" name="delete[]" value="' . $entry['id'] . '"' . ($entry['editable'] ? '' : ' disabled="disabled"') . ' />';
-						},
+						'function' => static fn($entry) => '<input type="checkbox" name="delete[]" value="' . $entry['id'] . '"' . ($entry['editable'] ? '' : ' disabled="disabled"') . ' />',
 						'class' => 'centertext',
 					),
 				),

--- a/sources/ElkArte/AdminController/RepairBoards.php
+++ b/sources/ElkArte/AdminController/RepairBoards.php
@@ -28,7 +28,7 @@ class RepairBoards extends AbstractController
 	/**
 	 * Default method.
 	 *
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{

--- a/sources/ElkArte/AdminController/Reports.php
+++ b/sources/ElkArte/AdminController/Reports.php
@@ -51,7 +51,7 @@ class Reports extends AbstractController
 	 *
 	 * @event integrate_report_types
 	 * @event integrate_report_buttons
-	 * @see \ElkArte\AbstractController::action_index()
+	 * @see AbstractController::action_index()
 	 */
 	public function action_index()
 	{
@@ -96,7 +96,7 @@ class Reports extends AbstractController
 			);
 		}
 
-		$report_type = !empty($this->_req->post->rt) ? $this->_req->post->rt : (!empty($this->_req->query->rt) ? $this->_req->query->rt : null);
+		$report_type = empty($this->_req->post->rt) ? (!empty($this->_req->query->rt) ? $this->_req->query->rt : null) : ($this->_req->post->rt);
 
 		// If they haven't chosen a report type which is valid, send them off to the report type chooser!
 		if (empty($report_type) || !isset($context['report_types'][$report_type]))
@@ -426,7 +426,7 @@ class Reports extends AbstractController
 				$curData = array('col' => $perm_info['title']);
 
 				// Now cycle each membergroup in this set of permissions.
-				foreach ($member_groups as $id_group => $name)
+				foreach (array_keys($member_groups) as $id_group)
 				{
 					// Don't overwrite the key column!
 					if ($id_group === 'col')
@@ -528,7 +528,7 @@ class Reports extends AbstractController
 				'color' => empty($row['online_color']) ? '-' : '<span style="color: ' . $row['online_color'] . ';">' . $row['online_color'] . '</span>',
 				'min_posts' => $row['min_posts'] == -1 ? 'N/A' : $row['min_posts'],
 				'max_messages' => $row['max_messages'],
-				'icons' => !empty($row['icons'][0]) && !empty($row['icons'][1]) ? str_repeat('<img src="' . $settings['images_url'] . '/group_icons/' . $row['icons'][1] . '" alt="*" />', $row['icons'][0]) : '',
+				'icons' => isset($row['icons'][0]) && ($row['icons'][0] !== '' && $row['icons'][0] !== '0') && (isset($row['icons'][1]) && ($row['icons'][1] !== '' && $row['icons'][1] !== '0')) ? str_repeat('<img src="' . $settings['images_url'] . '/group_icons/' . $row['icons'][1] . '" alt="*" />', $row['icons'][0]) : '',
 			);
 
 			// Board permissions.
@@ -809,7 +809,7 @@ function newTable($title = '', $default_value = '', $shading = 'all', $width_nor
  * will add a separator across the table at this point.
  * once the incoming data has been sanitized, it is added to the table.
  *
- * @param mixed[] $inc_data
+ * @param array $inc_data
  * @param int|null $custom_table = null
  *
  * @return bool
@@ -905,14 +905,7 @@ function addSeparator($title = '', $custom_table = null)
 		return false;
 	}
 
-	if ($custom_table !== null)
-	{
-		$table = $custom_table;
-	}
-	else
-	{
-		$table = $context['current_table'];
-	}
+	$table = $custom_table ?? $context['current_table'];
 
 	// Plumb in the separator
 	$context['tables'][$table]['data'][] = array(
@@ -980,7 +973,7 @@ function finishTables()
  * are used as opposed to the keys(!
  *
  * @param string $method = 'rows' rows or cols
- * @param mixed[] $keys = array()
+ * @param array $keys = array()
  * @param bool $reverse = false
  */
 function setKeys($method = 'rows', $keys = array(), $reverse = false)

--- a/sources/ElkArte/BoardsTree.php
+++ b/sources/ElkArte/BoardsTree.php
@@ -31,7 +31,7 @@ class BoardsTree
 	protected $cat_tree = [];
 	protected $boards = [];
 	protected $boardList = [];
-	protected $db = null;
+	protected $db;
 
 	public function __construct(QueryInterface $db)
 	{
@@ -50,7 +50,7 @@ class BoardsTree
 	 *
 	 * @param array $query
 	 *
-	 * @throws \ElkArte\Exceptions\Exception no_valid_parent
+	 * @throws Exception no_valid_parent
 	 */
 	protected function loadBoardTree($query = array())
 	{
@@ -109,8 +109,8 @@ class BoardsTree
 					'level' => $row['child_level'],
 					'order' => (int) $row['board_order'],
 					'name' => $row['board_name'],
-					'member_groups' => explode(',', $row['member_groups']),
-					'deny_groups' => explode(',', $row['deny_member_groups']),
+					'member_groups' => array_map('intval', explode(',', $row['member_groups'])),
+					'deny_groups' => array_map('intval', explode(',', $row['deny_member_groups'])),
 					'description' => $row['description'],
 					'count_posts' => empty($row['count_posts']),
 					'old_posts' => empty($row['old_posts']),
@@ -268,7 +268,7 @@ class BoardsTree
 	{
 		if (isset($this->boards[$id]))
 		{
-			return $this->boards[$id];
+			return (int) $this->boards[$id];
 		}
 
 		throw new \Exception('Board id doesn\'t exist: ' . $id);

--- a/sources/ElkArte/Database/AbstractQuery.php
+++ b/sources/ElkArte/Database/AbstractQuery.php
@@ -965,7 +965,7 @@ abstract class AbstractQuery implements QueryInterface
 			return 0;
 		}
 
-		return $result->num_rows();
+		return (int) $result->num_rows();
 	}
 
 	/**

--- a/sources/ElkArte/Database/Mysqli/Result.php
+++ b/sources/ElkArte/Database/Mysqli/Result.php
@@ -64,7 +64,7 @@ class Result extends AbstractResult
 	public function num_rows()
 	{
 		// Simply delegate to the native function
-		return mysqli_num_rows($this->result);
+		return (int) mysqli_num_rows($this->result);
 	}
 
 	/**

--- a/sources/ElkArte/Database/Mysqli/Search.php
+++ b/sources/ElkArte/Database/Mysqli/Search.php
@@ -70,7 +70,7 @@ class Search extends AbstractSearch
 			);
 		}
 
-		if ($request !== false && $request->num_rows() == 1)
+		if ($request !== false && $request->num_rows() === 1)
 		{
 			// Only do this if the user has permission to execute this query.
 			$row = $request->fetch_assoc();
@@ -104,7 +104,7 @@ class Search extends AbstractSearch
 			);
 		}
 
-		if ($request !== false && $request->num_rows() == 1)
+		if ($request !== false && $request->num_rows() === 1)
 		{
 			// Only do this if the user has permission to execute this query.
 			$row = $request->fetch_assoc();

--- a/sources/ElkArte/Database/Postgresql/Result.php
+++ b/sources/ElkArte/Database/Postgresql/Result.php
@@ -94,7 +94,7 @@ class Result extends AbstractResult
 		// simply delegate to the native function
 		if (is_resource($this->result) || $this->result instanceof \PgSql\Result)
 		{
-			return pg_num_rows($this->result);
+			return (int) pg_num_rows($this->result);
 		}
 	}
 

--- a/sources/ElkArte/MessagesDelete.php
+++ b/sources/ElkArte/MessagesDelete.php
@@ -357,7 +357,7 @@ class MessagesDelete
 
 		// Remove the topic if it doesn't have any messages.
 		$topic_exists = true;
-		if ($request->num_rows() == 0)
+		if ($request->num_rows() === 0)
 		{
 			require_once(SUBSDIR . '/Topic.subs.php');
 			removeTopics($from_topic, false, true);
@@ -630,7 +630,7 @@ class MessagesDelete
 				'id_msg' => $message,
 			)
 		);
-		if ($request->num_rows() == 0)
+		if ($request->num_rows() === 0)
 		{
 			return false;
 		}
@@ -732,7 +732,7 @@ class MessagesDelete
 					'recycle_board' => $this->_recycle_board,
 				)
 			);
-			if ($request->num_rows() == 0)
+			if ($request->num_rows() === 0)
 			{
 				throw new Exceptions\Exception('recycle_no_valid_board');
 			}

--- a/sources/ElkArte/Search/API/Fulltext.php
+++ b/sources/ElkArte/Search/API/Fulltext.php
@@ -106,7 +106,7 @@ class Fulltext extends Standard
 				'fulltext_minimum_word_length' => 'ft_min_word_len',
 			)
 		);
-		if ($request !== false && $request->num_rows() == 1)
+		if ($request !== false && $request->num_rows() === 1)
 		{
 			list (, $min_word_length) = $request->fetch_row();
 			$request->free_result();

--- a/sources/ElkArte/Search/SearchParams.php
+++ b/sources/ElkArte/Search/SearchParams.php
@@ -397,7 +397,7 @@ class SearchParams extends ValuesContainer
 			$this->_userQuery = '';
 		}
 		// Nothing? lets try the poster name instead since that is what they go by
-		elseif ($request->num_rows() == 0)
+		elseif ($request->num_rows() === 0)
 		{
 			$this->_userQuery = $this->_db->quote(
 				'm.id_member = {int:id_member_guest} AND ({raw:match_possible_guest_names})',
@@ -482,7 +482,7 @@ class SearchParams extends ValuesContainer
 					'is_approved_true' => 1,
 				)
 			);
-			if ($request->num_rows() == 0)
+			if ($request->num_rows() === 0)
 			{
 				throw new Exception('topic_gone', false);
 			}

--- a/sources/ElkArte/Subscriptions/PaymentGateway/PayPal/Payment.php
+++ b/sources/ElkArte/Subscriptions/PaymentGateway/PayPal/Payment.php
@@ -309,7 +309,7 @@ class Payment implements PaymentInterface
 			)
 		);
 		// No joy?
-		if ($request->num_rows() == 0)
+		if ($request->num_rows() === 0)
 		{
 			// Can we identify them by email?
 			if (!empty($_POST['payer_email']))

--- a/sources/subs/Attachments.subs.php
+++ b/sources/subs/Attachments.subs.php
@@ -484,7 +484,7 @@ function getAttachmentFromTopic($id_attach, $id_topic)
 			'current_topic' => $id_topic,
 		)
 	);
-	if ($request->num_rows() != 0)
+	if ($request->num_rows() !== 0)
 	{
 		$attachmentData = $request->fetch_assoc();
 	}
@@ -535,7 +535,7 @@ function getAttachmentThumbFromTopic($id_attach, $id_topic)
 	$attachmentData = [
 		'id_folder' => '', 'filename' => '', 'file_hash' => '', 'fileext' => '', 'id_attach' => '',
 		'attachment_type' => '', 'mime_type' => '', 'approved' => '', 'id_member' => ''];
-	if ($request->num_rows() != 0)
+	if ($request->num_rows() !== 0)
 	{
 		$row = $request->fetch_assoc();
 

--- a/sources/subs/Bans.subs.php
+++ b/sources/subs/Bans.subs.php
@@ -781,7 +781,7 @@ function insertBanGroup($ban_info = array())
 	);
 
 	// @todo shouldn't be an error here?
-	if ($request->num_rows() == 1)
+	if ($request->num_rows() === 1)
 	{
 		list ($id_ban) = $request->fetch_row();
 		$request->free_result();
@@ -953,7 +953,7 @@ function validateIPBan($ip_array, $fullip = '')
 		LIMIT 1',
 		$values
 	);
-	if ($request->num_rows() != 0)
+	if ($request->num_rows() !== 0)
 	{
 		list ($error_id_ban, $error_ban_name) = $request->fetch_row();
 		$values = array('error' => array('ban_trigger_already_exists', array(

--- a/sources/subs/Boards.subs.php
+++ b/sources/subs/Boards.subs.php
@@ -899,7 +899,7 @@ function hasBoardNotification($id_member, $id_board)
 			'current_member' => $id_member,
 		)
 	);
-	$hasNotification = $request->num_rows() != 0;
+	$hasNotification = $request->num_rows() !== 0;
 	$request->free_result();
 
 	return $hasNotification;
@@ -976,7 +976,7 @@ function resetSentBoardNotification($id_member, $id_board, $check = true)
 			)
 		);
 		// nothing to do
-		if ($request->num_rows() == 0)
+		if ($request->num_rows() === 0)
 		{
 			return false;
 		}

--- a/sources/subs/Calendar.subs.php
+++ b/sources/subs/Calendar.subs.php
@@ -1340,9 +1340,9 @@ function getHoliday($id_holiday)
 		function ($row) use (&$holiday) {
 			$holiday = array(
 				'id' => $row['id_holiday'],
-				'day' => $row['day'],
-				'month' => $row['month'],
-				'year' => $row['year'] <= 4 ? 0 : $row['year'],
+				'day' => (int) $row['day'],
+				'month' => (int) $row['month'],
+				'year' => $row['year'] <= 4 ? 0 : (int) $row['year'],
 				'title' => $row['title']
 			);
 		}

--- a/sources/subs/Membergroups.subs.php
+++ b/sources/subs/Membergroups.subs.php
@@ -1073,11 +1073,16 @@ function membergroupsById($group_ids, $limit = 1, $detailed = false, $assignable
 			'limit' => $limit,
 		)
 	)->fetch_callback(
-		function ($row) use (&$groups) {
+		function ($row) use (&$groups, $detailed) {
 			$row['id_group'] = (int) $row['id_group'];
-			$row['id_parent'] = (int) $row['id_parent'];
 			$row['group_type'] = (int) $row['group_type'];
-			$row['min_posts'] = (int) $row['min_posts'];
+
+			if ($detailed)
+			{
+				$row['id_parent'] = (int) $row['id_parent'];
+				$row['min_posts'] = (int) $row['min_posts'];
+				$row['max_messages'] = (int) $row['max_messages'];
+			}
 
 			$groups[$row['id_group']] = $row;
 		}

--- a/sources/subs/Membergroups.subs.php
+++ b/sources/subs/Membergroups.subs.php
@@ -782,13 +782,13 @@ function list_getMembergroups($start, $items_per_page, $sort, $membergroup_type,
 				return;
 			}
 
-			if ($row['id_parent'] != -2)
+			if ((int) $row['id_parent'] !== -2)
 			{
-				$parent_groups[] = $row['id_parent'];
+				$parent_groups[] = (int) $row['id_parent'];
 			}
 
 			// If it's inherited, just add it as a child.
-			if ($aggregate && $row['id_parent'] != -2)
+			if ($aggregate && (int) $row['id_parent'] !== -2)
 			{
 				if (isset($groups[$row['id_parent']]))
 				{
@@ -799,27 +799,27 @@ function list_getMembergroups($start, $items_per_page, $sort, $membergroup_type,
 			}
 
 			$row['icons'] = explode('#', $row['icons']);
-
+			$row['id_group'] = (int) $row['id_group'];
 			$groups[$row['id_group']] = array(
 				'id_group' => $row['id_group'],
 				'group_name' => $row['group_name'],
 				'group_name_color' => empty($row['online_color']) ? $row['group_name'] : '<span style="color: ' . $row['online_color'] . '">' . $row['group_name'] . '</span>',
-				'min_posts' => $row['min_posts'],
+				'min_posts' => (int) $row['min_posts'],
 				'desc' => $row['description'],
 				'online_color' => $row['online_color'],
-				'type' => $row['group_type'],
-				'num_members' => $row['num_members'],
+				'type' => (int) $row['group_type'],
+				'num_members' => (int) $row['num_members'],
 				'moderators' => array(),
 				'icons' => $row['icons'],
-				'can_search' => $row['id_group'] != 3,
-				'id_parent' => $row['id_parent'],
+				'can_search' => $row['id_group'] !== 3,
+				'id_parent' => (int) $row['id_parent'],
 			);
 
 			if ($count_permissions)
 			{
 				$groups[$row['id_group']]['num_permissions'] = array(
-					'allowed' => $row['id_group'] == 1 ? '(' . $txt['permissions_all'] . ')' : 0,
-					'denied' => $row['id_group'] == 1 ? '(' . $txt['permissions_none'] . ')' : 0,
+					'allowed' => $row['id_group'] === 1 ? '(' . $txt['permissions_all'] . ')' : 0,
+					'denied' => $row['id_group'] === 1 ? '(' . $txt['permissions_none'] . ')' : 0,
 				);
 			}
 
@@ -1077,6 +1077,7 @@ function membergroupsById($group_ids, $limit = 1, $detailed = false, $assignable
 			$row['id_group'] = (int) $row['id_group'];
 			$row['id_parent'] = (int) $row['id_parent'];
 			$row['group_type'] = (int) $row['group_type'];
+			$row['min_posts'] = (int) $row['min_posts'];
 
 			$groups[$row['id_group']] = $row;
 		}

--- a/sources/subs/Members.subs.php
+++ b/sources/subs/Members.subs.php
@@ -1922,12 +1922,14 @@ function countInactiveMembers()
 }
 
 /**
- * Get the member's id and group
+ * Get member data by name
  *
- * @param string $name
- * @param bool $flexible if true searches for both real_name and member_name (default false)
- * @return int
- * @package Members
+ * Retrieves the details of a member by their real name or username. The search is case-insensitive by default,
+ * but can be made flexible by setting the $flexible parameter to true.
+ *
+ * @param string $name The name to search for
+ * @param bool $flexible Set to true to enable flexible search
+ * @return array|int Returns an array containing the id_member and id_group of the member, or 0 if no member is found
  */
 function getMemberByName($name, $flexible = false)
 {
@@ -2086,9 +2088,9 @@ function retrieveMemberData($conditions)
 		function ($row) use (&$data) {
 			global $modSettings, $language;
 
-			$data['members'][] = $row['id_member'];
+			$data['members'][] = (int) $row['id_member'];
 			$data['member_info'][] = array(
-				'id' => $row['id_member'],
+				'id' => (int) $row['id_member'],
 				'username' => $row['member_name'],
 				'name' => $row['real_name'],
 				'email' => $row['email_address'],

--- a/sources/subs/Messages.subs.php
+++ b/sources/subs/Messages.subs.php
@@ -344,7 +344,7 @@ function associatedTopic($msg_id, $topicID = null)
 				'msg' => $msg_id,
 			)
 		);
-		if ($request->num_rows() != 1)
+		if ($request->num_rows() !== 1)
 		{
 			$topic = false;
 		}
@@ -544,7 +544,7 @@ function recordReport($message, $poster_comment)
 			'ignored' => 1,
 		)
 	);
-	if ($request->num_rows() != 0)
+	if ($request->num_rows() !== 0)
 	{
 		list ($id_report, $ignore_all) = $request->fetch_row();
 	}

--- a/sources/subs/PaidSubscriptions.subs.php
+++ b/sources/subs/PaidSubscriptions.subs.php
@@ -251,7 +251,7 @@ function addSubscription($id_subscribe, $id_member, $renewal = '', $forceStartTi
 			'is_active' => 1,
 		)
 	);
-	if ($request->num_rows() != 0)
+	if ($request->num_rows() !== 0)
 	{
 		list ($id_sublog, $endtime, $starttime) = $request->fetch_row();
 
@@ -339,7 +339,7 @@ function addSubscription($id_subscribe, $id_member, $renewal = '', $forceStartTi
 		)
 	);
 	// @todo Don't really need to do this twice...
-	if ($request->num_rows() != 0)
+	if ($request->num_rows() !== 0)
 	{
 		list ($id_sublog, $endtime, $starttime) = $request->fetch_row();
 
@@ -978,7 +978,7 @@ function alreadySubscribed($id_sub, $id_member)
 			'current_member' => $id_member,
 		)
 	);
-	$result = $request->num_rows() != 0;
+	$result = $request->num_rows() !== 0;
 	$request->free_result();
 
 	return $result;

--- a/sources/subs/Poll.subs.php
+++ b/sources/subs/Poll.subs.php
@@ -228,7 +228,7 @@ function pollInfoForTopic($topicID)
 	);
 
 	// The topic must exist
-	if ($request->num_rows() == 0)
+	if ($request->num_rows() === 0)
 	{
 		return false;
 	}
@@ -265,7 +265,7 @@ function topicFromPoll($pollID)
 	);
 
 	// The topic must exist
-	if ($request->num_rows() == 0)
+	if ($request->num_rows() === 0)
 	{
 		$topicID = false;
 	}
@@ -560,7 +560,7 @@ function pollStarters($id_topic)
 		)
 	);
 
-	if ($request->num_rows() != 0)
+	if ($request->num_rows() !== 0)
 	{
 		$pollStarters = $request->fetch_row();
 	}

--- a/sources/subs/Post.subs.php
+++ b/sources/subs/Post.subs.php
@@ -599,7 +599,7 @@ function modifyPost(&$msgOptions, &$topicOptions, &$posterOptions)
 				'id_first_msg' => $msgOptions['id'],
 			)
 		);
-		if ($request->num_rows() == 1)
+		if ($request->num_rows() === 1)
 		{
 			require_once(SUBSDIR . '/Messages.subs.php');
 			updateSubjectStats($topicOptions['id'], $msgOptions['subject']);
@@ -1096,7 +1096,7 @@ function lastPost()
 			'is_approved' => 1,
 		)
 	);
-	if ($request->num_rows() == 0)
+	if ($request->num_rows() === 0)
 	{
 		return array();
 	}
@@ -1193,7 +1193,7 @@ function getFormMsgSubject($editing, $topic, $first_subject = '', $msg_id = 0)
 					'is_approved' => 1,
 				)
 			);
-			if ($request->num_rows() == 0)
+			if ($request->num_rows() === 0)
 			{
 				throw new \ElkArte\Exceptions\Exception('quoted_post_deleted', false);
 			}

--- a/sources/subs/ScheduledTasks.subs.php
+++ b/sources/subs/ScheduledTasks.subs.php
@@ -556,7 +556,7 @@ function processNextTasks($ts = 0)
 			'current_time' => time(),
 		)
 	);
-	if ($request->num_rows() != 0)
+	if ($request->num_rows() !== 0)
 	{
 		// The two important things really...
 		$row = $request->fetch_assoc();

--- a/sources/subs/Topic.subs.php
+++ b/sources/subs/Topic.subs.php
@@ -618,7 +618,7 @@ function moveTopics($topics, $toBoard, $log = false)
 		)
 	);
 	// Num of rows = 0 -> no topics found. Num of rows > 1 -> topics are on multiple boards.
-	if ($request->num_rows() == 0)
+	if ($request->num_rows() === 0)
 	{
 		return;
 	}
@@ -2547,7 +2547,7 @@ function splitTopic($split1_ID_TOPIC, $splitMessages, $new_subject)
 		)
 	);
 	// You can't select ALL the messages!
-	if ($request->num_rows() == 0)
+	if ($request->num_rows() === 0)
 	{
 		throw new \ElkArte\Exceptions\Exception('selected_all_posts', false);
 	}
@@ -3398,7 +3398,7 @@ function getSubject($id_topic)
 			'search_topic_id' => $id_topic,
 		)
 	);
-	if ($request->num_rows() == 0)
+	if ($request->num_rows() === 0)
 	{
 		throw new \ElkArte\Exceptions\Exception('topic_gone', false);
 	}

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -143,7 +143,7 @@ $request = $db->query('', '
 		'current_member' => $member_id,
 	)
 );
-if ($request->num_rows() == 0)
+if ($request->num_rows() === 0)
 {
 	generateSubscriptionError(sprintf($txt['paid_count_not_find_subscription_log'], $member_id, $subscription_id), $notify_users);
 }

--- a/tests/sources/controllers/RegisterWeb.php
+++ b/tests/sources/controllers/RegisterWeb.php
@@ -190,6 +190,9 @@ class SupportRegisterController extends ElkArteWebSupport
 
 		$_SESSION['just_registered'] = 0;
 
+		// Lets be sure we are not logged in
+		$this->adminLogout();
+
 		// Select login from the main page
 		$this->url('index.php');
 		$this->clickit('#button_login > a');

--- a/tests/sources/subs/BBCHTMLSubsTest.php
+++ b/tests/sources/subs/BBCHTMLSubsTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use BBC\HtmlParser;
-use PHPUnit\Framework\TestCase;
+use tests\ElkArteCommonSetupTest;
 
-class BBCHTMLSubsTest extends \tests\ElkArteCommonSetupTest
+class BBCHTMLSubsTest extends ElkArteCommonSetupTest
 {
 	protected $bbcTestCases;
 	protected $backupGlobalsExcludeList = ['user_info'];


### PR DESCRIPTION
This is a run through the admin controllers to "freshen" the php level in a few areas.

- use static on closures that don't need $this
- arrow functions fn() => for some one line closures
- replace those \\ElkArte\\AdminController\\XYZ calls with an import and XYZ::class
- some hardening
- some useless else removal
- early returns
- remove list()
- defer suggest.js
- cast ints in some of the queries
- positive logic in some if
- etc