### PR TITLE
Continuation of freshen mode

### DIFF
--- a/sources/ElkArte/AbstractController.php
+++ b/sources/ElkArte/AbstractController.php
@@ -21,36 +21,20 @@ namespace ElkArte;
  */
 abstract class AbstractController
 {
-	/**
-	 * The event manager.
-	 *
-	 * @var object
-	 */
+	/** @var object The event manager. */
 	protected $_events;
 
-	/**
-	 * The current hook.
-	 *
-	 * @var string
-	 */
+	/** @var string The current hook. */
 	protected $_hook = '';
 
-	/**
-	 * Holds instance of \ElkArte\HttpReq object
-	 *
-	 * @var \ElkArte\HttpReq
-	 */
+	/** @var HttpReq Holds instance of \ElkArte\HttpReq object */
 	protected $_req;
 
-	/**
-	 * Holds instance of \ElkArte\User::$info object
-	 *
-	 * @var \ElkArte\ValuesContainer
-	 */
+	/** @var ValuesContainer Holds instance of \ElkArte\User::$info object */
 	protected $user;
 
 	/**
-	 * @param \ElkArte\EventManager $eventManager
+	 * @param EventManager $eventManager
 	 */
 	public function __construct($eventManager)
 	{
@@ -61,8 +45,7 @@ abstract class AbstractController
 	}
 
 	/**
-	 * Standard method to add an "home" button when using a custom action
-	 * as forum index.
+	 * Standard method to add an "home" button when using a custom action as forum index.
 	 *
 	 * @param array $buttons
 	 */
@@ -84,8 +67,7 @@ abstract class AbstractController
 	}
 
 	/**
-	 * Standard method to tweak the current action when using a custom
-	 * action as forum index.
+	 * Standard method to tweak the current action when using a custom action as forum index.
 	 *
 	 * @param string $current_action
 	 */
@@ -95,6 +77,7 @@ abstract class AbstractController
 		{
 			$current_action = 'base';
 		}
+
 		if (!empty($_REQUEST['action']) && $_REQUEST['action'] === 'forum')
 		{
 			$current_action = 'home';
@@ -108,7 +91,7 @@ abstract class AbstractController
 	 */
 	public static function canFrontPage()
 	{
-		return in_array('ElkArte\\FrontpageInterface', class_implements(get_called_class()));
+		return in_array('ElkArte\\FrontpageInterface', class_implements(get_called_class()), true);
 	}
 
 	/**
@@ -116,7 +99,7 @@ abstract class AbstractController
 	 */
 	public static function frontPageOptions()
 	{
-		return array();
+		return [];
 	}
 
 	/**
@@ -130,7 +113,7 @@ abstract class AbstractController
 	/**
 	 * Sets the $this->user property to the current user
 	 *
-	 * @param \ElkArte\ValuesContainer $user
+	 * @param ValuesContainer $user
 	 */
 	public function setUser($user)
 	{
@@ -295,8 +278,7 @@ abstract class AbstractController
 	 * If the property does not exist in the class, will also look in globals.
 	 *
 	 * @param string $dep - The name of the property the even wants
-	 * @param mixed[] $dependencies - the array that will be filled with the
-	 *                                references to the dependencies
+	 * @param array $dependencies - the array that will be filled with the references to the dependencies
 	 */
 	public function provideDependencies($dep, &$dependencies)
 	{
@@ -312,6 +294,14 @@ abstract class AbstractController
 		{
 			$dependencies[$dep] = &$GLOBALS[$dep];
 		}
+	}
+
+	/**
+	 * @return ValuesContainer
+	 */
+	public function getUser(): ValuesContainer
+	{
+		return $this->user;
 	}
 
 	/**

--- a/sources/ElkArte/AbstractModel.php
+++ b/sources/ElkArte/AbstractModel.php
@@ -22,13 +22,13 @@ namespace ElkArte;
 abstract class AbstractModel
 {
 	/** @var \ElkArte\Database\QueryInterface The database object */
-	protected $_db = null;
+	protected $_db;
 
 	/** @var \ElkArte\UserInfo The current user data */
-	protected $user = null;
+	protected $user;
 
 	/** @var object The modSettings */
-	protected $_modSettings = array();
+	protected $_modSettings = [];
 
 	/** @var \ElkArte\HttpReq The request values */
 	protected $_req;

--- a/sources/ElkArte/AdminController/ManageAttachments.php
+++ b/sources/ElkArte/AdminController/ManageAttachments.php
@@ -21,7 +21,7 @@ use ElkArte\Action;
 use ElkArte\FileFunctions;
 use ElkArte\Graphics\Image;
 use ElkArte\Graphics\Manipulators\Gd2;
-use ElkArte\Graphics\Manipulators\Imagick;
+use ElkArte\Graphics\Manipulators\ImageMagick;
 use ElkArte\SettingsForm\SettingsForm;
 use ElkArte\Util;
 use ElkArte\AttachmentsDirectory;
@@ -321,8 +321,8 @@ class ManageAttachments extends AbstractController
 
 		// Perform several checks to determine imaging capabilities.
 		$image = new Image($settings['default_theme_dir'] . '/images/blank.png');
-		$testImg = Gd2::canUse() || Imagick::canUse();
-		$testImgRotate = Imagick::canUse() || (Gd2::canUse() && function_exists('exif_read_data'));
+		$testImg = Gd2::canUse() || ImageMagick::canUse();
+		$testImgRotate = ImageMagick::canUse() || (Gd2::canUse() && function_exists('exif_read_data'));
 
 		// Check on webp support, and correct if wrong
 		$testWebP = $image->hasWebpSupport();

--- a/sources/ElkArte/AdminController/ManageAvatars.php
+++ b/sources/ElkArte/AdminController/ManageAvatars.php
@@ -17,7 +17,7 @@ use ElkArte\AbstractController;
 use ElkArte\Action;
 use ElkArte\FileFunctions;
 use ElkArte\Graphics\Manipulators\Gd2;
-use ElkArte\Graphics\Manipulators\Imagick;
+use ElkArte\Graphics\Manipulators\ImageMagick;
 use ElkArte\SettingsForm\SettingsForm;
 
 /**
@@ -124,7 +124,7 @@ class ManageAvatars extends AbstractController
 		global $txt, $context, $modSettings;
 
 		// Check for GD and ImageMagick. It will set up a warning for the admin otherwise.
-		$testImg = Gd2::canUse() || Imagick::canUse();
+		$testImg = Gd2::canUse() || ImageMagick::canUse();
 
 		$context['valid_avatar_dir'] = FileFunctions::instance()->isDir($modSettings['avatar_directory']);
 		$context['valid_custom_avatar_dir'] = !empty($modSettings['custom_avatar_dir'])

--- a/sources/ElkArte/Converters/AbstractDomParser.php
+++ b/sources/ElkArte/Converters/AbstractDomParser.php
@@ -216,6 +216,7 @@ abstract class AbstractDomParser
 			{
 				$lines[] = '';
 			}
+
 			while (!empty($string))
 			{
 				// Get the next #width characters before a break (space, punctuation tab etc)

--- a/sources/ElkArte/Database/AbstractDump.php
+++ b/sources/ElkArte/Database/AbstractDump.php
@@ -17,45 +17,23 @@
 
 namespace ElkArte\Database;
 
+use ElkArte\Exceptions\Exception;
+
 /**
  * Abstract database class, implements database to control functions
  */
 abstract class AbstractDump
 {
 	/**
-	 * Holds current instance of the db class
-	 *
-	 * @var \ElkArte\Database\QueryInterface
-	 */
-	protected $_db = null;
-
-	/**
-	 * Holds current instance of the tables-related class
-	 *
-	 * @var \ElkArte\Database\AbstractTable
-	 */
-	protected $_db_table = null;
-
-	/**
-	 * The db prefix
-	 *
-	 * @var string
-	 */
-	protected $_db_prefix = '';
-
-	/**
 	 * Initializes a database connection.
 	 * It returns the connection, if successful.
 	 *
-	 * @param \ElkArte\Database\QueryInterface $db
-	 * @param \ElkArte\Database\AbstractTable|null $db_table
-	 * @param string|null $db_prefix
+	 * @param QueryInterface $_db Holds current instance of the db class
+	 * @param AbstractTable|null $_db_table Holds current instance of the tables-related class
+	 * @param string|null $_db_prefix The db prefix
 	 */
-	public function __construct($db, $db_table = null, $db_prefix = null)
+	public function __construct(protected $_db, protected $_db_table = null, protected $_db_prefix = null)
 	{
-		$this->_db = $db;
-		$this->_db_table = $db_table;
-		$this->_db_prefix = $db_prefix;
 	}
 
 	/**
@@ -64,7 +42,7 @@ abstract class AbstractDump
 	 * @param string $tableName - the table
 	 *
 	 * @return string - the CREATE statement as string
-	 * @throws \ElkArte\Exceptions\Exception
+	 * @throws Exception
 	 */
 	abstract public function table_sql($tableName);
 
@@ -85,8 +63,8 @@ abstract class AbstractDump
 	 * @param string $table_name
 	 * @param string $backup_table
 	 *
-	 * @return bool|\ElkArte\Database\AbstractResult - the request handle to the table creation query
-	 * @throws \ElkArte\Exceptions\Exception
+	 * @return bool|AbstractResult - the request handle to the table creation query
+	 * @throws Exception
 	 */
 	abstract public function backup_table($table_name, $backup_table);
 
@@ -98,7 +76,7 @@ abstract class AbstractDump
 	 * @param bool $new_table
 	 *
 	 * @return string the query to insert the data back in, or an empty string if the table was empty.
-	 * @throws \ElkArte\Exceptions\Exception
+	 * @throws Exception
 	 */
 	abstract public function insert_sql($tableName, $new_table = false);
 }

--- a/sources/ElkArte/Database/AbstractResult.php
+++ b/sources/ElkArte/Database/AbstractResult.php
@@ -24,27 +24,18 @@ use ElkArte\ValuesContainer;
  */
 abstract class AbstractResult
 {
-	/**
-	 * Result object
-	 *
-	 * @var resource
-	 */
-	protected $result = null;
-
-	/**
-	 * @var \ElkArte\ValuesContainer
-	 */
-	protected $details = null;
+	/** @var ValuesContainer */
+	protected $details;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param $result
+	 * @param $result Result Object
 	 * @param null $details
+	 * @param resource $result
 	 */
-	public function __construct($result, $details = null)
+	public function __construct(protected $result, $details = null)
 	{
-		$this->result = $result;
 		$this->details = $details ?? new ValuesContainer();
 	}
 

--- a/sources/ElkArte/Database/AbstractResult.php
+++ b/sources/ElkArte/Database/AbstractResult.php
@@ -30,7 +30,7 @@ abstract class AbstractResult
 	/**
 	 * Constructor.
 	 *
-	 * @param $result Result Object
+	 * @param $result Object
 	 * @param null $details
 	 * @param resource $result
 	 */

--- a/sources/ElkArte/Database/AbstractSearch.php
+++ b/sources/ElkArte/Database/AbstractSearch.php
@@ -18,33 +18,18 @@ namespace ElkArte\Database;
  */
 abstract class AbstractSearch implements SearchInterface
 {
-	/**
-	 * The database object
-	 *
-	 * @var \ElkArte\Database\QueryInterface
-	 */
-	protected $_db = null;
-
-	/**
-	 * The supported search methods
-	 *
-	 * @var string[]
-	 */
+	/** @var string[] The supported search methods */
 	protected $_supported_types = array();
 
-	/**
-	 * The way to skip a database error
-	 *
-	 * @var bool
-	 */
+	/** @var bool The way to skip a database error */
 	protected $_skip_error = false;
 
 	/**
 	 * Usual constructor
+	 * @param QueryInterface $_db The database object
 	 */
-	public function __construct($db)
+	public function __construct(protected $_db)
 	{
-		$this->_db = $db;
 	}
 
 	/**
@@ -90,22 +75,22 @@ abstract class AbstractSearch implements SearchInterface
 	{
 		$db_table = db_table();
 		$db_table->create_table('{db_prefix}log_search_words',
-			array(
-				array(
+			[
+				[
 					'name' => 'id_word',
 					'type' => 'int',
 					'size' => 10,
 					'unsigned' => true,
 					'default' => 0
-				),
-				array(
+				],
+				[
 					'name' => 'id_msg',
 					'type' => 'int',
 					'size' => 10,
 					'unsigned' => true,
 					'default' => 0
-				),
-			),
+				],
+			],
 			array(
 				array('name' => 'id_word', 'columns' => array('id_word', 'id_msg'), 'type' => 'primary')
 			)

--- a/sources/ElkArte/Database/ConnectionInterface.php
+++ b/sources/ElkArte/Database/ConnectionInterface.php
@@ -25,10 +25,9 @@ interface ConnectionInterface
 	 * @param string $db_user
 	 * @param string $db_passwd
 	 * @param string $db_prefix
-	 * @param mixed[] $db_options
+	 * @param array $db_options
 	 *
-	 * @return \ElkArte\Database\QueryInterface|null
-	 * @throws \Exception
+	 * @return QueryInterface|null
 	 */
 	public static function initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix, $db_options = array());
 }

--- a/sources/ElkArte/Database/Mysqli/Connection.php
+++ b/sources/ElkArte/Database/Mysqli/Connection.php
@@ -54,14 +54,14 @@ class Connection implements ConnectionInterface
 			mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_INDEX & ~MYSQLI_REPORT_STRICT);
 		}
 		catch (\mysqli_sql_exception $e)
