### PR TITLE
Chunk upload

### DIFF
--- a/sources/ElkArte/AdminController/ManageFeatures.php
+++ b/sources/ElkArte/AdminController/ManageFeatures.php
@@ -205,9 +205,7 @@ class ManageFeatures extends AbstractController
 		{
 			$clean_hives_result = theme()->cleanHives();
 
-			theme()->getLayers()->removeAll();
-			theme()->getTemplates()->load('Json');
-			$context['sub_template'] = 'send_json';
+			setJsonTemplate();
 			$context['json_data'] = array(
 				'success' => $clean_hives_result,
 				'response' => $clean_hives_result ? $txt['clean_hives_sucess'] : $txt['clean_hives_failed']
@@ -643,7 +641,10 @@ class ManageFeatures extends AbstractController
 		Txt::load('Profile+UserNotifications');
 		loadJavascriptFile('ext/jquery.multiselect.min.js');
 		theme()->addInlineJavascript('
-		$(\'.select_multiple\').multiselect({\'language_strings\': {\'Select all\': ' . JavascriptEscape($txt['notify_select_all']) . '}});', true);
+			$(\'.select_multiple\').multiselect({\'language_strings\': {\'Select all\': ' . JavascriptEscape($txt['notify_select_all']) . '}});
+			document.addEventListener("DOMContentLoaded", function() {
+                 prepareNotificationOptions();
+			});', true);
 		loadCSSFile('multiselect.css');
 
 		// The mentions settings

--- a/sources/ElkArte/AdminController/ManagePosts.php
+++ b/sources/ElkArte/AdminController/ManagePosts.php
@@ -201,12 +201,9 @@ class ManagePosts extends AbstractController
 		if (isset($this->_req->post->censortest) && $this->getApi() === 'json')
 		{
 			// Clear the templates
-			$template_layers = theme()->getLayers();
-			$template_layers->removeAll();
+			setJsonTemplate();
 
 			// Send back a response
-			theme()->getTemplates()->load('Json');
-			$context['sub_template'] = 'send_json';
 			$context['json_data'] = array(
 				'result' => true,
 				'censor' => $pre_censor . ' <i class="icon i-chevron-circle-right"></i> ' . $context['censor_test'],

--- a/sources/ElkArte/Attachments/TemporaryAttachment.php
+++ b/sources/ElkArte/Attachments/TemporaryAttachment.php
@@ -515,6 +515,8 @@ class TemporaryAttachment extends ValuesContainer
 	 */
 	public function autoRotate()
 	{
+		global $modSettings;
+
 		// Want to correct for phone rotated photos, hell yeah ya do!
 		if (!empty($modSettings['attachment_autorotate'])
 			&& $this->hasErrors() === false && substr($this->data['type'], 0, 5) === 'image')

--- a/sources/ElkArte/Attachments/TemporaryAttachmentChunk.php
+++ b/sources/ElkArte/Attachments/TemporaryAttachmentChunk.php
@@ -1,0 +1,505 @@
+<?php
+
+/**
+ * Handles the job of attachment chunked upload management.
+ *
+ * @package   ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ *
+ * @version 2.0 dev
+ *
+ */
+
+namespace ElkArte\Attachments;
+
+use ElkArte\Helper\FileFunctions;
+use ElkArte\Helper\HttpReq;
+use ElkArte\Helper\TokenHash;
+
+/**
+ * Class TemporaryAttachmentChunk
+ *
+ * Handles the job of attachment chunked upload management.
+ */
+class TemporaryAttachmentChunk
+{
+	/** @var HttpReq */
+	public $req;
+
+	/** @var AttachmentsDirectory */
+	public $attachmentDirectory;
+
+	/** @var string Active attachment directory */
+	public $attach_current_dir;
+
+	/** @var int Maximum chunk size allowed */
+	public $chunkSize;
+
+	/** @var string the combined file temporary path and name */
+	private $combinedFilePath;
+
+	/**
+	 * Class constructor.
+	 *
+	 * Initializes the object and sets the necessary properties.
+	 */
+	public function __construct()
+	{
+		global $modSettings;
+
+		$this->req = HttpReq::instance();
+		$this->attachmentDirectory = new AttachmentsDirectory($modSettings, database());
+
+		$this->attachmentDirectory->automanageCheckDirectory();
+
+		$this->attach_current_dir = $this->attachmentDirectory->getCurrent();
+
+		$this->chunkSize = empty($modSettings['attachmentChunkSize']) ? 250000 : $modSettings['attachmentChunkSize'];
+
+		require_once(SUBSDIR . '/Attachments.subs.php');
+	}
+
+	/**
+	 * Handle asynchronous file upload by saving all fragments submitted
+	 *
+	 * @return array
+	 */
+	public function action_async()
+	{
+		if (checkSession('post', '', false) !== '')
+		{
+			return ['result' => false, 'data' => 'session_timeout'];
+		}
+
+		$result = $this->saveAsyncFile();
+
+		return $this->returnResults($result);
+	}
+
+	/**
+	 * Saves an asynchronously uploaded file.
+	 *
+	 * @return array An array containing the ID of the uploaded file and an error code.
+	 */
+	public function saveAsyncFile()
+	{
+		[$uuid, $chunkIndex, $totalChunkCount] = $this->extractPostData();
+		$postValidationError = $this->validatePostData($uuid, $chunkIndex, $totalChunkCount);
+		if ($postValidationError !== true)
+		{
+			return $this->errorAsyncFile($postValidationError, $uuid);
+		}
+
+		$validationError = $this->validateReceivedFile();
+		if ($validationError !== true)
+		{
+			return $this->errorAsyncFile($validationError, $uuid);
+		}
+
+		$local_file = $this->generateLocalFileName($uuid, $totalChunkCount, $chunkIndex);
+		$chunkWritingError = $this->writeChunkToFile($local_file);
+		if ($chunkWritingError !== true)
+		{
+			return $this->errorAsyncFile($chunkWritingError, $uuid);
+		}
+
+		return ['id' => $uuid, 'code' => ''];
+	}
+
+	/**
+	 * Extracts post data from the request
+	 *
+	 * @return array[int, int, int] An array containing the UUID, chunk index, and total chunk count
+	 */
+	private function extractPostData()
+	{
+		$chunkIndex = $this->req->getPost('elkchunkindex', 'intval');
+		$totalChunkCount = $this->req->getPost('elktotalchunkcount', 'intval');
+		$uuid = $this->req->getPost('elkuuid', 'intval');
+
+		if (!isset($chunkIndex, $totalChunkCount))
+		{
+			$chunkIndex = 0;
+			$totalChunkCount = 0;
+		}
+
+		return [$uuid, $chunkIndex, $totalChunkCount];
+	}
+
+	/**
+	 * Validates the post data is complete and within the known bounds.
+	 *
+	 * @param string $uuid The UUID of the data.
+	 * @param int $chunkIndex The index of the current chunk.
+	 * @param int $totalChunkCount The total number of chunks.
+	 *
+	 * @return string Returns 'invalid_chunk' if the chunk index is invalid or 'invalid_uuid' if the UUID is not set.
+	 * If the chunk and UUID are valid, it delegates the validation to the validateInitialChunk method and returns its result.
+	 */
+	private function validatePostData($uuid, $chunkIndex, $totalChunkCount)
+	{
+		if ($chunkIndex < 0 || $totalChunkCount < 1 || $chunkIndex >= $totalChunkCount)
+		{
+			return 'invalid_chunk';
+		}
+
+		if (!isset($uuid))
+		{
+			return 'invalid_uuid';
+		}
+
+		return $this->validateInitialChunk($totalChunkCount, $chunkIndex);
+	}
+
+	/**
+	 * Validates
+	 * - the total number of chunks will fit within the maximum post size
+	 * - that the output directory is writable
+	 * - only does this on the first chuck
+	 *
+	 * @param int $totalChunkCount The total number of chunks.
+	 * @param int $chunkIndex The index of the current chunk.
+	 *
+	 * @return string|bool Returns 'chunk_quota' if the chunk quota check fails, 'not_writable' if the attachment directory is not writable.
+	 * If the checks passed, it returns true.
+	 */
+	private function validateInitialChunk($totalChunkCount, $chunkIndex)
+	{
+		// Make sure this (when completed) file size will not exceed what we are willing to accept
+		if ($totalChunkCount === 1 || ($totalChunkCount > 1 && $chunkIndex === 0))
+		{
+			if ($this->checkTotalSize($totalChunkCount) !== true)
+			{
+				return 'chunk_quota';
+			}
+
+			if (!FileFunctions::instance()->isWritable($this->attach_current_dir))
+			{
+				return 'not_writable';
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Make sure total file size isn't going to be bigger than limit
+	 *
+	 * @param int $totalChunks
+	 * @param int $chunkSize
+	 * @return bool
+	 */
+	public function checkTotalSize($totalChunks, $chunkSize = 250000)
+	{
+		$expectedSize = $totalChunks * $chunkSize;
+
+		// What upload max sizes are defined
+		$post_max_size = ini_get('post_max_size');
+		$testPM = memoryReturnBytes($post_max_size);
+		$acpPM = isset($modSettings['attachmentPostLimit']) ? $modSettings['attachmentPostLimit'] * 1024 : 0;
+
+		// Limitless ?
+		if ($testPM === 0 && $acpPM === 0)
+		{
+			return true;
+		}
+
+		// Which is creating the limit?
+		$limit = $this->getSmallerNonZero($testPM, $acpPM);
+
+		return ($expectedSize <= $limit);
+	}
+
+	/**
+	 * Returns the smaller non-zero number between two given numbers.
+	 *
+	 * @param int|float $num1 The first number to compare.
+	 * @param int|float $num2 The second number to compare.
+	 *
+	 * @return int|float Returns the smaller non-zero number between $num1 and $num2.
+	 * If $num1 is equal to $num2 or if both numbers are zero, returns zero.
+	 */
+	public function getSmallerNonZero($num1, $num2)
+	{
+		if (empty($num1))
+		{
+			return $num2;
+		}
+
+		if (empty($num2))
+		{
+			return $num1;
+		}
+
+		if ($num1 < $num2)
+		{
+			return $num1;
+		}
+
+		return $num2;
+	}
+
+	/**
+	 * Retrieves the error message for the given code and cleans up any related async files.
+	 *
+	 * @param string|int $code The error code.
+	 * @param string $fileID The ID of the file. Default is an empty string.
+	 * @return array An associative array containing the error message, code, and file ID.
+	 */
+	public function errorAsyncFile($code, $fileID = '')
+	{
+		global $txt;
+
+		$error = $txt['attachment_' . $code] ?? $code;
+
+		// Clean up
+		$user_ident = $this->getUserIdentifier();
+		$in = $this->attach_current_dir . '/post_tmp_async_' . $user_ident . '_' . $fileID . '*.dat';
+		$iterator = new \GlobIterator($in, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_FILENAME);
+		foreach ($iterator as $file)
+		{
+			@unlink($file->getPathname());
+		}
+
+		return ['error' => $error, 'code' => $code, 'id' => $fileID];
+	}
+
+	/**
+	 * Retrieves the user identifier for the current user.
+	 *
+	 * @return string The user identifier.
+	 * @global array $user_info The user information array.
+	 *
+	 */
+	protected function getUserIdentifier()
+	{
+		global $user_info;
+
+		return empty($user_info['id']) ? preg_replace('~[^0-9a-z]~i', '', $_SESSION['session_value']) : $user_info['id'];
+	}
+
+	/**
+	 * Validates that a file was properly received. Validates it is of the correct chunk size.
+	 *
+	 * @return string|bool Returns a string indicating the error type,
+	 *                     or a boolean true if the file is valid.
+	 */
+	private function validateReceivedFile()
+	{
+		if (!$this->attachmentDirectory->hasFileTmpAttachments())
+		{
+			return 'no_files';
+		}
+
+		if ($_FILES['attachment']['size'][0] > $this->chunkSize)
+		{
+			return 'chunk_quota';
+		}
+
+		// If we have an initial PHP upload error, then we are baked
+		$errors = doPHPUploadChecks(0);
+		if (!empty($errors))
+		{
+			$this->tempAttachment->setErrors($errors);
+			$this->tempAttachment->remove(false);
+
+			return 'upload_error';
+		}
+
+		return true;
+	}
+
+	/**
+	 * Generate a local file name based on provided parameters.
+	 *
+	 * @param string $uuid The unique identifier.
+	 * @param int $totalChunkCount The total count of chunks.
+	 * @param int $chunkIndex The index of the current chunk.
+	 *
+	 * @return string The generated local file name.
+	 */
+	private function generateLocalFileName($uuid, $totalChunkCount, $chunkIndex): string
+	{
+		$salt = basename($_FILES['attachment']['tmp_name'][0]);
+		$user_ident = $this->getUserIdentifier();
+
+		return 'post_tmp_async_' . $user_ident . '_' . $uuid . ($totalChunkCount > 1 ? '_part_' . $chunkIndex : '') . '_' . $salt . '.dat';
+	}
+
+	/**
+	 * Write a chunk of a file to the specified location.
+	 *
+	 * @param string $local_file The local file name.
+	 *
+	 * @return bool|string Returns true if the chunk was written successfully, 'not_found' if the destination file was not found.
+	 */
+	private function writeChunkToFile($local_file)
+	{
+		$out = $this->attach_current_dir . '/' . $local_file;
+		$in = $_FILES['attachment']['tmp_name'][0];
+		@move_uploaded_file($in, $out);
+
+		if (!FileFunctions::instance()->fileExists($out))
+		{
+			return 'not_found';
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return the results of a process.
+	 *
+	 * @param array $result The result of the process.
+	 *
+	 * @return array The result array
+	 */
+	public function returnResults($result)
+	{
+		// Some error?
+		if (!empty($result['code']))
+		{
+			return [
+				'result' => false,
+				'error' => $result['error'],
+				'code' => $result['code'],
+				'fatal' => true,
+				'async' => $result['id']
+			];
+		}
+
+		return [
+			'result' => true,
+			'async' => $result['id']
+		];
+	}
+
+	/**
+	 * Combine the file chunks into a single file.
+	 *
+	 * @return array The path of the combined file.
+	 */
+	public function action_combineChunks()
+	{
+		[$uuid, , $totalChunkCount] = $this->extractPostData();
+		$user_ident = $this->getUserIdentifier();
+		$in = $this->getPathWithChunks($user_ident, $uuid);
+
+		// Check that all chunks do exist
+		if (!$this->verifyChunkExistence($in, $totalChunkCount))
+		{
+			$result = $this->errorAsyncFile('not_found', $uuid);
+			return $this->returnResults($result);
+		}
+
+		// Combine the fragments in the correct order
+		$success = $this->combineFileFragments($user_ident, $uuid, $in);
+
+		if ($success)
+		{
+			$this->build_fileArray();
+			$result = ['id' => $this->combinedFilePath, 'code' => ''];
+		}
+		else
+		{
+			$result = $this->errorAsyncFile('not_found', $uuid);
+		}
+
+		return $this->returnResults($result);
+	}
+
+	/**
+	 * Build the fileArray parameter for now combined file.
+	 *
+	 * This will then be used in action_ulattach as though it was uploaded as a single file,
+	 * and now be subject to all the same tests and manipulations.  This will also be done as strict=false
+	 * as we have already verified these were php uploaded files.
+	 *
+	 * @return void
+	 */
+	public function build_fileArray()
+	{
+		unset($_FILES['attachment']);
+
+		// What was sent should match what was claimed
+		$sizeOnDisk = FileFunctions::instance()->fileSize($this->combinedFilePath);
+		$sizeOnForm = $this->req->getPost('filesize', 'intval');
+		$error = ($sizeOnDisk !== $sizeOnForm) ? UPLOAD_ERR_PARTIAL : UPLOAD_ERR_OK;
+
+		$_FILES['attachment']['name'][] = $this->req->getPost('filename', 'trim');
+		$_FILES['attachment']['type'][] = $this->req->getPost('filetype', 'trim');
+		$_FILES['attachment']['size'][] = $this->req->getPost('filesize', 'intval');
+		$_FILES['attachment']['tmp_name'][] = $this->combinedFilePath;
+		$_FILES['attachment']['error'][] = $error;
+	}
+
+	/**
+	 * Generate the path to a file with chunks based on provided parameters.
+	 *
+	 * @param string $user_ident The user identifier.
+	 * @param string $uuid The unique identifier.
+	 *
+	 * @return string The generated path to the file with chunks.
+	 */
+	private function getPathWithChunks($user_ident, $uuid)
+	{
+		return $this->attach_current_dir . '/post_tmp_async_' . $user_ident . '_' . $uuid . '_part_*.dat';
+	}
+
+	/**
+	 * Get the combined file path and name based on the user identifier, UUID and some salt
+	 *
+	 * @param string $user_ident The user identifier.
+	 * @param string $uuid The unique identifier.
+	 *
+	 * @return string The combined file path.
+	 */
+	private function getCombinedFilePath(string $user_ident, string $uuid): string
+	{
+		$tokenizer = new TokenHash();
+
+		return $this->attach_current_dir . '/post_tmp_async_combined_' . $user_ident . '_' . $uuid . '_' . $tokenizer->generate_hash(8) . '.dat';
+	}
+
+	/**
+	 * Verify the existence of all chunks based on the provided file pattern and total chunk count.
+	 *
+	 * @param string $in The file pattern to search for chunks.
+	 * @param int $totalChunkCount The total count of chunks.
+	 *
+	 * @return bool True if all chunks exist, false otherwise.
+	 */
+	private function verifyChunkExistence($in, $totalChunkCount)
+	{
+		$iterator = new \GlobIterator($in, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_FILENAME);
+
+		return $iterator->count() && $iterator->count() === $totalChunkCount;
+	}
+
+	/**
+	 * Combine file fragments into a single file.
+	 *
+	 * @param string $user_ident The user identifier.
+	 * @param string $uuid The unique identifier.
+	 * @param string $in The input directory containing file fragments.
+	 *
+	 * @return bool Returns true if the file fragments were successfully combined into a single file, false otherwise.
+	 */
+	private function combineFileFragments($user_ident, $uuid, $in)
+	{
+		$files = iterator_to_array(new \GlobIterator($in, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_FILENAME));
+		ksort($files);
+		$this->combinedFilePath = $this->getCombinedFilePath($user_ident, $uuid);
+		$success = true;
+
+		foreach ($files as $file)
+		{
+			$fileInputPath = $this->attach_current_dir . '/' . $file->getFilename();
+			$success &= file_put_contents($this->combinedFilePath, file_get_contents($fileInputPath), LOCK_EX | FILE_APPEND) !== false;
+			@unlink($fileInputPath);
+		}
+
+		return $success;
+	}
+}

--- a/sources/ElkArte/Attachments/TemporaryAttachmentProcess.php
+++ b/sources/ElkArte/Attachments/TemporaryAttachmentProcess.php
@@ -1,0 +1,432 @@
+<?php
+
+/**
+ *
+ * @package   ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ *
+ * @version 2.0 dev
+ *
+ */
+
+namespace ElkArte\Attachments;
+
+use ElkArte\Errors\AttachmentErrorContext;
+use ElkArte\Errors\Errors;
+use ElkArte\Helper\FileFunctions;
+use ElkArte\Helper\TokenHash;
+use ElkArte\User;
+use ElkArte\Helper\HttpReq;
+
+/**
+ * Handle the actual saving of attachments to the active attachment directory.
+ */
+class TemporaryAttachmentProcess
+{
+	/** @var AttachmentErrorContext */
+	public $attach_errors;
+
+	/** @var FileFunctions */
+	public $file_functions;
+
+	/** @var TemporaryAttachmentsList */
+	public $tmp_attachments;
+
+	/** @var AttachmentsDirectory */
+	public $attachmentDirectory;
+
+	/** @var HttpReq */
+	public $req;
+
+	/** @var bool if to use rename or move_uploaded_file (strict) */
+	public $strict = true;
+
+	/**
+	 * Class constructor.
+	 *
+	 * Initializes the object and sets the necessary properties.
+	 */
+	public function __construct()
+	{
+		global $modSettings;
+
+		$this->attach_errors = AttachmentErrorContext::context();
+		$this->file_functions = FileFunctions::instance();
+		$this->tmp_attachments = new TemporaryAttachmentsList();
+		$this->attachmentDirectory = new AttachmentsDirectory($modSettings, database());
+		$this->req = HttpReq::instance();
+
+		require_once(SUBSDIR . '/Attachments.subs.php');
+	}
+
+	/**
+	 * Handles the actual saving of attachments to a directory.
+	 *
+	 * What it does:
+	 *
+	 * - Loops through $_FILES['attachment'] array and saves each file to the current attachments' folder.
+	 * - Validates the save location actually exists.
+	 *
+	 * @param int $id_msg 0 or id of the message with attachments, if any.
+	 *                    If 0, this is an upload in progress for a new post.
+	 * @return bool
+	 */
+	public function processAttachments($id_msg = 0)
+	{
+		global $topic, $board;
+
+		// Validate we need to do processing, nothing new, nothing previously sent
+		if (!$this->hasAttachmentsToProcess())
+		{
+			return false;
+		}
+
+		// Make sure we're uploading to the right place and that it is available for writing
+		$this->setupAttachmentDirectory();
+		$attach_current_dir = $this->attachmentDirectory->getCurrent();
+		$this->ensureDirectoryExists($attach_current_dir);
+
+		// Check for any current attachments associated with the message (number and size)
+		$this->currentValuesForAttachments($id_msg);
+
+		// Are there are files already in session?
+		$ignore_temp = $this->hasPendingSessionAttachments();
+
+		// Validate we have new files to process
+		$this->ensureValidAttachmentFile();
+
+		if (!$ignore_temp)
+		{
+			$this->postTemporaryAttachments($id_msg, $topic, $board);
+		}
+
+		// If we have a system error, like no attachment directory, show the error and clear any attachments sent
+		if ($this->tmp_attachments->hasSystemError())
+		{
+			$this->processInitialErrors();
+		}
+
+		// Do the actual moving
+		$this->moveAttachmentsToCurrentDirectory($attach_current_dir);
+
+		// Mod authors, finally a hook to hang an alternate attachment upload system upon
+		// Upload to the current attachment folder with the file name $attachID or 'post_tmp_' . User::$info->id . '_' . md5(mt_rand())
+		// Populate TemporaryAttachmentsList[$attachID] with the following:
+		//   name => The file name
+		//   tmp_name => Path to the temp file (AttachmentsDirectory->getCurrent() . '/' . $attachID).
+		//   size => File size (required).
+		//   type => MIME type (optional if not available on upload).
+		//   id_folder => AttachmentsDirectory->currentDirectoryId
+		//   errors => An array of errors (use the index of the $txt variable for that error).
+		// Template changes can be done using "integrate_upload_template".
+		call_integration_hook('integrate_attachment_upload');
+
+		return $ignore_temp;
+	}
+
+	/**
+	 * Check if processing is needed.
+	 *
+	 * This method checks if processing is needed based on the following conditions:
+	 *
+	 * - If the 'files' post parameter is null in the temporary attachments list (a session check)
+	 * - If there are no attachments in the temporary attachments list.
+	 * - If there are no temporary attachments in the attachments directory.
+	 *
+	 * @return bool Returns `true` if processing is needed, otherwise returns `false`.
+	 */
+	private function hasAttachmentsToProcess()
+	{
+		if ($this->tmp_attachments->getPostParam('files') !== null)
+		{
+			return true;
+		}
+
+		if ($this->tmp_attachments->hasAttachments())
+		{
+			return true;
+		}
+
+		return $this->attachmentDirectory->hasFileTmpAttachments($this->strict);
+	}
+
+	/**
+	 * Prepare the attachment directory.
+	 *
+	 * This method checks and creates the attachment directory automatically when needed.
+	 *
+	 * @return void
+	 */
+	private function setupAttachmentDirectory()
+	{
+		$action = $this->req->getRequest('action', 'trim', '');
+
+		// Check / create an attachment directory automatically and when needed.
+		$this->attachmentDirectory->automanageCheckDirectory($action === 'admin');
+	}
+
+	/**
+	 * Check if the given attachment directory exists and is writable
+	 *
+	 * @param string $attach_current_dir The path to the attachment directory.
+	 */
+	private function ensureDirectoryExists($attach_current_dir)
+	{
+		global $txt;
+
+		if (!$this->file_functions->isDir($attach_current_dir) || !$this->file_functions->isWritable($attach_current_dir))
+		{
+			$this->tmp_attachments->setSystemError('attach_folder_warning');
+			Errors::instance()->log_error(
+				sprintf($txt['attach_folder_admin_warning'], $attach_current_dir),
+				'critical'
+			);
+		}
+	}
+
+	/**
+	 * Get the current values for attachments.
+	 *
+	 * This method retrieves the current values for attachments, such as the quantity and total size, and stores
+	 * them in the $context variable.
+	 *
+	 * @param int $id_msg The message id
+	 * @return void
+	 */
+	private function currentValuesForAttachments($id_msg)
+	{
+		global $context;
+
+		// No system errors, like missing attachment directory, then prepare our values
+		if (!isset($context['attachments']['quantity']) && $this->tmp_attachments->hasSystemError() === false)
+		{
+			$context['attachments']['quantity'] = 0;
+			$context['attachments']['total_size'] = 0;
+
+			// If this isn't a new post, check for any current attachments (number and size)
+			if ($id_msg !== 0)
+			{
+				[$context['attachments']['quantity'], $context['attachments']['total_size']] = attachmentsSizeForMessage($id_msg);
+			}
+		}
+	}
+
+	/**
+	 * Checks if there are temporary attachments and determines whether to ignore (keep) them or not.
+	 *
+	 * @return bool Returns true if temporary attachments should be ignored, false otherwise.
+	 */
+	private function hasPendingSessionAttachments()
+	{
+		$ignore_temp = false;
+		if ($this->tmp_attachments->getPostParam('files') !== null && $this->tmp_attachments->hasAttachments())
+		{
+			// Let's try to keep them. But...
+			$ignore_temp = true;
+
+			// If new files are being added. We can't ignore those
+			if (!empty($_FILES['attachment']['tmp_name']) && array_filter($_FILES['attachment']['tmp_name']) !== [])
+			{
+				$ignore_temp = false;
+			}
+
+			// Need to make space for the new files. So, bye bye.
+			if (!$ignore_temp)
+			{
+				$this->tmp_attachments->removeAll(User::$info->id);
+				$this->tmp_attachments->unset();
+				$this->attach_errors->activate()->addError('temp_attachments_flushed');
+			}
+		}
+
+		return $ignore_temp;
+	}
+
+	/**
+	 * Ensure that the attachment files are available.
+	 *
+	 * This method removes any empty attachment files from the $_FILES array if no files are being uploaded.
+	 *
+	 * @return void
+	 */
+	private function ensureValidAttachmentFile()
+	{
+		// If we have an array of already attached files, but no longer any files being uploaded.
+		if (empty($_FILES['attachment']['tmp_name']))
+		{
+			return;
+		}
+
+		if (array_filter($_FILES['attachment']['tmp_name']) !== [])
+		{
+			return;
+		}
+
+		foreach (array_keys($_FILES['attachment']['tmp_name']) as $index)
+		{
+			if ($_FILES['attachment']['name'][$index] === '')
+			{
+				unset($_FILES['attachment']['tmp_name'][$index]);
+			}
+		}
+	}
+
+	/**
+	 * Post values for any temporary attachments for a message.
+	 *
+	 * This method sets the post parameters for temporary attachments, including the message ID,
+	 * last message ID, topic ID, and board ID.
+	 *
+	 * @param int $id_msg The ID of the message.
+	 * @param int|null $topic The ID of the topic (optional).
+	 * @param int|null $board The ID of the board (optional).
+	 * @return void
+	 */
+	private function postTemporaryAttachments($id_msg, $topic, $board)
+	{
+		// Remember where we are at. If it's anywhere at all.
+		$this->tmp_attachments->setPostParam([
+			'msg' => $id_msg,
+			'last_msg' => (int) ($_REQUEST['last_msg'] ?? 0),
+			'topic' => (int) ($topic ?? 0),
+			'board' => (int) ($board ?? 0),
+		]);
+	}
+
+	/**
+	 * Process initial errors.
+	 *
+	 * This method is used to display a generic error message, delete temporary files, and reset the attachment array.
+	 */
+	private function processInitialErrors()
+	{
+		$this->attach_errors->activate();
+		$this->attach_errors->addError('attach_no_upload');
+
+		// And delete the files 'cos they ain't going nowhere.
+		foreach ($_FILES['attachment']['tmp_name'] as $n => $dummy)
+		{
+			if (is_writable($_FILES['attachment']['tmp_name'][$n]))
+			{
+				unlink($_FILES['attachment']['tmp_name'][$n]);
+			}
+		}
+
+		$_FILES['attachment']['tmp_name'] = [];
+	}
+
+	/**
+	 * Move uploaded attachments to the current active attachment directory.
+	 *
+	 * This method loops through the $_FILES['attachment'] array and moves each file to the current attachments' folder.
+	 *
+	 * @param string $attach_current_dir The directory to which the attachments should be moved.
+	 * @return void
+	 */
+	private function moveAttachmentsToCurrentDirectory($attach_current_dir)
+	{
+		// Loop through $_FILES['attachment'] array and move each file to the current attachments' folder.
+		foreach ($_FILES['attachment']['tmp_name'] as $index => $dummy)
+		{
+			if ($_FILES['attachment']['name'][$index] === '')
+			{
+				continue;
+			}
+
+			// First, let's check for standard PHP upload errors.
+			$errors = doPHPUploadChecks($index);
+
+			$tempAttachment = $this->prepareTemporaryAttachmentData($index);
+
+			// If we are error free, Try to move and rename the file before doing more checks on it.
+			if (empty($errors))
+			{
+				$tempAttachment->moveUploaded($attach_current_dir, $this->strict);
+			}
+			// Upload error(s) were detected, flag the error, remove the file
+			else
+			{
+				$tempAttachment->setErrors($errors);
+				$tempAttachment->remove(false);
+			}
+
+			// The file made it to the server,
+			// - Do our checks such as injection, size, extension
+			// - Do any adjustments such as rotation, webp, resizing
+			$tempAttachment->doElkarteUploadChecks($this->attachmentDirectory);
+
+			// Sort out the errors for display and delete any associated files.
+			if ($tempAttachment->hasErrors())
+			{
+				$this->handleAttachmentErrors($tempAttachment);
+			}
+
+			$this->tmp_attachments->addAttachment($tempAttachment);
+		}
+	}
+
+	/**
+	 * Prepare temporary attachment data.
+	 *
+	 * This method creates and returns an instance of the TemporaryAttachment class with the provided data.
+	 *
+	 * @param int $index The index of the attachment in the $_FILES array.
+	 * @return TemporaryAttachment An instance of the TemporaryAttachment class with the following properties:
+	 * - name: The name of the attachment file.
+	 * - tmp_name: The temporary name of the attachment file.
+	 * - attachid: The attachment ID generated by the tmp_attachments->getTplName method.
+	 * - public_attachid: The public attachment ID generated by the tmp_attachments->getTplName method.
+	 * - user_id: The ID of the user.
+	 * - size: The size of the attachment file.
+	 * - type: The type of the attachment file.
+	 * - id_folder: The ID of the current attachment directory.
+	 * - mime: The MIME type of the attachment file.
+	 */
+	public function prepareTemporaryAttachmentData($index)
+	{
+		$tokenizer = new TokenHash();
+
+		return new TemporaryAttachment([
+			'name' => basename($_FILES['attachment']['name'][$index]),
+			'tmp_name' => $_FILES['attachment']['tmp_name'][$index],
+			'attachid' => $this->tmp_attachments->getTplName(User::$info->id, $tokenizer->generate_hash(16)),
+			'public_attachid' => $this->tmp_attachments->getTplName(User::$info->id, $tokenizer->generate_hash(16)),
+			'user_id' => User::$info->id,
+			'size' => $_FILES['attachment']['size'][$index],
+			'type' => $_FILES['attachment']['type'][$index],
+			'id_folder' => $this->attachmentDirectory->currentDirectoryId(),
+			'mime' => getMimeType($_FILES['attachment']['tmp_name'][$index]),
+		]);
+	}
+
+	/**
+	 * Handle attachment errors.
+	 *
+	 * This method handles any errors that occurred during attachment processing.
+	 *
+	 * @param object $tempAttachment The temporary attachment object.
+	 * @return void
+	 */
+	private function handleAttachmentErrors($tempAttachment)
+	{
+		global $txt;
+
+		$this->attach_errors->addAttach($tempAttachment['attachid'], $tempAttachment->getName());
+		$log_these = ['attachments_no_create', 'attachments_no_write', 'attach_timeout',
+			'ran_out_of_space', 'cant_access_upload_path', 'attach_0_byte_file', 'bad_attachment'];
+
+		foreach ($tempAttachment->getErrors() as $error)
+		{
+			$error = array_filter($error);
+			$this->attach_errors->addError(isset($error[1]) ? $error : $error[0]);
+			if (in_array($error[0], $log_these, true))
+			{
+				Errors::instance()->log_error($tempAttachment->getName() . ': ' . $txt[$error[0]], 'critical');
+
+				// For critical errors, we don't want the file or session data to persist
+				$tempAttachment->remove(false);
+			}
+		}
+	}
+}

--- a/sources/ElkArte/Attachments/TemporaryAttachmentsList.php
+++ b/sources/ElkArte/Attachments/TemporaryAttachmentsList.php
@@ -13,6 +13,7 @@
 
 namespace ElkArte\Attachments;
 
+use ElkArte\Helper\FileFunctions;
 use ElkArte\Helper\ValuesContainer;
 
 /**
@@ -69,7 +70,7 @@ class TemporaryAttachmentsList extends ValuesContainer
 	public function remove($file)
 	{
 		// Must exist and have edit permissions
-		return \ElkArte\Helper\FileFunctions::instance()->delete($file);
+		return FileFunctions::instance()->delete($file);
 	}
 
 	/**
@@ -138,8 +139,7 @@ class TemporaryAttachmentsList extends ValuesContainer
 	}
 
 	/**
-	 * Checks if at least one temporary file for a certain user exists in the
-	 * file system.
+	 * Checks if at least one temporary file for a certain user exists in the file system.
 	 *
 	 * @param int $userId
 	 * @return bool

--- a/sources/ElkArte/Controller/Giphy.php
+++ b/sources/ElkArte/Controller/Giphy.php
@@ -177,10 +177,7 @@ class Giphy extends AbstractController
 	{
 		global $context;
 
-		theme()->getLayers()->removeAll();
-		theme()->getTemplates()->load('Json');
-		$context['sub_template'] = 'send_json';
-
+		setJsonTemplate();
 		$context['json_data'] = [
 			'giphy' => $images,
 			'data' => $result

--- a/sources/ElkArte/Controller/Jslocale.php
+++ b/sources/ElkArte/Controller/Jslocale.php
@@ -138,9 +138,7 @@ class Jslocale extends AbstractController
 		$languages = getLanguages();
 		$lang = $this->_req->getPost('lang', 'trim', 'English');
 
-		theme()->getLayers()->removeAll();
-		theme()->getTemplates()->load('Json');
-		$context['sub_template'] = 'send_json';
+		setJsonTemplate();
 		$context['require_agreement'] = !empty($modSettings['requireAgreement']);
 
 		if (isset($languages[$lang]))

--- a/sources/ElkArte/Controller/Likes.php
+++ b/sources/ElkArte/Controller/Likes.php
@@ -220,9 +220,7 @@ class Likes extends AbstractController
 		global $context, $txt;
 
 		// Make room for ajax
-		theme()->getLayers()->removeAll();
-		theme()->getTemplates()->load('Json');
-		$context['sub_template'] = 'send_json';
+		setJsonTemplate();
 
 		// No errors, build the new button tag
 		if (empty($this->_likes_response))

--- a/sources/ElkArte/Controller/Mentions.php
+++ b/sources/ElkArte/Controller/Mentions.php
@@ -134,10 +134,7 @@ class Mentions extends AbstractController
 			die();
 		}
 
-		$template_layers = theme()->getLayers();
-		$template_layers->removeAll();
-		theme()->getTemplates()->load('Json');
-		$context['sub_template'] = 'send_json';
+		setJsonTemplate();
 
 		require_once(SUBSDIR . '/Mentions.subs.php');
 

--- a/sources/ElkArte/Errors/AttachmentErrorContext.php
+++ b/sources/ElkArte/Errors/AttachmentErrorContext.php
@@ -223,7 +223,7 @@ class AttachmentErrorContext
 	{
 		global $txt;
 
-		$returns = array();
+		$returns = [];
 
 		if ($this->_generic_error !== null)
 		{
@@ -238,11 +238,11 @@ class AttachmentErrorContext
 		{
 			foreach ($this->_attachs as $attachID => $error)
 			{
-				$returns[$attachID] = array(
+				$returns[$attachID] = [
 					'errors' => $error['error']->prepareErrors($severity),
 					'type' => $this->getErrorType(),
 					'title' => sprintf($txt['attach_warning'], $error['name']),
-				);
+				];
 			}
 		}
 

--- a/sources/ElkArte/Languages/Post/English.php
+++ b/sources/ElkArte/Languages/Post/English.php
@@ -21,9 +21,6 @@ $txt['lamp'] = 'Lamp';
 $txt['add_smileys'] = 'Add smileys';
 $txt['topic_notify_no'] = 'There are no topics with notification.';
 
-$txt['rich_edit_wont_work'] = 'Your browser does not support Rich Text editing.';
-$txt['rich_edit_function_disabled'] = 'Your browser does not support this function.';
-
 // Use numeric entities in the below five strings.
 $txt['notifyUnsubscribe'] = 'Unsubscribe to this topic by clicking here';
 
@@ -151,6 +148,7 @@ $txt['php_upload_error_4'] = 'No file was uploaded. This is a PHP related error.
 $txt['php_upload_error_6'] = 'Unable to save. Missing a temporary directory. Please contact your host if you are unable to correct this problem.';
 $txt['php_upload_error_7'] = 'Failed to write file to disk. This is a PHP related error. Please contact your host if this problem continues.';
 $txt['php_upload_error_8'] = 'A PHP extension stopped the file upload. This is a PHP related error. Please contact your host if this problem continues.';
+
 $txt['error_temp_attachments_new'] = 'There are attachments which you had previously attached but not posted. These attachments are still attached to this post. This post does need to be submitted before these attachments are either saved or removed. <a class="linkbutton" href="#postAttachment">You can do that here</a>';
 $txt['error_temp_attachments_found'] = 'The following attachments were found which you had previously attached to another post but not posted. It is advisable that you do not post until these are either removed or that post has been submitted.<br /><a class="linkbutton" href="%1$s">Click here to remove </a>those attachments. Or <a class="linkbutton" href="%2$s">here to return to that post</a>.%3$s';
 $txt['error_temp_attachments_lost'] = 'The following attachments were found which you had previously attached to another post but not posted. It is advisable that you do not upload any more attachments until these are removed or that post has been submitted.<br /><a class="linkbutton" href="%1$s">Click here to remove these attachments</a>.%2$s';
@@ -163,11 +161,20 @@ $txt['file_too_big'] = 'Your file is too large. The maximum attachment size allo
 $txt['attach_timeout'] = 'Your attachment couldn\'t be saved. This might happen because it took too long to upload or the file is bigger than the server will allow.<br /><br />Please consult your server administrator for more information.';
 $txt['bad_attachment'] = 'Your attachment has failed security checks and cannot be uploaded. Please consult the forum administrator.';
 $txt['ran_out_of_space'] = 'The upload directory is full. Please contact an administrator about this problem.';
+
 $txt['attachments_no_write'] = 'The attachments upload directory is not writable.  Your attachment or avatar cannot be saved.';
 $txt['attachments_no_create'] = 'Unable to create a new attachment directory.  Your attachment or avatar cannot be saved.';
 $txt['attachments_limit_per_post'] = 'You may not upload more than %1$d attachments per post';
 $txt['attachment_upload_abort'] = 'The upload was canceled on user request.';
 $txt['attachment_processing'] = 'Processing';
+
+$txt['attachment_invalid_chunk'] = 'An unexpected file fragment was received.';
+$txt['attachment_invalid_uuid'] = 'No fragment identifier was found in the request.';
+$txt['attachment_no_files'] = 'No file fragment was found to process.';
+$txt['attachment_chunk_quota'] = 'The file is larger than the server will accept.';
+$txt['attachment_upload_error'] = 'There was an error uploading the file, this is a PHP related error on the server.';
+$txt['attachment_not_found'] = 'There was an error copying the fragment.';
+$txt['attachment_not_writable'] = 'The attachment directory is not writable, the file cannot be saved.';
 
 // Post settings (when I implement the post interface)
 $txt['ila_insert'] = 'Insert Attachment %1$d in the message';

--- a/sources/ElkArte/Modules/Attachments/Post.php
+++ b/sources/ElkArte/Modules/Attachments/Post.php
@@ -17,6 +17,7 @@
 namespace ElkArte\Modules\Attachments;
 
 use ElkArte\Attachments\TemporaryAttachment;
+use ElkArte\Attachments\TemporaryAttachmentProcess;
 use ElkArte\Attachments\TemporaryAttachmentsList;
 use ElkArte\Errors\AttachmentErrorContext;
 use ElkArte\Errors\ErrorContext;
@@ -443,7 +444,8 @@ class Post extends AbstractModule
 		if ($context['attachments']['can']['post'] && empty($this->_req->getPost('from_qr')))
 		{
 			require_once(SUBSDIR . '/Attachments.subs.php');
-			$this->ignore_temp = processAttachments((int) $msg);
+			$processAttachments = new TemporaryAttachmentProcess();
+			$this->ignore_temp = $processAttachments->processAttachments((int) $msg);
 		}
 	}
 

--- a/sources/ElkArte/Notifications/PostNotifications.php
+++ b/sources/ElkArte/Notifications/PostNotifications.php
@@ -433,7 +433,7 @@ class PostNotifications extends AbstractModel
 		// In group mode like google groups or yahoo groups, the mail is from the poster
 		if (!empty($this->_modSettings['maillist_group_mode']))
 		{
-			return un_htmlspecialchars($topicDatum['name']);
+			return un_htmlspecialchars($topicDatum['name'] ?? 'N/A');
 		}
 
 		// Otherwise in maillist mode, it is from the site
@@ -528,7 +528,7 @@ class PostNotifications extends AbstractModel
 				if ($maillist && $email_perm && $type === self::NOTIFY_REPLY && !empty($notifyDatum['notify_send_body']))
 				{
 					// Set from name based on group or maillist mode
-					$email_from = $this->_getEmailFrom($topicNotifications[$notifyDatum['id_topic']]);
+					$email_from = $this->_getEmailFrom($topicData[$notifyDatum['id_topic']]);
 					$from_wrapper = $this->_getFromWrapper();
 
 					$sendMail->buildEmail($notifyDatum['email_address'], $emaildata['subject'], $emaildata['body'], $email_from, 'm' . $topicNotifications[$notifyDatum['id_topic']]['last_id'], true, 3, false, $from_wrapper, $notifyDatum['id_topic']);

--- a/sources/ElkArte/Notifications/UserNotification.php
+++ b/sources/ElkArte/Notifications/UserNotification.php
@@ -133,7 +133,7 @@ class UserNotification extends AbstractModel
 				Push.config({serviceWorker: "./elkServiceWorker.min.js"}); 
 				
 				// Grab the site icon to use in the desktop notification widget
-				ElkNotifications.add(new ElkDesktop(
+				ElkNotifier.add(new ElkDesktop(
 					{"icon": $("head").find("link[rel=\'shortcut icon\']").attr("href")}
 				));
 			});', true);

--- a/sources/ElkArte/UrlGenerator/Standard/Standard.php
+++ b/sources/ElkArte/UrlGenerator/Standard/Standard.php
@@ -38,6 +38,11 @@ class Standard extends AbstractUrlGenerator
 	 */
 	protected function generateQuery($params)
 	{
+		if (!is_array($params))
+		{
+			return '';
+		}
+
 		$args = [];
 		foreach ($params as $k => $v)
 		{

--- a/sources/Subs.php
+++ b/sources/Subs.php
@@ -1886,6 +1886,27 @@ function theme()
 }
 
 /**
+ * Set the JSON template for sending JSON response.
+ *
+ * This method prepares the template layers, loads the 'Json' template,
+ * and sets the sub_template to 'send_json' in the global $context array.
+ * The JSON data is initialized to null.
+ *
+ * @return void
+ */
+function setJsonTemplate()
+{
+	global $context;
+
+	$template_layers = $GLOBALS['context']['theme_instance']->getLayers();
+	$template_layers->removeAll();
+	$GLOBALS['context']['theme_instance']->getTemplates()->load('Json');
+	$context['sub_template'] = 'send_json';
+
+	$context['json_data'] = null;
+}
+
+/**
  * Send a 1x1 GIF response and terminate the script execution
  *
  * @param bool $expired Flag to determine if header Expires should be sent

--- a/sources/subs/Editor.subs.php
+++ b/sources/subs/Editor.subs.php
@@ -80,7 +80,8 @@ function create_control_richedit($editorOptions)
 			'editor/jquery.sceditor.elkarte.js',
 			'post.js',
 			'editor/dropAttachments.js',
-			'editor/ilaAttachments.js'
+			'editor/ilaAttachments.js',
+			'editor/chunkUpload.js'
 		]);
 
 		theme()->addJavascriptVar([

--- a/sources/subs/Notification.subs.php
+++ b/sources/subs/Notification.subs.php
@@ -455,11 +455,11 @@ function getNotifierToken($memID, $memEmail, $memSalt, $area, $extra)
 {
 	global $modSettings;
 
-	$tokenizer = new TokenHash();
-
 	// We need a site salt to keep things moving
 	if (empty($modSettings['unsubscribe_site_salt']))
 	{
+		$tokenizer = new TokenHash();
+
 		// Extra digits of salt
 		$unsubscribe_site_salt = $tokenizer->generate_hash(22);
 		updateSettings(['unsubscribe_site_salt' => $unsubscribe_site_salt]);

--- a/tests/ElkArte/Attachments/TemporaryAttachmentChunkTest.php
+++ b/tests/ElkArte/Attachments/TemporaryAttachmentChunkTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ *
+ * @package   ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ *
+ * @version 2.0 dev
+ *
+ */
+
+namespace ElkArte\Attachments;
+
+use tests\ElkArteCommonSetupTest;
+
+class TemporaryAttachmentChunkTest extends ElkArteCommonSetupTest
+{
+	protected $tempAttachmentChunk;
+
+	protected function setUp(): void
+	{
+		$this->tempAttachmentChunk = new TemporaryAttachmentChunk();
+	}
+
+	public function testActionAsync()
+	{
+		$result = $this->tempAttachmentChunk->action_async();
+
+		// No session will just return
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('result', $result);
+	}
+
+	public function testSaveAsyncFile()
+	{
+		$result = $this->tempAttachmentChunk->saveAsyncFile();
+
+		// No post data, will fail validatePostData()
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', $result);
+		$this->assertArrayHasKey('code', $result);
+		$this->assertEquals('invalid_chunk', $result['code']);
+
+		// Dummy data to pass some checks
+		$_POST = [
+			'elkchunkindex' => 0,
+			'elktotalchunkcount' => 1,
+			'elkuuid' => 1234,
+		];
+
+		$result = $this->tempAttachmentChunk->saveAsyncFile();
+
+		// Should get to validateReceivedFile and fail
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', $result);
+		$this->assertArrayHasKey('code', $result);
+		$this->assertEquals('no_files', $result['code']);
+	}
+
+	public function testCheckTotalSize()
+	{
+		$result = $this->tempAttachmentChunk->checkTotalSize(5);
+		$this->assertTrue($result);
+	}
+
+	public function testGetSmallerNonZero()
+	{
+		$result = $this->tempAttachmentChunk->getSmallerNonZero(5, 10);
+		$this->assertEquals(5, $result);
+	}
+
+	public function testErrorAsyncFile()
+	{
+		$error_code = 'invalid_chunk';
+		$fileID = 'test_id';
+		$result = $this->tempAttachmentChunk->errorAsyncFile($error_code, $fileID);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('error', $result);
+		$this->assertArrayHasKey('code', $result);
+		$this->assertArrayHasKey('id', $result);
+		$this->assertEquals($error_code, $result['code']);
+		$this->assertEquals($fileID, $result['id']);
+	}
+
+	public function testReturnResults()
+	{
+		$result_data = [
+			'id' => 'test_id',
+			'code' => ''
+		];
+		$result = $this->tempAttachmentChunk->returnResults($result_data);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('result', $result);
+		$this->assertArrayHasKey('async', $result);
+	}
+}

--- a/tests/sources/subs/AttachmentSubsTest.php
+++ b/tests/sources/subs/AttachmentSubsTest.php
@@ -10,6 +10,7 @@
  *
  */
 
+use ElkArte\Attachments\TemporaryAttachmentProcess;
 use ElkArte\Errors\AttachmentErrorContext;
 use ElkArte\Languages\Loader;
 use tests\ElkArteCommonSetupTest;
@@ -66,7 +67,8 @@ class AttachmentSubsTest extends ElkArteCommonSetupTest
 	public function testProcessAttachments()
 	{
 		// Better not pass
-		$result = processAttachments(0);
+		$processAttachments = new TemporaryAttachmentProcess();
+		$result = $processAttachments->processAttachments(0);
 		$this->assertFalse($result);
 
 		// What did it think of this

--- a/themes/default/Post.template.php
+++ b/themes/default/Post.template.php
@@ -606,6 +606,7 @@ function template_add_new_attachments()
 		individualSizeAllowed: ' . (empty($modSettings['attachmentSizeLimit']) ? 0 : $modSettings['attachmentSizeLimit'] * 1024) . ',
 		numOfAttachmentAllowed: ' . (empty($modSettings['attachmentNumPerPostLimit']) ? 50 : $modSettings['attachmentNumPerPostLimit']) . ',
 		numAttachUploaded: ' . $context['attachments']['quantity'] . ',
+		chunkSize: ' . (empty($modSettings['attachmentChunkSize']) ? 250000 : $modSettings['attachmentChunkSize']) . ',
 		resizeImageEnabled: ' . (empty($modSettings['attachment_image_resize_enabled']) ? 0 : 1) . ',
 		fileDisplayTemplate: \'<div class="statusbar"><div class="info"></div><div class="progressBar"><div></div></div><div class="control icon i-close"></div></div>\',
 		oTxt: {

--- a/themes/default/scripts/admin.js
+++ b/themes/default/scripts/admin.js
@@ -1723,7 +1723,7 @@ function ajax_getCensorPreview ()
  * Used to show/hide sub options for the various notifications
  * action=admin;area=featuresettings;sa=mention
  */
-$(function() {
+function prepareNotificationOptions () {
 	let headers = Array.from(document.querySelectorAll('input[id^=\'notifications\'][id$=\'[enable]\']'));
 
 	headers.forEach(function(header) {
@@ -1767,7 +1767,7 @@ $(function() {
 		let event = new Event('change', {'bubbles': true, 'cancelable': true});
 		header.dispatchEvent(event);
 	});
-});
+}
 
 /**
  * Ajax function to clear CSS and JS hives.  Called from action=admin;area=featuresettings;sa=basic

--- a/themes/default/scripts/editor/chunkUpload.js
+++ b/themes/default/scripts/editor/chunkUpload.js
@@ -1,0 +1,336 @@
+/*!
+ * @package   ElkArte Forum
+ * @copyright ElkArte Forum contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause (see accompanying LICENSE.txt file)
+ *
+ * @version 2.0 dev
+ */
+
+/**
+ * This file contains javascript associated with the chunked upload functionality
+ */
+class chunkUpload
+{
+	constructor (params)
+	{
+		this.url = params.url;
+		this.form = params.form;
+		this.chunkSize = params.chunkSize || 250000;
+		this.retries = params.retries || 4;
+		this.delayBeforeRetry = params.delayBeforeRetry || 5;
+		this.signal = params.signal;
+
+		// Ensure the params are valid
+		this._validateParams();
+
+		// Setup for this file
+		this._init();
+		this._reader = new FileReader();
+		this._eventEmitter = new ChunkEventEmitter();
+
+		// Send the fragments
+		this._sendChunks();
+	}
+
+	/**
+	 * Subscribe to an event, there are currently 4 events emitted
+	 * - fileRetry
+	 * - progress
+	 * - error
+	 * - complete
+	 */
+	on (eType, fn)
+	{
+		this._eventEmitter.on(eType, fn);
+
+		return this;
+	}
+
+	/**
+	 * Sends a finalize request to the server.
+	 * It appends necessary data to FormData and sends a POST request to the specified URL.
+	 * Throws an error in case of a network error.
+	 */
+	finalize()
+	{
+		const combineChunkForm = new FormData();
+
+		combineChunkForm.append('elkuuid', this.uuid);
+		combineChunkForm.append('elkchunkindex', this.chunkCount);
+		combineChunkForm.append('elktotalchunkcount', this.totalChunks);
+		combineChunkForm.append('filename', this.file.name.php_urlencode());
+		combineChunkForm.append('filesize', this.file.size);
+		combineChunkForm.append('filetype', this.file.type);
+		combineChunkForm.append(elk_session_var, elk_session_id);
+		combineChunkForm.append('async', 'complete');
+
+		fetch(this.url, {
+			method: 'POST',
+			headers: {
+				'X-Requested-With': 'XMLHttpRequest',
+				'Accept': 'application/json',
+			},
+			body: combineChunkForm,
+			cache: 'no-store'
+		})
+			.then(response => {
+				if (!response.ok)
+				{
+					let error = new Error('Network error');
+					error.cause = response;
+					throw error;
+				}
+
+				return response.json();
+			})
+			.then(response => {
+				this._eventEmitter.emit('done',  response);
+
+			})
+			.catch(error => {
+				this._eventEmitter.emit('error', error.message);
+
+				if ('console' in window && console.error)
+				{
+					console.error('Error : ', error);
+				}
+			})
+			.finally(() => {
+				this._eventEmitter.emit('always', {});
+			});
+	}
+
+	/**
+	 * Initialize the object's properties for chunking this file
+	 *
+	 * @private
+	 */
+	_init ()
+	{
+		this.file = this.form.get('attachment[]');
+		this.start = 0;
+		this.retriesCount = 0;
+		this.chunkData = null;
+		this.chunkCount = 0;
+		this.totalChunks = this._getTotalChunks();
+		this.uuid = this._getUniqueId();
+	}
+
+	/**
+	 * Private method to validate parameters before executing the main logic.
+	 *
+	 * @private
+	 *
+	 * @throws {TypeError} Throws an error if the "url" parameter is not defined.
+	 * @throws {TypeError} Throws an error if the "form" parameter is not an instance of FormData.
+	 * @throws {TypeError} Throws an error if the "attachment[]" parameter in the FormData is not an instance of File.
+	 */
+	_validateParams ()
+	{
+		if (!this.url || !this.url.length)
+		{
+			throw new TypeError('url must be defined');
+		}
+
+		if (!(this.form instanceof FormData))
+		{
+			throw new TypeError('Form must be a FormData object');
+		}
+
+		if (!(this.form.get('attachment[]') instanceof File))
+		{
+			throw new TypeError('attachment in FormData must be a File object');
+		}
+	}
+
+	/**
+	 * Calculates the total number of chunks based on the file size and chunk size.
+	 *
+	 * @returns {number} The total number of chunks.
+	 * @private
+	 */
+	_getTotalChunks ()
+	{
+		return Math.ceil(this.file.size / (this.chunkSize));
+	}
+
+	/**
+	 * Generates a unique ID using a combination of random numbers and the current timestamp.
+	 *
+	 * @returns {number} The unique ID.
+	 * @private
+	 */
+	_getUniqueId ()
+	{
+		return Math.floor(Math.random() * 123456789) + Date.now() + this.file.size;
+	}
+
+	/**
+	 * Retrieves the next chunk of data from the file.
+	 *
+	 * @returns {Promise<unknown>} A promise that resolves when the chunk is retrieved.
+	 * @private
+	 */
+	_getChunk ()
+	{
+		return new Promise((resolve) => {
+			const length = this.totalChunks === 1 ? this.file.size : this.chunkSize;
+			const start = length * this.chunkCount;
+
+			this._reader.onload = () => {
+				this.chunkData = new Blob([this._reader.result], {type: 'application/octet-stream'});
+				resolve();
+			};
+
+			this._reader.readAsArrayBuffer(this.file.slice(start, start + length));
+		});
+	}
+
+	/**
+	 * Sends a chunk of data to the server.
+	 *
+	 * @private
+	 * @returns {Promise<Response>} - A Promise that resolves to a Response object.
+	 */
+	_sendChunk ()
+	{
+		const chunkForm = new FormData();
+
+		// Load the form with useful data
+		chunkForm.append('elkchunkindex', this.chunkCount);
+		chunkForm.append('elktotalchunkcount', this.totalChunks);
+		chunkForm.append('elkuuid', this.uuid);
+		chunkForm.append('filename', this.file.name.php_urlencode());
+		chunkForm.append('filesize',  this.chunkData.size);
+		chunkForm.append('filetype', this.file.type);
+		chunkForm.append('attachment[]', this.chunkData);
+		chunkForm.append(elk_session_var, elk_session_id);
+
+		// Provide a way for the user to abort the upload
+		let signal = this.signal;
+
+		return fetch(this.url, {
+			signal,
+			method: 'POST',
+			headers: {
+				'X-Requested-With': 'XMLHttpRequest',
+				'Accept': 'application/json',
+			},
+			body: chunkForm,
+			cache: 'no-store'
+		});
+	}
+
+	/**
+	 * Manages retries for uploading a chunk of a file.
+	 *
+	 * @private
+	 */
+	_manageRetries ()
+	{
+		if (this.retriesCount++ < this.retries)
+		{
+			setTimeout(() => this._sendChunks(), this.delayBeforeRetry * 1000);
+
+			this._eventEmitter.emit('fileRetry', {
+				message: 'An error occurred uploading chunk ' + this.chunkCount + '. ' + (this.retries - this.retriesCount) + ' retries left',
+				chunk: this.chunkCount,
+				retriesLeft: this.retries - this.retriesCount
+			});
+
+			return;
+		}
+
+		this._eventEmitter.emit('error', 'An error occurred uploading part [' + this.chunkCount + ']');
+	}
+
+	/**
+	 * Handle the sending of all chunks of data.
+	 *
+	 * @private
+	 * @returns {void}
+	 */
+	_sendChunks ()
+	{
+		this._getChunk()
+			.then(() => this._sendChunk())
+			.then(response => {
+				if (!response.ok)
+				{
+					let error = new Error('Network error');
+					error.cause = response;
+					throw error;
+				}
+
+				return response.json();
+			})
+			.then(response => {
+				if (response.result === true)
+				{
+					if (++this.chunkCount < this.totalChunks)
+					{
+						this._sendChunks();
+					}
+					else
+					{
+						this._eventEmitter.emit('complete', response);
+					}
+
+					const percentProgress = Math.round((100 / this.totalChunks) * this.chunkCount);
+					this._eventEmitter.emit('progress', percentProgress);
+				}
+				else
+				{
+					let error = new Error('Error: ' + response.error);
+					error.cause = {'status': 200};
+					throw error;
+				}
+			})
+			.catch((response) => {
+				if (response.name === 'AbortError')
+				{
+					this._eventEmitter.emit('error', 'abort');
+				}
+				else if (response.cause && [408, 502, 503, 504].includes(response.cause.status))
+				{
+					this._manageRetries();
+				}
+				else
+				{
+					this._eventEmitter.emit('error', response.message);
+				}
+			});
+	}
+}
+
+/**
+ * An event emitter class that extends the EventTarget class.
+ *
+ * @class
+ * @extends EventTarget
+ */
+class ChunkEventEmitter extends EventTarget
+{
+	constructor ()
+	{
+		super();
+	}
+
+	// Custom method to subscribe to events
+	on (eventType, callback)
+	{
+		this.addEventListener(eventType, callback);
+	}
+
+	// Custom method to unsubscribe from events
+	off (eventType, callback)
+	{
+		this.removeEventListener(eventType, callback);
+	}
+
+	// Custom method to emit events
+	emit (eventType, eventData)
+	{
+		this.dispatchEvent(new CustomEvent(eventType, {detail: eventData}));
+	}
+}


### PR DESCRIPTION
Adding of Chunked Attachment Uploads 

Uploaded attachments are cut into chunks, sent, re-combined on the server, and then processed as if it was sent as one large file

This has retries on the chunks should a network glitch occur and allows multiple sends to be occurring which could improve speed.

This simplifies the "upload_max_filesize" as each chunk will be small enough to pass the limit. 