-        {
-	        // Something's wrong, show an error if its fatal (which we assume it is)
-	        // If the connection fails more than once (e.g. wrong password) the exception
-	        // should be thrown only once.
-	        self::$failed_once = true;
+		{
+			// Something's wrong, show an error if its fatal (which we assume it is)
+			// If the connection fails more than once (e.g. wrong password) the exception
+			// should be thrown only once.
+			self::$failed_once = true;
 
-	        throw new \RuntimeException('Db initialization failed ' . $e->getMessage());
-        }
+			throw new \RuntimeException('Db initialization failed ' . $e->getMessage());
+		}
 
 		return $query;
 	}

--- a/sources/ElkArte/Database/Mysqli/Connection.php
+++ b/sources/ElkArte/Database/Mysqli/Connection.php
@@ -30,7 +30,7 @@ class Connection implements ConnectionInterface
 	 */
 	public static function initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix, $db_options = [])
 	{
-		$db_port = (int) ($db_options['port'] ?? 0);
+		$db_port = (int) ($db_options['port'] ?? null);
 		$db_name = empty($db_options['select_db']) ? '' : $db_name;
 		$db_server = (empty($db_options['persist']) ? '' : 'p:') . $db_server;
 

--- a/sources/ElkArte/Database/Mysqli/Connection.php
+++ b/sources/ElkArte/Database/Mysqli/Connection.php
@@ -17,7 +17,6 @@
 namespace ElkArte\Database\Mysqli;
 
 use ElkArte\Database\ConnectionInterface;
-use ElkArte\Exceptions\Exception;
 
 /**
  * SQL database class, implements database class to control mysql functions
@@ -31,38 +30,38 @@ class Connection implements ConnectionInterface
 	 */
 	public static function initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix, $db_options = [])
 	{
-		// Non-standard port
 		$db_port = (int) ($db_options['port'] ?? 0);
+		$db_name = empty($db_options['select_db']) ? '' : $db_name;
+		$db_server = (empty($db_options['persist']) ? '' : 'p:') . $db_server;
 
-		// Select the database. Maybe.
-		$db_name = !empty($db_options['select_db']) ? $db_name : '';
-
-		$db_server = (!empty($db_options['persist']) ? 'p:' : '') . $db_server;
-
-		$connection = @mysqli_connect($db_server, $db_user, $db_passwd, $db_name, $db_port);
-
-		// Something's wrong, show an error if its fatal (which we assume it is)
-		// If the connection fails more than once (e.g. wrong password) the exception
-		// should be thrown only once.
-		if (!$connection && !self::$failed_once)
+		try
 		{
-			self::$failed_once = true;
-			throw new \RuntimeException('Db initialization failed');
+			$connection = mysqli_init();
+			$connection->real_connect($db_server, $db_user, $db_passwd, $db_name, $db_port);
+
+			$query = new Query($db_prefix, $connection);
+
+			// This makes it possible to automatically change the sql_mode and autocommit if needed.
+			if (!empty($db_options['mysql_set_mode']))
+			{
+				$query->query('', "SET sql_mode = '', AUTOCOMMIT = 1", []);
+			}
+
+			// Few databases still have not set UTF-8 as their default input charset
+			$query->query('', 'SET NAMES UTF8', []);
+
+			// PHP 8.1 default is to throw exceptions, this reverts it to the <=php8 semantics
+			mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_INDEX & ~MYSQLI_REPORT_STRICT);
 		}
+		catch (\mysqli_sql_exception $e)
+        {
+	        // Something's wrong, show an error if its fatal (which we assume it is)
+	        // If the connection fails more than once (e.g. wrong password) the exception
+	        // should be thrown only once.
+	        self::$failed_once = true;
 
-		// PHP 8.1 default is to throw exceptions, this reverts it to the <=php8 semantics
-		mysqli_report(MYSQLI_REPORT_OFF);
-
-		$query = new Query($db_prefix, $connection);
-
-		// This makes it possible to automatically change the sql_mode and autocommit if needed.
-		if (!empty($db_options['mysql_set_mode']))
-		{
-			$query->query('', 'SET sql_mode = \'\', AUTOCOMMIT = 1',[]);
-		}
-
-		// Few databases still have not set UTF-8 as their default input charset
-		$query->query('', 'SET NAMES UTF8',[]);
+	        throw new \RuntimeException('Db initialization failed ' . $e->getMessage());
+        }
 
 		return $query;
 	}

--- a/sources/ElkArte/Database/Mysqli/Query.php
+++ b/sources/ElkArte/Database/Mysqli/Query.php
@@ -19,7 +19,9 @@ namespace ElkArte\Database\Mysqli;
 
 use ElkArte\Cache\Cache;
 use ElkArte\Database\AbstractQuery;
+use ElkArte\Database\AbstractResult;
 use ElkArte\Errors\Errors;
+use ElkArte\Languages\Txt;
 use ElkArte\Util;
 use ElkArte\ValuesContainer;
 
@@ -28,25 +30,28 @@ use ElkArte\ValuesContainer;
  */
 class Query extends AbstractQuery
 {
-	/**
-	 * {@inheritDoc}
-	 */
+	/** {@inheritDoc} */
 	protected $ilike = ' LIKE ';
 
-	/**
-	 * {@inheritDoc}
-	 */
+	/** {@inheritDoc} */
 	protected $not_ilike = ' NOT LIKE ';
 
-	/**
-	 * {@inheritDoc}
-	 */
+	/** {@inheritDoc} */
 	protected $rlike = ' RLIKE ';
 
-	/**
-	 * {@inheritDoc}
-	 */
+	/** {@inheritDoc} */
 	protected $not_rlike = ' NOT RLIKE ';
+
+	// Error number constants
+	private const ERR_COMMAND_DENIED = 1142;
+	private const ERR_TABLE_HANDLER = 1030;
+	private const ERR_KEY_FILE = 1016;
+	private const ERR_INCORRECT_KEY_FILE = 1034;
+	private const ERR_OLD_KEY_FILE = 1035;
+	private const ERR_LOCK_WAIT_TIMEOUT_EXCEEDED = 1205;
+	private const ERR_DEADLOCK_FOUND = 1213;
+	private const ERR_SERVER_HAS_GONE_AWAY = 2006;
+	private const ERR_LOST_CONNECTION_TO_SERVER = 2013;
 
 	/**
 	 * {@inheritDoc}
@@ -97,7 +102,7 @@ class Query extends AbstractQuery
 	 */
 	public function insert($method, $table, $columns, $data, $keys, $disable_trans = false)
 	{
-		list($table, $indexed_columns, $insertRows) = $this->prepareInsert($table, $columns, $data);
+		[$table, $indexed_columns, $insertRows] = $this->prepareInsert($table, $columns, $data);
 
 		// Determine the method of insertion.
 		$queryTitle = $method === 'replace' ? 'REPLACE' : ($method === 'ignore' ? 'INSERT IGNORE' : 'INSERT');
@@ -149,6 +154,7 @@ class Query extends AbstractQuery
 				$db_string .= "\n\t\t\tORDER BY null";
 			}
 		}
+
 		return $db_string;
 	}
 
@@ -175,15 +181,322 @@ class Query extends AbstractQuery
 	 */
 	public function error($db_string)
 	{
+		[$file, $line] = $this->backtrace_message();
+		$file = $file ?? __FILE__;
+		$line = $line ?? __LINE__;
+
+		$query_error = mysqli_error($this->connection);
+		$query_errno = mysqli_errno($this->connection);
+
+		// See if there is a recovery we can attempt
+		switch ($query_errno)
+		{
+			case self::ERR_COMMAND_DENIED:
+				$check = $this->handleCommandDeniedError($db_string, $query_error, $file, $line);
+				break;
+			case self::ERR_TABLE_HANDLER:
+			case self::ERR_KEY_FILE:
+			case self::ERR_INCORRECT_KEY_FILE:
+			case self::ERR_OLD_KEY_FILE:
+				$check = $this->handleTableOrKeyFileError($db_string, $query_errno, $query_error);
+				break;
+			case self::ERR_SERVER_HAS_GONE_AWAY:
+			case self::ERR_LOST_CONNECTION_TO_SERVER:
+				$check = $this->handleConnectionError($db_string);
+				break;
+			default:
+				$check = null;
+				break;
+		}
+
+		// Did we attempt to do a repair, return those results
+		if ($check !== null)
+		{
+			return $check;
+		}
+
+		// Log the error.
+		$query_error = $this->handleSpaceError($query_errno,$query_error);
+		if ($query_errno !== self::ERR_DEADLOCK_FOUND && $query_errno !== self::ERR_LOCK_WAIT_TIMEOUT_EXCEEDED)
+		{
+			Errors::instance()->log_error($txt['database_error'] . ': ' . $query_error . (empty($modSettings['enableErrorQueryLogging']) ? '' : "\n\n$db_string"), 'database', $file, $line);
+		}
+
+		// Argh, enough said.
+		$this->throwError($db_string, $query_error, $file, $line);
+	}
+
+	/**
+	 * Handles the command denied error and takes appropriate action.
+	 *
+	 * @param string $db_string The database query string.
+	 * @param string $query_error The error message related to the query.
+	 * @param string $file The file where the error occurred.
+	 * @param int $line The line number where the error occurred.
+	 * @return bool|null Returns false if the command is DELETE, UPDATE, or INSERT. Returns null otherwise.
+	 */
+	private function handleCommandDeniedError($db_string, $query_error, $file, $line)
+	{
+		global $txt, $modSettings;
+
+		// We cannot do something, try to find out what and act accordingly
+		$command = substr(trim($db_string), 0, 6);
+		if ($command === 'DELETE' || $command === 'UPDATE' || $command === 'INSERT')
+		{
+			// We can try to ignore it (warning the admin though it's a thing to do) \
+			// and serve the page just SELECTing
+			$_SESSION['query_command_denied'][$command] = $query_error;
+
+			// Let the admin know there is a command denied issue
+			Errors::instance()->log_error($txt['database_error'] . ': ' . $query_error . (empty($modSettings['enableErrorQueryLogging']) ? '' : "\n\n$db_string"), 'database', $file, $line);
+
+			return false;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Handles table or key file errors in the database.
+	 *
+	 * @param string $db_string The database query string.
+	 * @param int $query_errno The error code of the query.
+	 * @param string $query_error The error message of the query.
+	 *
+	 * @return null|AbstractResult Returns the result of the query if successful, otherwise null.
+	 */
+	private function handleTableOrKeyFileError($db_string, $query_errno, $query_error)
+	{
+		global $modSettings;
+
+		if (function_exists('\\ElkArte\\Cache\\Cache::instance()->get')
+			&& (!isset($modSettings['autoFixDatabase']) || $modSettings['autoFixDatabase'] === '1'))
+		{
+			$db_last_error = db_last_error();
+			$cache = Cache::instance();
+
+			// Force caching on, just for the error checking.
+			$old_cache = $cache->getLevel();
+			if ($cache->isEnabled() === false)
+			{
+				$cache->setLevel(1);
+			}
+
+			$temp = null;
+			if ($cache->getVar($temp, 'db_last_error', 600))
+			{
+				$db_last_error = max($db_last_error, $temp);
+			}
+
+			// Check for errors like 145... only fix it once every three days, and send an email. (can't use empty because it might not be set yet...)
+			if ($db_last_error < time() - 3600 * 24 * 3)
+			{
+				// We know there's a problem... but what?  Try to auto-detect.
+				$fix_tables = $this->getTablesToRepair($db_string, $query_errno, $query_error);
+				if ($fix_tables !== false)
+				{
+					return $this->attemptRepair($fix_tables, $db_string);
+				}
+			}
+
+			$modSettings['cache_enable'] = $old_cache;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Handles connection errors and tries to reconnect.
+	 *
+	 * @param string $db_string The database query string.
+	 * @return null|AbstractResult Returns the result of the query if successful, otherwise null.
+	 */
+	private function handleConnectionError($db_string)
+	{
+		global $db_persist, $db_server, $db_user, $db_passwd, $db_name, $ssi_db_user, $ssi_db_passwd;
+
+		// Check for the "lost connection" or "deadlock found" errors - and try it just one more time.
+		$new_connection = false;
+
+		// Are we in SSI mode?  If so try that username and password first
+		if (ELK === 'SSI' && !empty($ssi_db_user) && !empty($ssi_db_passwd))
+		{
+			$new_connection = @mysqli_connect((empty($db_persist) ? '' : 'p:') . $db_server, $ssi_db_user, $ssi_db_passwd, $db_name);
+		}
+
+		// Fall back to the regular username and password if need be
+		if (!$new_connection)
+		{
+			$new_connection = @mysqli_connect((empty($db_persist) ? '' : 'p:') . $db_server, $db_user, $db_passwd, $db_name);
+		}
+
+		if ($new_connection)
+		{
+			$this->connection = $new_connection;
+
+			// Try a deadlock more than once more.
+			for ($n = 0; $n < 4; $n++)
+			{
+				$ret = $this->query('', $db_string, false);
+
+				$new_errno = mysqli_errno($new_connection);
+				if ($ret->hasResults() || in_array($new_errno, [self::ERR_LOCK_WAIT_TIMEOUT_EXCEEDED, self::ERR_DEADLOCK_FOUND]))
+				{
+					break;
+				}
+			}
+
+			// If it failed again, shucks to be you... we're not trying it over and over.
+			if ($ret->hasResults())
+			{
+				return $ret;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Handle space error in a database query.
+	 *
+	 * @param int $query_errno The error number of the query.
+	 * @param string $query_error The error message of the query.
+	 * @return string The updated error message with space error handling.
+	 */
+	private function handleSpaceError($query_errno, $query_error)
+	{
+		global $txt;
+
+		if ($query_errno === self::ERR_TABLE_HANDLER &&
+			(strpos($query_error, ' -1 ') !== false
+				|| strpos($query_error, ' 28 ') !== false
+				|| strpos($query_error, ' 12 ') !== false))
+		{
+			if (!isset($txt))
+			{
+				$query_error .= ' - check database storage space.';
+			}
+			else
+			{
+				if (!isset($txt['mysql_error_space']))
+				{
+					Txt::load('Errors');
+				}
+
+				$query_error .= $txt['mysql_error_space'] ?? ' - check database storage space.';
+			}
+		}
+
+		return $query_error;
+	}
+
+	/**
+	 * Returns an array of tables to repair based on the provided parameters.
+	 *
+	 * @param string $db_string The database query string.
+	 * @param int $query_errno The error number associated with the query.
+	 * @param string $query_error The error message associated with the query.
+	 * @return array|bool An array of tables to repair, or false if no tables to repair.
+	 */
+	private function getTablesToRepair($db_string, $query_errno, $query_error)
+	{
+		if ($query_errno === self::ERR_TABLE_HANDLER && strpos($query_error, ' 127 ') !== false)
+		{
+			preg_match_all('~(?:[\n\r]|^)[^\']+?(?:FROM|JOIN|UPDATE|TABLE) ((?:[^\n\r(]+?(?:, )?)*)~', $db_string, $matches);
+
+			$fix_tables = [];
+			foreach ($matches[1] as $tables)
+			{
+				$tables = array_unique(explode(',', $tables));
+				foreach ($tables as $table)
+				{
+					// Now, it's still theoretically possible this could be an injection.  So backtick it!
+					if (trim($table) !== '')
+					{
+						$fix_tables[] = '`' . strtr(trim($table), ['`' => '']) . '`';
+					}
+				}
+			}
+
+			return array_unique($fix_tables);
+		}
+
+		// Table crashed.  Let's try to fix it.
+		if (($query_errno === self::ERR_KEY_FILE)
+			&& preg_match('~\'([^.\']+)~', $query_error, $match) === 1)
+		{
+			return ['`' . $match[1] . '`'];
+		}
+
+		// Indexes crashed.  Should be easy to fix!
+		if (($query_errno === self::ERR_INCORRECT_KEY_FILE || $query_errno === self::ERR_OLD_KEY_FILE)
+			&& preg_match("~'([^']+?)'~", $query_error, $match) === 1)
+		{
+			return ['`' . $match[1] . '`'];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Attempt to repair the specified tables in the database.
+	 *
+	 * @param array $fix_tables An array containing the names of the tables to be repaired.
+	 * @param string $db_string The database query string to be executed after attempting the repair.
+	 *
+	 * @return null|AbstractResult Returns the query results if the repair was successful, null otherwise.
+	 */
+	private function attemptRepair($fix_tables, $db_string)
+	{
+		global $webmaster_email, $txt;
+
+		// sources/Logging.php for logLastDatabaseError(), subs/Mail.subs.php for sendmail().
+		// @todo this should go somewhere else, not into the db-mysql layer I think
+		require_once(SOURCEDIR . '/Logging.php');
+		require_once(SUBSDIR . '/Mail.subs.php');
+
+		// Make a note of the REPAIR...
+		$cache = Cache::instance();
+		$cache->put('db_last_error', time(), 600);
+		if (!$cache->getVar($temp, 'db_last_error', 600))
+		{
+			logLastDatabaseError();
+		}
+
+		// Attempt to find and repair the broken table.
+		foreach ($fix_tables as $table)
+		{
+			$this->query('', '
+				REPAIR TABLE ' . $table, false);
+		}
+
+		// And send off an email!
+		sendmail($webmaster_email, $txt['database_error'], $txt['tried_to_repair']);
+
+		// Try the query again...?
+		$ret = $this->query('', $db_string, false);
+		if ($ret->hasResults())
+		{
+			return $ret;
+		}
+
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function olderror($db_string)
+	{
 		global $txt, $webmaster_email, $modSettings, $db_persist;
 		global $db_server, $db_user, $db_passwd, $db_name, $ssi_db_user, $ssi_db_passwd;
 
 		// We'll try recovering the file and line number the original db query was called from.
-		list ($file, $line) = $this->backtrace_message();
+		[$file, $line] = $this->backtrace_message();
 
 		// Just in case nothing can be found from debug_backtrace
-		$file = $file ?? __FILE__;
-		$line = $line ?? __LINE__;
+		$file ??= __FILE__;
+		$line ??= __LINE__;
 
 		// This is the error message...
 		$query_error = mysqli_error($this->connection);
@@ -201,7 +514,7 @@ class Query extends AbstractQuery
 		//    2013: Lost connection to server during query.
 
 		// We cannot do something, try to find out what and act accordingly
-		if ($query_errno == 1142)
+		if ($query_errno === self::ERR_COMMAND_DENIED)
 		{
 			$command = substr(trim($db_string), 0, 6);
 			if ($command === 'DELETE' || $command === 'UPDATE' || $command === 'INSERT')
@@ -211,14 +524,14 @@ class Query extends AbstractQuery
 				$_SESSION['query_command_denied'][$command] = $query_error;
 
 				// Let the admin know there is a command denied issue
-				Errors::instance()->log_error($txt['database_error'] . ': ' . $query_error . (!empty($modSettings['enableErrorQueryLogging']) ? "\n\n$db_string" : ''), 'database', $file, $line);
+				Errors::instance()->log_error($txt['database_error'] . ': ' . $query_error . (empty($modSettings['enableErrorQueryLogging']) ? '' : "\n\n$db_string"), 'database', $file, $line);
 
 				return false;
 			}
 		}
 
 		// Database error auto fixing ;).
-		if (function_exists('\\ElkArte\\Cache\\Cache::instance()->get') && (!isset($modSettings['autoFixDatabase']) || $modSettings['autoFixDatabase'] == '1'))
+		if (function_exists('\\ElkArte\\Cache\\Cache::instance()->get') && (!isset($modSettings['autoFixDatabase']) || $modSettings['autoFixDatabase'] === '1'))
 		{
 			$db_last_error = db_last_error();
 			$cache = Cache::instance();
@@ -229,6 +542,7 @@ class Query extends AbstractQuery
 			{
 				$cache->setLevel(1);
 			}
+
 			$temp = null;
 
 			if ($cache->getVar($temp, 'db_last_error', 600))
@@ -239,11 +553,11 @@ class Query extends AbstractQuery
 			if ($db_last_error < time() - 3600 * 24 * 3)
 			{
 				// We know there's a problem... but what?  Try to auto detect.
-				if ($query_errno == 1030 && strpos($query_error, ' 127 ') !== false)
+				if ($query_errno === 1030 && strpos($query_error, ' 127 ') !== false)
 				{
 					preg_match_all('~(?:[\n\r]|^)[^\']+?(?:FROM|JOIN|UPDATE|TABLE) ((?:[^\n\r(]+?(?:, )?)*)~', $db_string, $matches);
 
-					$fix_tables = array();
+					$fix_tables = [];
 					foreach ($matches[1] as $tables)
 					{
 						$tables = array_unique(explode(',', $tables));
@@ -260,18 +574,18 @@ class Query extends AbstractQuery
 					$fix_tables = array_unique($fix_tables);
 				}
 				// Table crashed.  Let's try to fix it.
-				elseif ($query_errno == 1016)
+				elseif ($query_errno === 1016)
 				{
-					if (preg_match('~\'([^\.\']+)~', $query_error, $match) != 0)
+					if (preg_match('~\'([^.\']+)~', $query_error, $match) != 0)
 					{
-						$fix_tables = array('`' . $match[1] . '`');
+						$fix_tables = ['`' . $match[1] . '`'];
 					}
 				}
 				// Indexes crashed.  Should be easy to fix!
-				elseif ($query_errno == 1034 || $query_errno == 1035)
+				elseif ($query_errno === 1034 || $query_errno === 1035)
 				{
-					preg_match('~\'([^\']+?)\'~', $query_error, $match);
-					$fix_tables = array('`' . $match[1] . '`');
+					preg_match("~'([^']+?)'~", $query_error, $match);
+					$fix_tables = ['`' . $match[1] . '`'];
 				}
 			}
 
@@ -293,8 +607,8 @@ class Query extends AbstractQuery
 				// Attempt to find and repair the broken table.
 				foreach ($fix_tables as $table)
 				{
-					$this->query('', "
-						REPAIR TABLE $table", false);
+					$this->query('', '
+						REPAIR TABLE ' . $table, false);
 				}
 
 				// And send off an email!
@@ -315,21 +629,21 @@ class Query extends AbstractQuery
 			}
 
 			// Check for the "lost connection" or "deadlock found" errors - and try it just one more time.
-			if (in_array($query_errno, array(1205, 1213, 2006, 2013)))
+			if (in_array($query_errno, [1205, 1213, 2006, 2013], true))
 			{
 				$new_connection = false;
-				if (in_array($query_errno, array(2006, 2013)))
+				if (in_array($query_errno, [2006, 2013], true))
 				{
 					// Are we in SSI mode?  If so try that username and password first
-					if (ELK == 'SSI' && !empty($ssi_db_user) && !empty($ssi_db_passwd))
+					if (ELK === 'SSI' && !empty($ssi_db_user) && !empty($ssi_db_passwd))
 					{
-						$new_connection = @mysqli_connect((!empty($db_persist) ? 'p:' : '') . $db_server, $ssi_db_user, $ssi_db_passwd, $db_name);
+						$new_connection = @mysqli_connect((empty($db_persist) ? '' : 'p:') . $db_server, $ssi_db_user, $ssi_db_passwd, $db_name);
 					}
 
 					// Fall back to the regular username and password if need be
 					if (!$new_connection)
 					{
-						$new_connection = @mysqli_connect((!empty($db_persist) ? 'p:' : '') . $db_server, $db_user, $db_passwd, $db_name);
+						$new_connection = @mysqli_connect((empty($db_persist) ? '' : 'p:') . $db_server, $db_user, $db_passwd, $db_name);
 					}
 				}
 
@@ -357,7 +671,7 @@ class Query extends AbstractQuery
 				}
 			}
 			// Are they out of space, perhaps?
-			elseif ($query_errno == 1030 && (strpos($query_error, ' -1 ') !== false || strpos($query_error, ' 28 ') !== false || strpos($query_error, ' 12 ') !== false))
+			elseif ($query_errno === 1030 && (strpos($query_error, ' -1 ') !== false || strpos($query_error, ' 28 ') !== false || strpos($query_error, ' 12 ') !== false))
 			{
 				if (!isset($txt))
 				{
@@ -367,7 +681,7 @@ class Query extends AbstractQuery
 				{
 					if (!isset($txt['mysql_error_space']))
 					{
-						\ElkArte\Languages\Txt::load('Errors');
+						Txt::load('Errors');
 					}
 
 					$query_error .= $txt['mysql_error_space'] ?? ' - check database storage space.';
@@ -376,9 +690,9 @@ class Query extends AbstractQuery
 		}
 
 		// Log the error.
-		if ($query_errno != 1213 && $query_errno != 1205)
+		if ($query_errno !== 1213 && $query_errno !== 1205)
 		{
-			Errors::instance()->log_error($txt['database_error'] . ': ' . $query_error . (!empty($modSettings['enableErrorQueryLogging']) ? "\n\n$db_string" : ''), 'database', $file, $line);
+			Errors::instance()->log_error($txt['database_error'] . ': ' . $query_error . (empty($modSettings['enableErrorQueryLogging']) ? '' : "\n\n$db_string"), 'database', $file, $line);
 		}
 
 		$this->throwError($db_string, $query_error, $file, $line);
@@ -413,7 +727,7 @@ class Query extends AbstractQuery
 			SELECT VERSION()',
 			array()
 		);
-		list ($ver) = $request->fetch_row();
+		[$ver] = $request->fetch_row();
 		$request->free_result();
 
 		return $ver;
@@ -462,7 +776,7 @@ class Query extends AbstractQuery
 			SELECT VERSION()',
 			array()
 		);
-		list ($ver) = $request->fetch_row();
+		[$ver] = $request->fetch_row();
 		$request->free_result();
 
 		return $ver;

--- a/sources/ElkArte/Database/Mysqli/Query.php
+++ b/sources/ElkArte/Database/Mysqli/Query.php
@@ -218,7 +218,7 @@ class Query extends AbstractQuery
 		}
 
 		// Log the error.
-		$query_error = $this->handleSpaceError($query_errno,$query_error);
+		$query_error = $this->handleSpaceError($query_errno, $query_error);
 		if ($query_errno !== self::ERR_DEADLOCK_FOUND && $query_errno !== self::ERR_LOCK_WAIT_TIMEOUT_EXCEEDED)
 		{
 			Errors::instance()->log_error($txt['database_error'] . ': ' . $query_error . (empty($modSettings['enableErrorQueryLogging']) ? '' : "\n\n$db_string"), 'database', $file, $line);

--- a/sources/ElkArte/Database/Mysqli/Result.php
+++ b/sources/ElkArte/Database/Mysqli/Result.php
@@ -52,7 +52,7 @@ class Result extends AbstractResult
 	public function free_result()
 	{
 		// Just delegate to MySQL's function
-		if ($this->result instanceof mysqli_result)
+		if ($this->result instanceof \mysqli_result && isset($this->result->num_rows))
 		{
 			mysqli_free_result($this->result);
 		}

--- a/sources/ElkArte/Database/Mysqli/Search.php
+++ b/sources/ElkArte/Database/Mysqli/Search.php
@@ -16,7 +16,7 @@ namespace ElkArte\Database\Mysqli;
 use ElkArte\Database\AbstractSearch;
 
 /**
- * MySQL implementation of DbSearch
+ * MySQLs implementation of DbSearch
  */
 class Search extends AbstractSearch
 {

--- a/sources/ElkArte/Database/Postgresql/Dump.php
+++ b/sources/ElkArte/Database/Postgresql/Dump.php
@@ -51,11 +51,11 @@ class Dump extends AbstractDump
 		);
 		while (($row = $result->fetch_assoc()))
 		{
-			if ($row['data_type'] == 'character varying')
+			if ($row['data_type'] === 'character varying')
 			{
 				$row['data_type'] = 'varchar';
 			}
-			elseif ($row['data_type'] == 'character')
+			elseif ($row['data_type'] === 'character')
 			{
 				$row['data_type'] = 'char';
 			}
@@ -66,7 +66,7 @@ class Dump extends AbstractDump
 			}
 
 			// Make the CREATE for this column.
-			$schema_create .= ' "' . $row['column_name'] . '" ' . $row['data_type'] . ($row['is_nullable'] != 'YES' ? ' NOT NULL' : '');
+			$schema_create .= ' "' . $row['column_name'] . '" ' . $row['data_type'] . ($row['is_nullable'] !== 'YES' ? ' NOT NULL' : '');
 
 			// Add a default...?
 			if (trim($row['column_default']) !== '')
@@ -85,7 +85,7 @@ class Dump extends AbstractDump
 							'table' => $tableName,
 						)
 					);
-					list ($max_ind) = $count_req->fetch_row();
+					[$max_ind] = $count_req->fetch_row();
 					$count_req->free_result();
 
 					// Get the right bloody start!
@@ -95,6 +95,7 @@ class Dump extends AbstractDump
 
 			$schema_create .= ',' . $crlf;
 		}
+
 		$result->free_result();
 
 		// Take off the last comma.
@@ -116,7 +117,7 @@ class Dump extends AbstractDump
 		{
 			if ($row['is_primary'])
 			{
-				if (preg_match('~\(([^\)]+?)\)~i', $row['inddef'], $matches) == 0)
+				if (preg_match('~\(([^)]+?)\)~i', $row['inddef'], $matches) !== 1)
 				{
 					continue;
 				}
@@ -128,6 +129,7 @@ class Dump extends AbstractDump
 				$index_create .= $crlf . $row['inddef'] . ';';
 			}
 		}
+
 		$result->free_result();
 
 		// Finish it off!
@@ -157,6 +159,7 @@ class Dump extends AbstractDump
 		{
 			$tables[] = $row[0];
 		}
+
 		$request->free_result();
 
 		return $tables;
@@ -204,7 +207,7 @@ class Dump extends AbstractDump
 
 		if ($new_table)
 		{
-			$limit = strstr($tableName, 'log_') !== false ? 500 : 250;
+			$limit = strpos($tableName, 'log_') !== false ? 500 : 250;
 			$start = 0;
 		}
 
@@ -246,7 +249,7 @@ class Dump extends AbstractDump
 			// Get the fields in this row...
 			$field_list = array();
 
-			foreach ($row as $key => $item)
+			foreach ($row as $item)
 			{
 				// Try to figure out the type of each field. (NULL, number, or 'string'.)
 				if (!isset($item))
@@ -259,13 +262,14 @@ class Dump extends AbstractDump
 				}
 				else
 				{
-					$field_list[] = '\'' . $this->_db->escape_string($item) . '\'';
+					$field_list[] = "'" . $this->_db->escape_string($item) . "'";
 				}
 			}
 
 			// 'Insert' the data.
 			$data .= $insert_msg . '(' . implode(', ', $field_list) . ');' . $crlf;
 		}
+
 		$result->free_result();
 
 		$data .= $crlf;

--- a/sources/ElkArte/Database/Postgresql/Result.php
+++ b/sources/ElkArte/Database/Postgresql/Result.php
@@ -79,9 +79,8 @@ class Result extends AbstractResult
 			{
 				@pg_free_result($this->result);
 			}
-			catch ( \Throwable $e )
+			catch (\Throwable)
 			{
-				null;
 			}
 		}
 	}
@@ -94,7 +93,7 @@ class Result extends AbstractResult
 		// simply delegate to the native function
 		if (is_resource($this->result) || $this->result instanceof \PgSql\Result)
 		{
-			return (int) pg_num_rows($this->result);
+			return pg_num_rows($this->result);
 		}
 	}
 
@@ -104,7 +103,9 @@ class Result extends AbstractResult
 	public function num_fields()
 	{
 		if (is_resource($this->result) || $this->result instanceof \PgSql\Result)
+		{
 			return pg_num_fields($this->result);
+		}
 	}
 
 	/**
@@ -124,7 +125,9 @@ class Result extends AbstractResult
 	public function fetch_assoc()
 	{
 		if (is_resource($this->result) || $this->result instanceof \PgSql\Result)
+		{
 			return pg_fetch_assoc($this->result);
+		}
 	}
 
 	/**

--- a/sources/ElkArte/Database/Postgresql/Result.php
+++ b/sources/ElkArte/Database/Postgresql/Result.php
@@ -70,7 +70,6 @@ class Result extends AbstractResult
 	 */
 	public function free_result()
 	{
-
 		// Just delegate to the native function
 		if (is_resource($this->result) || $this->result instanceof \PgSql\Result)
 		{
@@ -81,6 +80,7 @@ class Result extends AbstractResult
 			}
 			catch (\Throwable)
 			{
+				// It may already have been closed, no action is needed.
 			}
 		}
 	}

--- a/sources/ElkArte/Database/Postgresql/Search.php
+++ b/sources/ElkArte/Database/Postgresql/Search.php
@@ -16,7 +16,7 @@ namespace ElkArte\Database\Postgresql;
 use ElkArte\Database\AbstractSearch;
 
 /**
- * PostgreSQL implementation of DbSearch
+ * PostgreSQLs implementation of DbSearch
  */
 class Search extends AbstractSearch
 {
@@ -77,8 +77,10 @@ class Search extends AbstractSearch
 
 		// PostGreSql has some hidden sizes.
 		$request = $this->_db->query('', '
-			SELECT relname, relpages * 8 *1024 AS "KB" FROM pg_class
-			WHERE relname = {string:messages} OR relname = {string:log_search_words}
+			SELECT 
+				relname, relpages * 8 *1024 AS "KB" FROM pg_class
+			WHERE relname = {string:messages} 
+				OR relname = {string:log_search_words}
 			ORDER BY relpages DESC',
 			array(
 				'messages' => $db_prefix . 'messages',
@@ -90,7 +92,7 @@ class Search extends AbstractSearch
 		{
 			while (($row = $request->fetch_assoc()))
 			{
-				if ($row['relname'] == $db_prefix . 'messages')
+				if ($row['relname'] === $db_prefix . 'messages')
 				{
 					$table_info['data_length'] = (int) $row['KB'];
 					$table_info['index_length'] = (int) $row['KB'];
@@ -98,12 +100,13 @@ class Search extends AbstractSearch
 					// Doesn't support fulltext
 					$table_info['fulltext_length'] = $txt['not_applicable'];
 				}
-				elseif ($row['relname'] == $db_prefix . 'log_search_words')
+				elseif ($row['relname'] === $db_prefix . 'log_search_words')
 				{
 					$table_info['index_length'] = (int) $row['KB'];
 					$table_info['custom_index_length'] = (int) $row['KB'];
 				}
 			}
+
 			$request->free_result();
 		}
 		else

--- a/sources/ElkArte/Database/QueryInterface.php
+++ b/sources/ElkArte/Database/QueryInterface.php
@@ -55,8 +55,7 @@ interface QueryInterface
 	 * @param string $db_string
 	 * @param array|false $db_values = array()
 	 *
-	 * @return bool|\ElkArte\Database\AbstractResult
-	 * @throws \ElkArte\Exceptions\Exception
+	 * @return bool|AbstractResult
 	 */
 	public function query($identifier, $db_string, $db_values = array());
 
@@ -65,8 +64,7 @@ interface QueryInterface
 	 *
 	 * @param string $db_string
 	 * @param array $db_values = array()
-	 * @param array|null
-	 * @return bool|\ElkArte\Database\AbstractResult
+	 * @return bool|AbstractResult
 	 */
 	public function fetchQuery($db_string, $db_values = array());
 

--- a/sources/ElkArte/Database/SearchInterface.php
+++ b/sources/ElkArte/Database/SearchInterface.php
@@ -25,7 +25,7 @@ interface SearchInterface
 	 * @param string $db_string
 	 * @param array $db_values
 	 *
-	 * @return \ElkArte\Database\AbstractResult|boolean
+	 * @return AbstractResult|boolean
 	 */
 	public function search_query($identifier, $db_string, $db_values = array());
 

--- a/sources/ElkArte/Errors/AttachmentErrorContext.php
+++ b/sources/ElkArte/Errors/AttachmentErrorContext.php
@@ -20,17 +20,17 @@ namespace ElkArte\Errors;
  */
 class AttachmentErrorContext
 {
-	/** @var null|object Holds our static instance of the class  */
-	private static $_context = null;
+	/** @var null|object Holds our static instance of the class */
+	private static $_context;
 
-	/** @var null|array Holds all attachment ids  */
-	private $_attachs = null;
+	/** @var null|array Holds all attachment ids */
+	private $_attachs;
 
 	/** @var null|ErrorContext Holds any errors found */
-	private $_generic_error = null;
+	private $_generic_error;
 
 	/** @var null|string Holds if the error is generic of specific to an attachment */
-	private $_active_attach = null;
+	private $_active_attach;
 
 	/**
 	 * Find and return Attachment_ErrorContext instance if it exists,
@@ -185,12 +185,9 @@ class AttachmentErrorContext
 	 */
 	public function hasError($error_code, $attachID = null)
 	{
-		if ($this->_generic_error !== null)
+		if ($this->_generic_error !== null && $this->_generic_error->hasError($error_code))
 		{
-			if ($this->_generic_error->hasError($error_code))
-			{
-				return true;
-			}
+			return true;
 		}
 
 		if (!empty($this->_attachs))
@@ -199,14 +196,12 @@ class AttachmentErrorContext
 			{
 				return isset($this->_attachs[$attachID]) && $this->_attachs[$attachID]['error']->hasError($error_code);
 			}
-			else
+
+			foreach ($this->_attachs as $attach)
 			{
-				foreach ($this->_attachs as $attach)
+				if ($attach['error']->hasError($error_code))
 				{
-					if ($attach['error']->hasError($error_code))
-					{
-						return true;
-					}
+					return true;
 				}
 			}
 		}

--- a/sources/ElkArte/Errors/ErrorContext.php
+++ b/sources/ElkArte/Errors/ErrorContext.php
@@ -21,44 +21,27 @@ use ElkArte\Languages\Txt;
 final class ErrorContext
 {
 	public const MINOR = 0;
+
 	public const SERIOUS = 1;
-	/**
-	 * Multiton. This is an array of instances of ErrorContext.
-	 * All callers use an error context ('post', 'attach', or 'default' if none chosen).
-	 *
-	 * @var array of ErrorContext
-	 */
-	private static $_contexts = null;
-	/**
-	 * Holds the unique identifier of the error (a name).
-	 *
-	 * @var string
-	 */
-	private $_name = null;
-	/**
-	 * An array that holds all the errors occurred separated by severity.
-	 *
-	 * @var array
-	 */
-	private $_errors = null;
-	/**
-	 * The default severity code.
-	 *
-	 * @var mixed
-	 */
-	private $_default_severity = 0;
-	/**
-	 * A list of all severity code from the less important to the most serious.
-	 *
-	 * @var array|mixed
-	 */
-	private $_severity_levels = array(0);
-	/**
-	 * Certain errors may need some specific language file...
-	 *
-	 * @var array
-	 */
-	private $_language_files = array();
+
+	/** @var array of ErrorContext Multiton. This is an array of instances of ErrorContext.
+	 * All callers use an error context ('post', 'attach', or 'default' if none chosen). */
+	private static $_contexts;
+
+	/** @var string Holds the unique identifier of the error (a name). */
+	private $_name;
+
+	/** @var array An array that holds all the errors occurred separated by severity. */
+	private $_errors;
+
+	/** @var mixed The default severity code. */
+	private $_default_severity;
+
+	/** @var array|mixed A list of all severity code from the less important to the most serious. */
+	private $_severity_levels;
+
+	/** @var array Certain errors may need some specific language file... */
+	private $_language_files = [];
 
 	/**
 	 * Create and initialize an instance of the class
@@ -86,7 +69,7 @@ final class ErrorContext
 			$this->_default_severity = $default_severity;
 		}
 
-		$this->_errors = array();
+		$this->_errors = [];
 	}
 
 	/**
@@ -102,7 +85,7 @@ final class ErrorContext
 	{
 		if (self::$_contexts === null)
 		{
-			self::$_contexts = array();
+			self::$_contexts = [];
 		}
 
 		if (!array_key_exists($id, self::$_contexts))
@@ -130,10 +113,17 @@ final class ErrorContext
 			$this->_errors[$severity][$name] = $error;
 		}
 
-		if (!empty($lang_file) && !isset($this->_language_files[$lang_file]))
+		if (empty($lang_file))
 		{
-			$this->_language_files[$lang_file] = false;
+			return;
 		}
+
+		if (isset($this->_language_files[$lang_file]))
+		{
+			return;
+		}
+
+		$this->_language_files[$lang_file] = false;
 	}
 
 	/**
@@ -153,19 +143,16 @@ final class ErrorContext
 			{
 				return $this->getErrorName($first_error[0]);
 			}
-			else
-			{
-				return $first_error[0];
-			}
+
+			return $first_error[0];
 		}
-		elseif (is_object($error))
+
+		if (is_object($error))
 		{
 			return $error->getName();
 		}
-		else
-		{
-			return $error;
-		}
+
+		return $error;
 	}
 
 	/**
@@ -185,6 +172,7 @@ final class ErrorContext
 				{
 					unset($this->_errors[$severity][$name]);
 				}
+
 				if (empty($this->_errors[$severity]))
 				{
 					unset($this->_errors[$severity]);
@@ -208,14 +196,13 @@ final class ErrorContext
 		{
 			return $this->_errors[$severity];
 		}
-		elseif ($severity === null && !empty($this->_errors))
+
+		if ($severity === null && !empty($this->_errors))
 		{
 			return $this->_errors;
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**
@@ -245,14 +232,13 @@ final class ErrorContext
 		{
 			return !empty($this->_errors[$severity]);
 		}
-		elseif ($severity === null)
+
+		if ($severity === null)
 		{
 			return !empty($this->_errors);
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**
@@ -324,8 +310,8 @@ final class ErrorContext
 
 		call_integration_hook('integrate_' . $this->_name . '_errors', array(&$this->_errors, &$this->_severity_levels));
 
-		$errors = array();
-		$returns = array();
+		$errors = [];
+		$returns = [];
 		if ($severity === null)
 		{
 			foreach ($this->_errors as $err)
@@ -348,6 +334,7 @@ final class ErrorContext
 				{
 					continue;
 				}
+
 				$returns[$name] = vsprintf($txt['error_' . $name] ?? ($txt[$name] ?? $name), $value);
 			}
 			elseif (is_object($error_val))
@@ -372,17 +359,14 @@ final class ErrorContext
 		Txt::load('Errors');
 
 		// Any custom one?
-		if (!empty($this->_language_files))
+		foreach ($this->_language_files as $language => $loaded)
 		{
-			foreach ($this->_language_files as $language => $loaded)
+			if (!$loaded)
 			{
-				if (!$loaded)
-				{
-					Txt::load($language);
+				Txt::load($language);
 
-					// Remember this file has been loaded already
-					$this->_language_files[$language] = true;
-				}
+				// Remember this file has been loaded already
+				$this->_language_files[$language] = true;
 			}
 		}
 	}
@@ -404,14 +388,10 @@ final class ErrorContext
 			{
 				return null;
 			}
-			else
-			{
-				return $first_error[1];
-			}
+
+			return $first_error[1];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 }

--- a/sources/ElkArte/Exceptions/ControllerRedirectException.php
+++ b/sources/ElkArte/Exceptions/ControllerRedirectException.php
@@ -24,21 +24,16 @@ use ElkArte\User;
  */
 class ControllerRedirectException extends \Exception
 {
-	protected $_controller;
-	protected $_method;
-
 	/**
 	 * Redefine the initialization.
 	 * Do note that parent::__construct() is not called.
 	 *
-	 * @param string $controller Is the name of controller (lowercase and with namespace,
+	 * @param string $_controller Is the name of controller (lowercase and with namespace,
 	 *                 for example 'post', or 'calendar') that should be instantiated
-	 * @param string $method The method to call.
+	 * @param string $_method The method to call.
 	 */
-	public function __construct($controller, $method)
+	public function __construct(protected $_controller, protected $_method)
 	{
-		$this->_controller = $controller;
-		$this->_method = $method;
 	}
 
 	/**
@@ -50,7 +45,7 @@ class ControllerRedirectException extends \Exception
 	 */
 	public function doRedirect($source)
 	{
-		if (ltrim(get_class($source), '\\') === ltrim($this->_controller, '\\'))
+		if (ltrim($source::class, '\\') === ltrim($this->_controller, '\\'))
 		{
 			return $source->{$this->_method}();
 		}

--- a/sources/ElkArte/Exceptions/PmErrorException.php
+++ b/sources/ElkArte/Exceptions/PmErrorException.php
@@ -13,6 +13,8 @@
 
 namespace ElkArte\Exceptions;
 
+use ElkArte\ValuesContainer;
+
 /**
  * Class PmErrorException
  *
@@ -21,33 +23,15 @@ namespace ElkArte\Exceptions;
 class PmErrorException extends \Exception
 {
 	/**
-	 * @var int[]
-	 */
-	public $recipientList;
-
-	/**
-	 * @var array|string[]
-	 */
-	public $namedRecipientList;
-
-	/**
-	 * @var \ElkArte\ValuesContainer
-	 */
-	public $msgOptions;
-
-	/**
 	 * Redefine the initialization.
-	 * Do note that parent::__construct() is not called.
+	 * Do note that parent::__construct() is NOT called.
 	 *
 	 * @param array $recipientList Array of members ID separated into 'to' and 'bcc'
-	 * @param \ElkArte\ValuesContainer $msgOptions Some values for common
+	 * @param ValuesContainer $msgOptions Some values for common
 	 * @param string[] $namedRecipientList Array of member names separated into 'to' and 'bcc'
 	 *  this argument is deprecated
 	 */
-	public function __construct($recipientList, $msgOptions, $namedRecipientList = array())
+	public function __construct(public $recipientList, public $msgOptions, public $namedRecipientList = [])
 	{
-		$this->recipientList = $recipientList;
-		$this->msgOptions = $msgOptions;
-		$this->namedRecipientList = $namedRecipientList;
 	}
 }

--- a/sources/ElkArte/Graphics/ImageUploadResize.php
+++ b/sources/ElkArte/Graphics/ImageUploadResize.php
@@ -21,7 +21,7 @@ class ImageUploadResize
 	/** @var int[] Holds the WxH bounds an image must be within */
 	protected $_bounds;
 
-	/** @var \ElkArte\Graphics\Image The image we are working with */
+	/** @var Image The image we are working with */
 	protected $image;
 
 	/** @var string the full path name to the image */
@@ -171,7 +171,7 @@ class ImageUploadResize
 		}
 
 		// A WebP image will generally be smaller than Jpeg or Png
-		if ($this->getWebP() && ($this->_sizeCurrent[2] === IMAGETYPE_JPEG || $this->_sizeCurrent[2] === IMAGETYPE_PNG))
+		if (($this->_sizeCurrent[2] === IMAGETYPE_JPEG || $this->_sizeCurrent[2] === IMAGETYPE_PNG) && $this->getWebP())
 		{
 			return true;
 		}
@@ -183,13 +183,8 @@ class ImageUploadResize
 		}
 
 		// A transparent PNG, no WebP, If converted would be destructive, so just no
-		if ($this->_sizeCurrent[2] === IMAGETYPE_PNG && $this->image->getTransparency())
-		{
-			return false;
-		}
-
 		// Others like bmp or gif maybe even tiff
-		return true;
+		return !($this->_sizeCurrent[2] === IMAGETYPE_PNG && $this->image->getTransparency());
 	}
 
 	/**

--- a/sources/ElkArte/Graphics/Manipulators/AbstractManipulator.php
+++ b/sources/ElkArte/Graphics/Manipulators/AbstractManipulator.php
@@ -37,7 +37,7 @@ abstract class AbstractManipulator
 	/** @var int the height of the image, updated after any manipulation */
 	protected $_height = 0;
 
-	/** @var \Imagick|resource */
+	/** @var ImageMagick|resource */
 	protected $_image;
 
 	/**
@@ -121,7 +121,7 @@ abstract class AbstractManipulator
 		{
 			$this->imageDimensions = $type === 'string' ? getimagesizefromstring($data) : getimagesize($this->_fileName);
 		}
-		catch (\Exception $e)
+		catch (\Exception)
 		{
 			$this->imageDimensions = [];
 		}
@@ -167,7 +167,7 @@ abstract class AbstractManipulator
 	 *
 	 * @param bool $fatal if to throw an exception on lack of memory
 	 *
-	 * @return bool Whether or not the memory is available.
+	 * @return bool Whether the memory is available.
 	 * @throws \Exception
 	 */
 	public function memoryCheck($fatal = false)
@@ -236,7 +236,7 @@ abstract class AbstractManipulator
 
 		if ($this->_width > $this->_height)
 		{
-			$thumb_h = max (1, $this->_height * ($limit / $this->_width));
+			$thumb_h = max(1, $this->_height * ($limit / $this->_width));
 		}
 		// Portrait
 		elseif ($this->_width < $this->_height)

--- a/sources/ElkArte/Graphics/Manipulators/ImageMagick.php
+++ b/sources/ElkArte/Graphics/Manipulators/ImageMagick.php
@@ -2,7 +2,7 @@
 
 /**
  * This file deals with low-level graphics operations performed on images,
- * specially as needed for the Imagick library
+ * specially as needed for the ImageMagick library
  *
  * @package   ElkArte Forum
  * @copyright ElkArte Forum contributors
@@ -14,23 +14,27 @@
 
 namespace ElkArte\Graphics\Manipulators;
 
-use \ElkArte\Graphics\Image;
+use ElkArte\Graphics\Image;
+use Exception;
+use Imagick;
+use ImagickException;
+use ImagickPixel;
 
 /**
- * Class Imagick
+ * Class ImageMagick
  *
- * This class will load and save an animated gif, however any manipulation will remove said animation.  It currently
- * only provides validation/inspection functions (should you want to keep the animation intact).
+ * Note: This class will load and save an animated gif, however any manipulation will remove said animation.
+ * It currently only provides validation/inspection functions (should you want to keep the animation intact).
  *
  * @package ElkArte\Graphics
  */
-class Imagick extends AbstractManipulator
+class ImageMagick extends AbstractManipulator
 {
-	/** @var \Imagick */
+	/** @var Imagick */
 	protected $_image;
 
 	/**
-	 * Imagick constructor.
+	 * ImageMagick constructor.
 	 *
 	 * @param string $image
 	 */
@@ -42,20 +46,20 @@ class Imagick extends AbstractManipulator
 		{
 			$this->memoryCheck();
 		}
-		catch (\Exception $e)
+		catch (Exception)
 		{
 			// Just pass through
 		}
 	}
 
 	/**
-	 * Checks whether the Imagick class is present.
+	 * Checks whether the ImageMagick class is present.
 	 *
-	 * @return bool Whether or not the Imagick extension is available.
+	 * @return bool Whether the ImageMagick extension is available.
 	 */
 	public static function canUse()
 	{
-		return class_exists('\Imagick', false);
+		return class_exists(Imagick::class, false);
 	}
 
 	/**
@@ -76,9 +80,9 @@ class Imagick extends AbstractManipulator
 		{
 			try
 			{
-				$this->_image = new \Imagick($this->_fileName);
+				$this->_image = new Imagick($this->_fileName);
 			}
-			catch (\Exception $e)
+			catch (Exception)
 			{
 				return false;
 			}
@@ -106,10 +110,10 @@ class Imagick extends AbstractManipulator
 			$this->_width = $this->imageDimensions[0] = $this->_image->getImageWidth();
 			$this->_height = $this->imageDimensions[1] = $this->_image->getImageHeight();
 		}
-		catch (\ImagickException $e)
+		catch (ImagickException)
 		{
-			$this->_width = $this->imageDimensions[0] = $this->imageDimensions[0] ?? 0;
-			$this->_height = $this->imageDimensions[1] = $this->imageDimensions[1] ?? 0;
+			$this->_width = $this->imageDimensions[0] ??= 0;
+			$this->_height = $this->imageDimensions[1] ??= 0;
 		}
 	}
 
@@ -132,10 +136,10 @@ class Imagick extends AbstractManipulator
 		{
 			try
 			{
-				$this->_image = new \Imagick();
+				$this->_image = new Imagick();
 				$this->_image->readImageBlob($image_data);
 			}
-			catch (\ImagickException $e)
+			catch (ImagickException)
 			{
 				return false;
 			}
@@ -180,11 +184,11 @@ class Imagick extends AbstractManipulator
 		$src_height = $this->_height;
 
 		// Allow for a re-encode to the same size
-		$max_width = $max_width ?? $src_width;
-		$max_height = $max_height ?? $src_height;
+		$max_width ??= $src_width;
+		$max_height ??= $src_height;
 
 		// Determine whether to resize to max width or to max height (depending on the limits.)
-		list($dst_width, $dst_height) = $this->imageRatio($max_width, $max_height);
+		[$dst_width, $dst_height] = $this->imageRatio($max_width, $max_height);
 
 		// Don't bother resizing if it's already smaller...
 		if (!empty($dst_width) && !empty($dst_height) && ($dst_width < $src_width || $dst_height < $src_height || $force_resize))
@@ -197,10 +201,10 @@ class Imagick extends AbstractManipulator
 				}
 				else
 				{
-					$success = $this->_image->resizeImage($dst_width, $dst_height, \imagick::FILTER_LANCZOS, .9891, true);
+					$success = $this->_image->resizeImage($dst_width, $dst_height, Imagick::FILTER_LANCZOS, .9891, true);
 				}
 			}
-			catch (\ImagickException $e)
+			catch (ImagickException)
 			{
 				return false;
 			}
@@ -215,7 +219,7 @@ class Imagick extends AbstractManipulator
 			{
 				$success = $this->_image->stripImage() && $success;
 			}
-			catch (\ImagickException $e)
+			catch (ImagickException)
 			{
 				return $success;
 			}
@@ -265,7 +269,7 @@ class Imagick extends AbstractManipulator
 				break;
 			default:
 				$this->_image->borderImage('white', 0, 0);
-				$this->_image->setImageCompression(\imagick::COMPRESSION_JPEG);
+				$this->_image->setImageCompression(Imagick::COMPRESSION_JPEG);
 				$this->_image->setImageCompressionQuality($quality);
 				$success = $this->_image->setImageFormat('jpeg');
 				break;
@@ -280,21 +284,18 @@ class Imagick extends AbstractManipulator
 				{
 					echo $this->_image->getImagesBlob();
 				}
+				elseif ($preferred_format === IMAGETYPE_GIF && $this->_image->getNumberImages() !== 0)
+				{
+					// Write all animated gif frames
+					$success = $this->_image->writeImages($file_name, true);
+				}
 				else
 				{
-					if ($preferred_format === IMAGETYPE_GIF && $this->_image->getNumberImages() !== 0)
-					{
-						// Write all animated gif frames
-						$success = $this->_image->writeImages($file_name, true);
-					}
-					else
-					{
-						$success = $this->_image->writeImage($file_name);
-					}
+					$success = $this->_image->writeImage($file_name);
 				}
 			}
 		}
-		catch (\Exception $e)
+		catch (Exception)
 		{
 			return false;
 		}
@@ -327,52 +328,52 @@ class Imagick extends AbstractManipulator
 			switch ($this->orientation)
 			{
 				// 0 & 1 Not set or Normal
-				case \imagick::ORIENTATION_UNDEFINED:
-				case \imagick::ORIENTATION_TOPLEFT:
+				case Imagick::ORIENTATION_UNDEFINED:
+				case Imagick::ORIENTATION_TOPLEFT:
 					break;
 				// 2 Mirror image, Normal orientation
-				case \imagick::ORIENTATION_TOPRIGHT:
+				case Imagick::ORIENTATION_TOPRIGHT:
 					$this->_image->flopImage();
 					break;
 				// 3 Normal image, rotated 180
-				case \imagick::ORIENTATION_BOTTOMRIGHT:
-					$this->_image->rotateImage(new \ImagickPixel('#00000000'), 180);
+				case Imagick::ORIENTATION_BOTTOMRIGHT:
+					$this->_image->rotateImage(new ImagickPixel('#00000000'), 180);
 					break;
 				// 4 Mirror image, rotated 180
-				case \imagick::ORIENTATION_BOTTOMLEFT:
+				case Imagick::ORIENTATION_BOTTOMLEFT:
 					$this->_image->flipImage();
 					break;
 				// 5 Mirror image, rotated 90 CCW
-				case \imagick::ORIENTATION_LEFTTOP:
-					$this->_image->rotateImage(new \ImagickPixel('#00000000'), 90);
+				case Imagick::ORIENTATION_LEFTTOP:
+					$this->_image->rotateImage(new ImagickPixel('#00000000'), 90);
 					$this->_image->flopImage();
 					break;
 				// 6 Normal image, rotated 90 CCW
-				case \imagick::ORIENTATION_RIGHTTOP:
-					$this->_image->rotateImage(new \ImagickPixel('#00000000'), 90);
+				case Imagick::ORIENTATION_RIGHTTOP:
+					$this->_image->rotateImage(new ImagickPixel('#00000000'), 90);
 					break;
 				// 7 Mirror image, rotated 90 CW
-				case \imagick::ORIENTATION_RIGHTBOTTOM:
-					$this->_image->rotateImage(new \ImagickPixel('#00000000'), -90);
+				case Imagick::ORIENTATION_RIGHTBOTTOM:
+					$this->_image->rotateImage(new ImagickPixel('#00000000'), -90);
 					$this->_image->flopImage();
 					break;
 				// 8 Normal image, rotated 90 CW
-				case \imagick::ORIENTATION_LEFTBOTTOM:
-					$this->_image->rotateImage(new \ImagickPixel('#00000000'), -90);
+				case Imagick::ORIENTATION_LEFTBOTTOM:
+					$this->_image->rotateImage(new ImagickPixel('#00000000'), -90);
 					break;
 			}
 
 			// Now that it's auto-rotated, make sure the EXIF data is correctly updated
 			if ($this->orientation >= 2)
 			{
-				$this->_image->setImageOrientation(\imagick::ORIENTATION_TOPLEFT);
+				$this->_image->setImageOrientation(Imagick::ORIENTATION_TOPLEFT);
 				$this->orientation = 1;
 				$this->_setImage();
 			}
 
 			$success = true;
 		}
-		catch (\Exception $e)
+		catch (Exception)
 		{
 			$success = false;
 		}
@@ -391,7 +392,7 @@ class Imagick extends AbstractManipulator
 		{
 			$this->orientation = $this->_image->getImageOrientation();
 		}
-		catch (\ImagickException $e)
+		catch (ImagickException)
 		{
 			$this->orientation = 0;
 		}
@@ -424,7 +425,7 @@ class Imagick extends AbstractManipulator
 				$checkImage->scaleImage($scaleValue[0], $scaleValue[1], true);
 			}
 		}
-		catch (\ImagickException $e)
+		catch (ImagickException)
 		{
 			$checkImage->destroy();
 
@@ -451,7 +452,7 @@ class Imagick extends AbstractManipulator
 	 * - Resizes images > 1024x1024 to reduce pixel count
 	 * - Used as a backup function should checkOpacityChannel() fail
 	 *
-	 * @param \Imagick $checkImage
+	 * @param Imagick $checkImage
 	 * @return bool
 	 */
 	public function checkOpacityPixelInspection($checkImage)
@@ -478,7 +479,7 @@ class Imagick extends AbstractManipulator
 				}
 			}
 		}
-		catch (\ImagickException $e)
+		catch (ImagickException)
 		{
 			// We don't know what it is, so don't mess with it
 			return true;
@@ -493,7 +494,7 @@ class Imagick extends AbstractManipulator
 	 * - An opaque image will have 0 standard deviation and a mean of 1 (65535)
 	 * - If failure returns null, otherwise bool
 	 *
-	 * @param \Imagick $checkImage
+	 * @param Imagick $checkImage
 	 * @return bool|null
 	 */
 	public function checkOpacityChannel($checkImage)
@@ -503,7 +504,7 @@ class Imagick extends AbstractManipulator
 		try
 		{
 			$transparent = true;
-			$stats = $checkImage->getImageChannelMean(\imagick::CHANNEL_OPACITY);
+			$stats = $checkImage->getImageChannelMean(Imagick::CHANNEL_OPACITY);
 
 			// If mean = 65535 and std = 0, then its perfectly opaque.
 			$mean = (int) $stats['mean'];
@@ -512,7 +513,7 @@ class Imagick extends AbstractManipulator
 				$transparent = false;
 			}
 		}
-		catch (\ImagickException $e)
+		catch (ImagickException)
 		{
 			$transparent = null;
 		}
@@ -537,18 +538,18 @@ class Imagick extends AbstractManipulator
 
 		try
 		{
-			$this->_image = new \Imagick();
-			$this->_image->newImage($width, $height, new \ImagickPixel('white'));
+			$this->_image = new Imagick();
+			$this->_image->newImage($width, $height, new ImagickPixel('white'));
 			$this->_image->setImageFormat($format);
 
 			// 28pt is ~2em given default font stack
 			$font_size = 28;
 
 			$draw = new \ImagickDraw();
-			$draw->setStrokeColor(new \ImagickPixel("rgba(100%, 100%, 100%, 0)"));
-			$draw->setFillColor(new \ImagickPixel('#A9A9A9'));
+			$draw->setStrokeColor(new ImagickPixel("rgba(100%, 100%, 100%, 0)"));
+			$draw->setFillColor(new ImagickPixel('#A9A9A9'));
 			$draw->setStrokeWidth(1);
-			$draw->setTextAlignment(\imagick::ALIGN_CENTER);
+			$draw->setTextAlignment(Imagick::ALIGN_CENTER);
 			$draw->setFont($settings['default_theme_dir'] . '/fonts/OpenSans.ttf');
 
 			// Make sure the text will fit the allowed space
@@ -566,7 +567,7 @@ class Imagick extends AbstractManipulator
 
 			return $image;
 		}
-		catch (\Exception $e)
+		catch (Exception)
 		{
 			return false;
 		}
@@ -579,9 +580,9 @@ class Imagick extends AbstractManipulator
 	 */
 	public function hasWebpSupport()
 	{
-		$check = \Imagick::queryformats();
+		$check = Imagick::queryformats();
 
-		return in_array('WEBP', $check);
+		return in_array('WEBP', $check, true);
 	}
 
 	/**
@@ -589,9 +590,16 @@ class Imagick extends AbstractManipulator
 	 */
 	public function __destruct()
 	{
-		if (gettype($this->_image) === 'object' && get_class($this->_image) === 'Imagick')
+		if (!is_object($this->_image))
 		{
-			$this->_image->clear();
+			return;
 		}
+
+		if (!$this->_image instanceof Imagick)
+		{
+			return;
+		}
+
+		$this->_image->clear();
 	}
 }

--- a/sources/ElkArte/Graphics/TextImage.php
+++ b/sources/ElkArte/Graphics/TextImage.php
@@ -25,18 +25,14 @@ namespace ElkArte\Graphics;
  */
 class TextImage extends Image
 {
-	/** @var string text to be shown in the image */
-	protected $_text = '';
-
 	/**
 	 * Image constructor.
 	 *
-	 * @param string $text
+	 * @param string $_text
 	 * @param bool $force_gd
 	 */
-	public function __construct($text, $force_gd = false)
+	public function __construct(protected $_text, $force_gd = false)
 	{
-		$this->_text = $text;
 		$this->_force_gd = $force_gd;
 
 		// Determine and set what image library we will use
@@ -44,7 +40,7 @@ class TextImage extends Image
 		{
 			$this->setManipulator();
 		}
-		catch (\Exception $e)
+		catch (\Exception)
 		{
 			// Nothing to do
 		}
@@ -78,18 +74,18 @@ class TextImage extends Image
 
 	/**
 	 * Simple function to generate an image containing some text.
-	 * It uses preferentially Imagick if present, otherwise GD.
+	 * It uses preferentially ImageMagick if present, otherwise GD.
 	 * Font and size are fixed.
 	 *
 	 * @param int $width Width of the final image
 	 * @param int $height Height of the image
 	 * @param string $format Type of the image (valid types are png, jpeg, gif)
 	 *
-	 * @return bool|string The image or false if neither Imagick nor GD are found
+	 * @return bool|string The image or false if neither ImageMagick nor GD are found
 	 */
 	public function generate($width = 100, $height = 75, $format = 'png')
 	{
-		$valid_formats = array('jpeg', 'png', 'gif');
+		$valid_formats = ['jpeg', 'png', 'gif'];
 		if (!in_array($format, $valid_formats))
 		{
 			$format = 'png';

--- a/sources/ElkArte/ScheduledTasks/Tasks/MaillistFetchIMAP.php
+++ b/sources/ElkArte/ScheduledTasks/Tasks/MaillistFetchIMAP.php
@@ -23,7 +23,7 @@ namespace ElkArte\ScheduledTasks\Tasks;
 class MaillistFetchIMAP implements ScheduledTaskInterface
 {
 	/**
-	 * Run the the pseudo cron for IMAP email collection
+	 * Run the pseudo cron for IMAP email collection
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
Continuation of going through the controllers to "freshen" the php level in a few areas.

    use static on closures that don't need $this
    arrow functions fn() => for some one line closures
    replace those \ElkArte\AdminController\XYZ calls with an import and XYZ::class
    some hardening
    useless else removal
    early returns
    remove list()
    cast ints in some of the queries
    positive logic in some if
