### PR TITLE
Remove Allow other to email me

### DIFF
--- a/sources/ElkArte/Controller/Groups.php
+++ b/sources/ElkArte/Controller/Groups.php
@@ -398,14 +398,14 @@ class Groups extends AbstractController
 		// Sort out the sorting!
 		$sort_methods = array(
 			'name' => 'real_name',
-			'email' => allowedTo('moderate_forum') ? 'email_address' : 'hide_email ' . (isset($this->_req->query->desc) ? 'DESC' : 'ASC') . ', email_address',
+			'email' => allowedTo('moderate_forum') ? 'email_address' : ' ' . (isset($this->_req->query->desc) ? 'DESC' : 'ASC') . ', email_address',
 			'active' => 'last_login',
 			'registered' => 'date_registered',
 			'posts' => 'posts',
 		);
 
 		// They didn't pick one, or tried a wrong one, so default to by name..
-		if (!isset($this->_req->query->sort) || !isset($sort_methods[$this->_req->query->sort]))
+		if (!isset($this->_req->query->sort, $sort_methods[$this->_req->query->sort]))
 		{
 			$context['sort_by'] = 'name';
 			$querySort = 'real_name' . (isset($this->_req->query->desc) ? ' DESC' : ' ASC');
@@ -451,7 +451,7 @@ class Groups extends AbstractController
 				'id' => $row['id_member'],
 				'name' => '<a href="' . getUrl('profile', ['action' => 'profile', 'u' => $row['id_member'], 'name' => $row['real_name']]) . '">' . $row['real_name'] . '</a>',
 				'email' => $row['email_address'],
-				'show_email' => showEmailAddress(!empty($row['hide_email']), $row['id_member']),
+				'show_email' => showEmailAddress($row['id_member']),
 				'ip' => '<a href="' . getUrl('action', ['action' => 'trackip', 'searchip' => $row['member_ip']]) . '">' . $row['member_ip'] . '</a>',
 				'registered' => standardTime($row['date_registered']),
 				'last_online' => $last_online,
@@ -462,7 +462,7 @@ class Groups extends AbstractController
 
 		if (!empty($context['group']['assignable']))
 		{
-			loadJavascriptFile('suggest.js', array('defer' => true));
+			loadJavascriptFile('suggest.js', ['defer' => true]);
 		}
 
 		// Select the template.

--- a/sources/ElkArte/Controller/Mentions.php
+++ b/sources/ElkArte/Controller/Mentions.php
@@ -36,7 +36,7 @@ class Mentions extends AbstractController
 	/** @var string The url of the display mentions button (all, unread, etc) */
 	protected $_url_param = '';
 
-	/** @var int Used for pagenation, keeps track of the current start point */
+	/** @var int Used for pagination, keeps track of the current start point */
 	protected $_page = 0;
 
 	/** @var int Number of items per page */

--- a/sources/ElkArte/Controller/News.php
+++ b/sources/ElkArte/Controller/News.php
@@ -421,8 +421,8 @@ class News extends AbstractController
 				$data[] = array(
 					'title' => cdata_parse($row['subject']),
 					'link' => $scripturl . '?topic=' . $row['id_topic'] . '.0',
-					'description' => cdata_parse(strtr(un_htmlspecialchars($row['body']), '&', '&#x26;')),
-					'author' => in_array(showEmailAddress(!empty($row['hide_email']), $row['id_member']), array('yes', 'yes_permission_override')) ? $row['poster_email'] . ' (' . un_htmlspecialchars($row['poster_name']) . ')' : '<![CDATA[none@noreply.net (' . un_htmlspecialchars($row['poster_name']) . ')]]>',
+					'description' => cdata_parse(str_replace('&', '&#x26;', un_htmlspecialchars($row['body']))),
+					'author' => showEmailAddress($row['id_member']) ? $row['poster_email'] . ' (' . un_htmlspecialchars($row['poster_name']) . ')' : '<![CDATA[none@noreply.net (' . un_htmlspecialchars($row['poster_name']) . ')]]>',
 					'comments' => $scripturl . '?action=post;topic=' . $row['id_topic'] . '.0',
 					'category' => '<![CDATA[' . $row['bname'] . ']]>',
 					'pubDate' => gmdate('D, d M Y H:i:s \G\M\T', $row['poster_time']),
@@ -455,7 +455,7 @@ class News extends AbstractController
 					'category' => $row['bname'],
 					'author' => array(
 						'name' => $row['poster_name'],
-						'email' => in_array(showEmailAddress(!empty($row['hide_email']), $row['id_member']), array('yes', 'yes_permission_override')) ? $row['poster_email'] : null,
+						'email' => showEmailAddress($row['id_member']) ? $row['poster_email'] : null,
 						'uri' => empty($row['id_member']) ? '' : $scripturl . '?action=profile;u=' . $row['id_member'],
 					),
 					'published' => Util::gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['poster_time']),
@@ -530,7 +530,7 @@ class News extends AbstractController
 					'title' => $row['subject'],
 					'link' => $scripturl . '?topic=' . $row['id_topic'] . '.msg' . $row['id_msg'] . '#msg' . $row['id_msg'],
 					'description' => cdata_parse(strtr(un_htmlspecialchars($row['body']), '&', '&#x26;')),
-					'author' => in_array(showEmailAddress(!empty($row['hide_email']), $row['id_member']), array('yes', 'yes_permission_override')) ? $row['poster_email'] . ' (' . un_htmlspecialchars($row['poster_name']) . ')' : '<![CDATA[none@noreply.net (' . un_htmlspecialchars($row['poster_name']) . ')]]>',
+					'author' => showEmailAddress($row['id_member']) ? $row['poster_email'] . ' (' . un_htmlspecialchars($row['poster_name']) . ')' : '<![CDATA[none@noreply.net (' . un_htmlspecialchars($row['poster_name']) . ')]]>',
 					'category' => cdata_parse($row['bname']),
 					'comments' => $scripturl . '?action=post;topic=' . $row['id_topic'] . '.0',
 					'pubDate' => gmdate('D, d M Y H:i:s \G\M\T', $row['poster_time']),
@@ -561,7 +561,7 @@ class News extends AbstractController
 					'category' => $row['bname'],
 					'author' => array(
 						'name' => $row['poster_name'],
-						'email' => in_array(showEmailAddress(!empty($row['hide_email']), $row['id_member']), array('yes', 'yes_permission_override')) ? $row['poster_email'] : null,
+						'email' => showEmailAddress($row['id_member']) ? $row['poster_email'] : null,
 						'uri' => empty($row['id_member']) ? '' : $scripturl . '?action=profile;u=' . $row['id_member']
 					),
 					'published' => Util::gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['poster_time']),
@@ -671,7 +671,7 @@ class News extends AbstractController
 				'summary' => cdata_parse($member['group'] ?? $member['post_group']),
 				'author' => array(
 					'name' => $member['real_name'],
-					'email' => in_array(showEmailAddress(!empty($member['hide_email']), $member['id']), array('yes', 'yes_permission_override')) ? $member['email'] : null,
+					'email' => showEmailAddress($member['id']) ? $member['email'] : null,
 					'uri' => empty($member['website']) ? '' : $member['website']['url']
 				),
 				'published' => Util::gmstrftime('%Y-%m-%dT%H:%M:%SZ', $member->date_registered),
@@ -736,7 +736,7 @@ class News extends AbstractController
 				);
 			}
 
-			if (in_array($member['show_email'], array('yes', 'yes_permission_override')))
+			if ($member['show_email'])
 			{
 				$data['email'] = $member['email'];
 			}

--- a/sources/ElkArte/Controller/PersonalMessage.php
+++ b/sources/ElkArte/Controller/PersonalMessage.php
@@ -2561,7 +2561,7 @@ class PersonalMessage extends AbstractController
 					$member['group'] = $txt['guest_title'];
 					$member['link'] = $row['from_name'];
 					$member['email'] = '';
-					$member['show_email'] = showEmailAddress(true, 0);
+					$member['show_email'] = showEmailAddress(0);
 					$member['is_guest'] = true;
 				}
 

--- a/sources/ElkArte/Controller/Register.php
+++ b/sources/ElkArte/Controller/Register.php
@@ -251,7 +251,7 @@ class Register extends AbstractController
 		// Trigger the prepare_context event
 		$this->_events->trigger('prepare_context', array('current_step' => $current_step));
 
-		// See whether we have some pre filled values.
+		// See whether we have some pre-filled values.
 		$context['username'] = $this->_req->getPost('user', '\\ElkArte\\Helper\\Util::htmlspecialchars', '');
 		$context['email'] = $this->_req->getPost('email', '\\ElkArte\\Helper\\Util::htmlspecialchars', '');
 		$context['notify_announcements'] = (int) !empty($this->_req->post->notify_announcements);
@@ -421,9 +421,6 @@ class Register extends AbstractController
 		{
 			$this->_req->post->birthdate = sprintf('%04d-%02d-%02d', empty($this->_req->post->bday3) ? 0 : (int) $this->_req->post->bday3, (int) $this->_req->post->bday1, (int) $this->_req->post->bday2);
 		}
-
-		// By default, assume email is hidden, only show it if we tell it to.
-		$this->_req->post->hide_email = empty($this->_req->post->allow_email) ? 1 : 0;
 
 		// Validate the passed language file.
 		if (isset($this->_req->post->lngfile) && !empty($modSettings['userLanguage']))
@@ -660,8 +657,7 @@ class Register extends AbstractController
 		);
 
 		$possible_bools = array(
-			'notify_announcements', 'notify_regularity', 'notify_send_body',
-			'hide_email', 'show_online',
+			'notify_announcements', 'notify_regularity', 'notify_send_body', 'show_online',
 		);
 
 		if ($has_real_name && trim($this->_req->post->real_name) !== '' && !isReservedName($this->_req->post->real_name) && Util::strlen($this->_req->post->real_name) < 60)

--- a/sources/ElkArte/Languages/Index/English.php
+++ b/sources/ElkArte/Languages/Index/English.php
@@ -656,7 +656,7 @@ $txt['smtp_error'] = 'Ran into problems sending Mail. Error: ';
 $txt['mail_send_unable'] = 'Unable to send mail to the email address \'%1$s\'';
 
 $txt['mlist_search'] = 'Search For Members';
-$txt['mlist_search_email'] = 'Search by email address';
+$txt['mlist_search_email'] = 'Search by email';
 $txt['mlist_search_group'] = 'Search by position';
 $txt['mlist_search_name'] = 'Search by name';
 $txt['mlist_search_website'] = 'Search by website';

--- a/sources/ElkArte/Languages/Who/English.php
+++ b/sources/ElkArte/Languages/Who/English.php
@@ -26,7 +26,6 @@ $txt['whoall_activate'] = 'Activating their account.';
 $txt['whoall_buddy'] = 'Modifying their buddy list.';
 $txt['whoall_coppa'] = 'Filling out parent/guardian consent form.';
 $txt['whoall_credits'] = 'Viewing credits page.';
-$txt['whoall_emailuser'] = 'Sending email to another member.';
 $txt['whoall_groups'] = 'Viewing the member groups page.';
 $txt['whoall_help'] = 'Viewing the <a href="{help_url}">help page</a>.';
 $txt['whoall_quickhelp'] = 'Viewing a help popup.';

--- a/sources/ElkArte/Member.php
+++ b/sources/ElkArte/Member.php
@@ -147,7 +147,7 @@ class Member extends ValuesContainer
 		$this->data['href'] = getUrl('profile', ['action' => 'profile', 'u' => $this->data['id_member'], 'name' => $this->data['real_name']]);
 		$this->data['link'] = '<a href="' . $this->data['href'] . '" title="' . $txt['profile_of'] . ' ' . trim($this->data['real_name']) . '">' . $this->data['real_name'] . '</a>';
 		$this->data['email'] = $this->data['email_address'];
-		$this->data['show_email'] = showEmailAddress(!empty($this->data['hide_email']), $this->data['id_member']);
+		$this->data['show_email'] = showEmailAddress($this->data['id_member']);
 		if (empty($this->data['date_registered']))
 		{
 			$this->data['registered_raw'] = 0;

--- a/sources/ElkArte/MemberLoader.php
+++ b/sources/ElkArte/MemberLoader.php
@@ -93,7 +93,7 @@ class MemberLoader
 		$this->base_select_columns = '
 			COALESCE(lo.log_time, 0) AS is_online, COALESCE(a.id_attach, 0) AS id_attach, a.filename, a.attachment_type,
 			mem.signature, mem.avatar, mem.id_member, mem.member_name,
-			mem.real_name, mem.email_address, mem.hide_email, mem.date_registered, mem.website_title, mem.website_url,
+			mem.real_name, mem.email_address, mem.date_registered, mem.website_title, mem.website_url,
 			mem.birthdate, mem.member_ip, mem.member_ip2, mem.posts, mem.last_login, mem.likes_given, mem.likes_received,
 			mem.karma_good, mem.id_post_group, mem.karma_bad, mem.lngfile, mem.id_group, mem.time_offset, mem.show_online,
 			mg.online_color AS member_group_color, COALESCE(mg.group_name, {string:blank_string}) AS member_group,
@@ -208,7 +208,7 @@ class MemberLoader
 				break;
 			case MemberLoader::SET_MINIMAL:
 				$select_columns = '
-				mem.id_member, mem.member_name, mem.real_name, mem.email_address, mem.hide_email, mem.date_registered,
+				mem.id_member, mem.member_name, mem.real_name, mem.email_address, mem.date_registered,
 				mem.posts, mem.last_login, mem.member_ip, mem.member_ip2, mem.lngfile, mem.id_group';
 				$select_tables = '';
 				break;

--- a/sources/ElkArte/MessagesCallback/DisplayRenderer.php
+++ b/sources/ElkArte/MessagesCallback/DisplayRenderer.php
@@ -65,7 +65,7 @@ class DisplayRenderer extends Renderer
 		$this_member['ip'] = $this->_this_message['poster_ip'] ?? '';
 		$this_member['show_profile_buttons'] = (!empty($this_member['can_view_profile'])
 			|| (!empty($this_member['website']['url']) && !isset($context['disabled_fields']['website']))
-			|| (in_array($this_member['show_email'], ['yes', 'yes_permission_override', 'no_through_forum']))
+			|| $this_member['show_email']
 			|| $context['can_send_pm']);
 
 		$context['id_msg'] = $this->_this_message['id_msg'] ?? '';

--- a/sources/ElkArte/MessagesCallback/PmRenderer.php
+++ b/sources/ElkArte/MessagesCallback/PmRenderer.php
@@ -94,7 +94,7 @@ class PmRenderer extends Renderer
 
 		$member_context['show_profile_buttons'] = (!empty($member_context['can_view_profile'])
 			|| (!empty($member_context['website']['url']) && !isset($context['disabled_fields']['website']))
-			|| (in_array($member_context['show_email'], ['yes', 'yes_permission_override', 'no_through_forum']))
+			|| $member_context['show_email']
 			|| $context['can_send_pm']);
 	}
 

--- a/sources/ElkArte/MessagesCallback/Renderer.php
+++ b/sources/ElkArte/MessagesCallback/Renderer.php
@@ -207,7 +207,7 @@ abstract class Renderer
 		$member_context['group'] = $txt['guest_title'];
 		$member_context['link'] = $this->_this_message[$this->_idx_mapper->name];
 		$member_context['email'] = $this->_this_message['poster_email'] ?? '';
-		$member_context['show_email'] = showEmailAddress(true, 0);
+		$member_context['show_email'] = showEmailAddress(0);
 		$member_context['is_guest'] = true;
 	}
 

--- a/sources/ElkArte/Profile/ProfileFields.php
+++ b/sources/ElkArte/Profile/ProfileFields.php
@@ -384,17 +384,6 @@ class ProfileFields
 					return $isValid;
 				},
 			],
-			'hide_email' => [
-				'type' => 'check',
-				'value' => empty($cur_profile['hide_email']),
-				'label' => $txt['allow_user_email'],
-				'permission' => 'profile_identity',
-				'input_validate' => static function (&$value) {
-					$value = (int) $value === 0 ? 1 : 0;
-
-					return true;
-				},
-			],
 			// Selecting group membership is a complicated one, so we treat it separate!
 			'id_group' => [
 				'type' => 'callback',

--- a/sources/ElkArte/Profile/ProfileOptions.php
+++ b/sources/ElkArte/Profile/ProfileOptions.php
@@ -400,7 +400,7 @@ class ProfileOptions extends AbstractController
 				'fields' => [
 					'member_name', 'real_name', 'date_registered', 'posts', 'lngfile', 'hr',
 					'id_group', 'hr',
-					'email_address', 'hide_email', 'show_online', 'hr',
+					'email_address', 'show_online', 'hr',
 					'passwrd1', 'passwrd2', 'hr',
 					'secret_question', 'secret_answer',
 				],
@@ -410,7 +410,7 @@ class ProfileOptions extends AbstractController
 				'fields' => [
 					'member_name', 'real_name', 'date_registered', 'posts', 'lngfile', 'hr',
 					'id_group', 'hr',
-					'email_address', 'hide_email', 'show_online', 'hr',
+					'email_address', 'show_online', 'hr',
 					'passwrd1', 'passwrd2', 'hr',
 					'secret_question', 'secret_answer', 'hr',
 					'enable_otp', 'otp_secret', 'hr'

--- a/sources/ElkArte/SiteDispatcher.php
+++ b/sources/ElkArte/SiteDispatcher.php
@@ -21,7 +21,7 @@ use ElkArte\Controller\Attachment;
 use ElkArte\Controller\Auth;
 use ElkArte\Controller\BoardIndex;
 use ElkArte\Controller\Display;
-use ElkArte\Controller\Emailuser;
+use ElkArte\Controller\Emailmoderator;
 use ElkArte\Controller\Help;
 use ElkArte\Controller\Members;
 use ElkArte\Controller\MergeTopics;
@@ -118,7 +118,7 @@ class SiteDispatcher
 		'quickmod' => [MessageIndex::class, 'action_quickmod'],
 		'quickmod2' => [Display::class, 'action_quickmod2'],
 		'removetopic2' => [RemoveTopic::class, 'action_removetopic2'],
-		'reporttm' => [Emailuser::class, 'action_reporttm'],
+		'reporttm' => [Emailmoderator::class, 'action_reporttm'],
 		'restoretopic' => [RemoveTopic::class, 'action_restoretopic'],
 		'splittopics' => [SplitTopics::class, 'action_splittopics'],
 		'trackip' => [ProfileHistory::class, 'action_trackip'],

--- a/sources/Security.php
+++ b/sources/Security.php
@@ -1416,48 +1416,28 @@ function boardsAllowedTo($permissions, $check_access = true, $simple = true)
  * What it does:
  *
  * Possible outcomes are:
- * - 'yes': show the full email address
- * - 'yes_permission_override': show the full email address, either you
- * are a moderator or it's your own email address.
- * - 'no_through_forum': don't show the email address, but do allow
- * things to be mailed using the built-in forum mailer.
- * - 'no': keep the email address hidden.
+ *  If it's your own profile yes.
+ *  If you're a moderator with sufficient permissions: yes.
+ *  Otherwise: no
  *
- * @param bool $userProfile_hideEmail
  * @param int $userProfile_id
  *
- * @return string (yes, yes_permission_override, no_through_forum, no)
+ * @return bool
  */
-function showEmailAddress($userProfile_hideEmail, $userProfile_id)
+function showEmailAddress($userProfile_id)
 {
 	// Should this user's email address be shown?
-	// If you're guest: no.
-	// If the user is post-banned: no.
-	// If it's your own profile, and you've not set your address hidden: yes_permission_override.
-	// If you're a moderator with sufficient permissions: yes_permission_override.
-	// If the user has set their profile to do not email me: no.
-	// Otherwise: no_through_forum. (don't show it but allow emailing the member)
-	if (User::$info->is_guest || isset($_SESSION['ban']['cannot_post']))
+	if ((User::$info->is_guest === false && User::$info->id === (int) $userProfile_id))
 	{
-		return 'no';
-	}
-
-	if ((User::$info->is_guest === false && User::$info->id == $userProfile_id && !$userProfile_hideEmail))
-	{
-		return 'yes_permission_override';
+		return true;
 	}
 
 	if (allowedTo('moderate_forum'))
 	{
-		return 'yes_permission_override';
+		return true;
 	}
 
-	if ($userProfile_hideEmail)
-	{
-		return 'no';
-	}
-
-	return 'no_through_forum';
+	return false;
 }
 
 /**

--- a/sources/subs/Members.subs.php
+++ b/sources/subs/Members.subs.php
@@ -714,7 +714,7 @@ function registerMember(&$regOptions, $ErrorContext = 'register')
 	// Right, now let's prepare for insertion.
 	$knownInts = array(
 		'date_registered', 'posts', 'id_group', 'last_login', 'personal_messages', 'unread_messages', 'notifications',
-		'new_pm', 'pm_prefs', 'hide_email', 'show_online', 'pm_email_notify', 'karma_good', 'karma_bad',
+		'new_pm', 'pm_prefs', 'show_online', 'pm_email_notify', 'karma_good', 'karma_bad',
 		'notify_announcements', 'notify_send_body', 'notify_regularity', 'notify_types',
 		'id_theme', 'is_activated', 'id_msg_last_visit', 'id_post_group', 'total_time_logged_in', 'warning',
 	);
@@ -1589,7 +1589,7 @@ function membersBy($query, $query_params, $details = false, $only_active = true)
 	$db->fetchQuery('
 		SELECT
 		 	id_member' . ($details ? ', member_name, real_name, email_address, member_ip, date_registered, last_login,
-			hide_email, posts, is_activated, real_name' : '') . '
+			posts, is_activated, real_name' : '') . '
 		FROM {db_prefix}members
 		WHERE ' . $query_where . (!empty($query_params['order']) ? '
 		ORDER BY {raw:order}' : '') . (isset($query_params['start']) ? '
@@ -1600,12 +1600,13 @@ function membersBy($query, $query_params, $details = false, $only_active = true)
 			// Return all the details for each member found
 			if ($details)
 			{
+				$row['id_member'] = (int) $row['id_member'];
 				$members[$row['id_member']] = $row;
 			}
 			// Or just a int[] of found member id's
 			else
 			{
-				$members[] = $row['id_member'];
+				$members[] = (int) $row['id_member'];
 			}
 		}
 	);
@@ -1856,7 +1857,7 @@ function getBasicMemberData($member_ids, $options = array())
 	// Get some additional member info...
 	$db->fetchQuery('
 		SELECT 
-			id_member, member_name, real_name, email_address, hide_email, posts, id_theme' . (!empty($options['moderation']) ? ',
+			id_member, member_name, real_name, email_address, posts, id_theme' . (!empty($options['moderation']) ? ',
 			member_ip, id_group, additional_groups, last_login, id_post_group' : '') . (!empty($options['authentication']) ? ',
 		secret_answer, secret_question, is_activated, validation_code, passwd_flood, password_salt' : '') . (!empty($options['preferences']) ? ',
 			lngfile, mod_prefs, notify_types, signature' : '') . '
@@ -2704,7 +2705,7 @@ function updateMemberData($members, $data)
 	// Everything is assumed to be a string unless it's in the below.
 	$knownInts = array(
 		'date_registered', 'posts', 'id_group', 'last_login', 'personal_messages', 'unread_messages', 'mentions',
-		'new_pm', 'pm_prefs', 'hide_email', 'show_online', 'pm_email_notify', 'receive_from', 'karma_good', 'karma_bad',
+		'new_pm', 'pm_prefs', 'show_online', 'pm_email_notify', 'receive_from', 'karma_good', 'karma_bad',
 		'notify_announcements', 'notify_send_body', 'notify_regularity', 'notify_types',
 		'id_theme', 'is_activated', 'id_msg_last_visit', 'id_post_group', 'total_time_logged_in', 'warning', 'likes_given',
 		'likes_received', 'enable_otp', 'otp_used'
@@ -2724,7 +2725,6 @@ function updateMemberData($members, $data)
 			'birthdate',
 			'website_title',
 			'website_url',
-			'hide_email',
 			'time_format',
 			'time_offset',
 			'avatar',

--- a/sources/subs/Messages.subs.php
+++ b/sources/subs/Messages.subs.php
@@ -813,7 +813,7 @@ function mailFromMessage($id_msg)
 
 	$request = $db->query('', '
 		SELECT 
-			COALESCE(mem.email_address, m.poster_email) AS email_address, COALESCE(mem.real_name, m.poster_name) AS real_name, COALESCE(mem.id_member, 0) AS id_member, hide_email
+			COALESCE(mem.email_address, m.poster_email) AS email_address, COALESCE(mem.real_name, m.poster_name) AS real_name, COALESCE(mem.id_member, 0) AS id_member
 		FROM {db_prefix}messages AS m
 			LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = m.id_member)
 		WHERE m.id_msg = {int:id_msg}',

--- a/sources/subs/News.subs.php
+++ b/sources/subs/News.subs.php
@@ -229,7 +229,7 @@ function getXMLNews($query_this_board, $board, $limit)
 				m.smileys_enabled, m.poster_time, m.id_msg, m.subject, m.body, m.modified_time,
 				m.icon, t.id_topic, t.id_board, t.num_replies,
 				b.name AS bname,
-				mem.hide_email, COALESCE(mem.id_member, 0) AS id_member,
+				COALESCE(mem.id_member, 0) AS id_member,
 				COALESCE(mem.email_address, m.poster_email) AS poster_email,
 				COALESCE(mem.real_name, m.poster_name) AS poster_name
 			FROM {db_prefix}topics AS t
@@ -364,7 +364,7 @@ function getXMLRecent($query_this_board, $board, $limit)
 			m.smileys_enabled, m.poster_time, m.id_msg, m.subject, m.body, m.id_topic, t.id_board,
 			b.name AS bname, t.num_replies, m.id_member, m.icon, mf.id_member AS id_first_member,
 			COALESCE(mem.real_name, m.poster_name) AS poster_name, mf.subject AS first_subject,
-			COALESCE(memf.real_name, mf.poster_name) AS first_poster_name, mem.hide_email,
+			COALESCE(memf.real_name, mf.poster_name) AS first_poster_name,
 			COALESCE(mem.email_address, m.poster_email) AS poster_email, m.modified_time
 		FROM {db_prefix}messages AS m
 			INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)

--- a/sources/subs/PersonalMessage.subs.php
+++ b/sources/subs/PersonalMessage.subs.php
@@ -1018,7 +1018,7 @@ function query_sender_wrapper($from)
 	// The signature and email visibility details
 	$request = $db->query('', '
 		SELECT
-			hide_email, email_address, signature
+			email_address, signature
 		FROM {db_prefix}members
 		WHERE id_member  = {int:uid}
 			AND is_activated = {int:act}

--- a/tests/ElkArte/Controller/EmailModeratorTest.php
+++ b/tests/ElkArte/Controller/EmailModeratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * TestCase class for the EmailUser Controller
+ * TestCase class for the EmailModerator Controller
  *
  * WARNING. These tests work directly with the local database. Don't run
  * them local if you need to keep your data untouched!
@@ -16,7 +16,7 @@ use ElkArte\Languages\Loader;
 use ElkArte\User;
 use tests\ElkArteCommonSetupTest;
 
-class EmailUserTest extends ElkArteCommonSetupTest
+class EmailModeratorTest extends ElkArteCommonSetupTest
 {
 	protected $backupGlobalsExcludeList = ['user_info'];
 
@@ -61,7 +61,7 @@ class EmailUserTest extends ElkArteCommonSetupTest
 		$req->post->email = 'complainer@nowhere.tld';
 
 		// Get the controller
-		$controller = new Emailuser(new EventManager());
+		$controller = new Emailmoderator(new EventManager());
 		$controller->setUser(User::$info);
 		$controller->pre_dispatch();
 		$controller->action_reporttm();

--- a/tests/ElkArte/Controller/ModerationCenterTest.php
+++ b/tests/ElkArte/Controller/ModerationCenterTest.php
@@ -72,7 +72,7 @@ class ModerationCenterTest extends ElkArteCommonSetupTest
 	/**
 	 * Show a reported post listing
 	 *
-	 * Test testActionReporttm in EmailUserTest.php made a report, we depend on that
+	 * Test testActionReporttm in EmailModeratorTest.php made a report, we depend on that
 	 * being run first.  That order dependency should be defined in the XML at some point
 	 */
 	public function testActionReportedPosts()

--- a/themes/default/Emailmoderator.template.php
+++ b/themes/default/Emailmoderator.template.php
@@ -15,7 +15,7 @@
 /**
  * The report sub-template needs some error stuff
  */
-function template_Emailuser_init()
+function template_Emailmoderator_init()
 {
 	global $context, $txt;
 
@@ -53,109 +53,6 @@ function template_Emailuser_init()
 }
 
 /**
- * Send an email to a user!
- */
-function template_custom_email()
-{
-	global $context, $txt, $scripturl;
-
-	template_show_error('sendemail_error');
-
-	echo '
-	<div id="send_topic">
-		<form action="', $scripturl, '?action=emailuser;sa=email" method="post" accept-charset="UTF-8">
-			<h2 class="category_header hdicon i-envelope">
-				', $context['page_title'], '
-			</h2>
-			<div class="content">
-				<dl class="settings send_mail">
-					<dt>
-						<strong>', $txt['sendtopic_receiver_name'], ':</strong>
-					</dt>
-					<dd>
-						', $context['recipient']['link'], '
-					</dd>';
-
-	// Can the user see the persons email?
-	if ($context['can_view_recipient_email'])
-	{
-		echo '
-					<dt>
-						<strong>', $txt['sendtopic_receiver_email'], ':</strong>
-					</dt>
-					<dd>
-						', $context['recipient']['email_link'], '
-					</dd>
-				</dl>
-				<hr />
-				<dl class="settings send_mail">';
-	}
-
-	// If it's a guest we need their details.
-	if ($context['user']['is_guest'])
-	{
-		echo '
-					<dt>
-						<label for="y_name">', $txt['sendtopic_sender_name'], ':</label>
-					</dt>
-					<dd>
-						<input type="text" id="y_name" name="y_name" size="24" maxlength="40" value="', $context['user']['name'], '" class="input_text" />
-					</dd>
-					<dt>
-						<label for="y_email">', $txt['sendtopic_sender_email'], ':</label><br />
-						<span class="smalltext">', $txt['send_email_disclosed'], '</span>
-					</dt>
-					<dd>
-						<input type="text" id="y_mail" name="y_email" size="24" maxlength="50" value="', $context['user']['email'], '" class="input_text" />
-					</dt>';
-	}
-	// Otherwise show the user that we know their email.
-	else
-	{
-		echo '
-					<dt>
-						<strong>', $txt['sendtopic_sender_email'], ':</strong><br />
-						<span class="smalltext">', $txt['send_email_disclosed'], '</span>
-					</dt>
-					<dd>
-						<em>', $context['user']['email'], '</em>
-					</dd>';
-	}
-
-	echo '
-					<dt>
-						<label for="email_subject">', $txt['send_email_subject'], ':</label>
-					</dt>
-					<dd>
-						<input type="text" id="email_subject" name="email_subject" size="50" maxlength="100" class="input_text" />
-					</dd>
-					<dt>
-						<label for="email_body">', $txt['message'], ':</label>
-					</dt>
-					<dd>
-						<textarea id="email_body" name="email_body" rows="10" cols="20"></textarea>
-					</dd>
-				</dl>
-				<hr />
-				<div class="submitbutton">
-					<input type="submit" name="send" value="', $txt['sendtopic_send'], '" />';
-
-
-	foreach ($context['form_hidden_vars'] as $key => $value)
-	{
-		echo '
-					<input type="hidden" name="', $key, '" value="', $value, '" />';
-	}
-
-	echo '
-					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
-				</div>
-			</div>
-		</form>
-	</div>';
-}
-
-/**
  * The report sub template gets shown from:
  *  '?action=reporttm;topic=##.##;msg=##'
  * It should submit to:
@@ -163,7 +60,7 @@ function template_custom_email()
  *
  * It only needs to send the following fields:
  *  comment: an additional comment to give the moderator.
- *  sc: the session id, or $context['session_id'].
+ *  sessionDI: $context['session_id'].
  */
 function template_report()
 {

--- a/themes/default/GenericMessages.template.php
+++ b/themes/default/GenericMessages.template.php
@@ -197,7 +197,7 @@ function template_build_poster_div($message, $ignoring = false)
 			if ($context['can_send_email'])
 			{
 				$poster_div .= '
-									<li>' . template_msg_email($message['id'], $message['member']) . '</li>';
+									<li>' . template_member_email($message['member']) . '</li>';
 			}
 
 			$poster_div .= '
@@ -222,7 +222,7 @@ function template_build_poster_div($message, $ignoring = false)
 	elseif (!empty($message['member']['email']) && $context['can_send_email'])
 	{
 		$poster_div .= '
-							<li class="listlevel2 email">' . template_msg_email($message['id']) . '</li>';
+							<li class="listlevel2 email">' . template_member_email($message['member']) . '</li>';
 	}
 
 	// Stuff for the staff to wallop them with.

--- a/themes/default/Register.template.php
+++ b/themes/default/Register.template.php
@@ -17,17 +17,20 @@ function template_mailcheck_javascript()
 	global $txt;
 
 	theme()->addInlineJavascript('disableAutoComplete();
-	$("input[type=email]").on("blur", function(event) {
-		$(this).mailcheck({
-			suggested: function(element, suggestion) {
-					$("#suggestion").html("' . $txt['register_did_you'] . ' <b><i>" + suggestion.full + "</b></i>");
-					element.addClass("check_input");
-			},
-			empty: function(element) {
-				$("#suggestion").html("");
-				element.removeClass("check_input");
-			}
-		});
+	document.querySelectorAll("input[type=email]").forEach(function(input) {
+	
+	    input.addEventListener("blur", function(event) {
+	        $(this).mailcheck({
+	            suggested: function(input, suggestion) {
+	                document.getElementById("suggestion").innerHTML = "<i class=\"icon i-warn\"></i>' . $txt['register_did_you'] . ' <b><i>" + suggestion.full + "</b></i>";
+	                input[0].classList.add("check_input");
+	            },
+	            empty: function() {
+	                document.getElementById("suggestion").innerHTML = "";
+	                input[0].classList.remove("check_input");
+	            }
+	        });
+	    });
 	});', true);
 }
 
@@ -174,7 +177,6 @@ function template_registration_form()
 		<form action="', getUrl('atcion', ['action' => 'register', 'sa' => 'register2']), '" method="post" accept-charset="UTF-8" name="registration" id="registration" onsubmit="return verifyAgree();">
 			<h2 class="category_header">', $txt['registration_form'], '</h2>
 			<input type="text" name="reason_for_joining_hp" class="hide" autocomplete="off" />
-			<input type="hidden" name="allow_email" value="0" />
 			<div class="content">
 				<div class="form_container">
 					<div class="form_field w_icon">

--- a/themes/default/Xml.template.php
+++ b/themes/default/Xml.template.php
@@ -113,7 +113,7 @@ function template_post()
 		<subject><![CDATA[', $context['preview_subject'], ']]></subject>
 		<body><![CDATA[', $context['preview_message'], ']]></body>
 	</preview>
-	<errors serious="', empty($context['errors']['type']) || $context['errors']['type'] != 'serious' ? '0' : '1', '" topic_locked="', $context['locked'] ? '1' : '0', '">';
+	<errors serious="', empty($context['errors']['type']) || $context['errors']['type'] !== 'serious' ? '0' : '1', '" topic_locked="', $context['locked'] ? '1' : '0', '">';
 
 	if (!empty($context['post_error']['errors']))
 	{
@@ -468,7 +468,7 @@ function template_generic_xml_recursive($xml_data, $parent_ident, $child_ident, 
 
 /**
  * Formats data retrieved in other functions into xml format.
- * Additionally formats data based on the specific format passed.
+ * Additionally, formats data based on the specific format passed.
  * This function is recursively called to handle sub arrays of data.
  *
  * @param mixed[] $data the array to output as xml data

--- a/themes/default/css/icons_svg.css
+++ b/themes/default/css/icons_svg.css
@@ -708,7 +708,7 @@ legend::before, .i-caret-down::before {
 }
 
 .i-warning-mute::before, .i-post_moderation_deny::before, .i-fail::before,
-.i-alert::before, .i-warn::before, .i-exclamation::before,
+.i-alert::before, .i-exclamation::before,
 .i-dot-red::before,
 .i-mark_unread::before {
 	filter: invert(30%) sepia(65%) saturate(2235%) hue-rotate(342deg) brightness(102%) contrast(91%);

--- a/themes/default/css/index.css
+++ b/themes/default/css/index.css
@@ -5253,7 +5253,7 @@ div.labels {
 
 #mlsearch_options .mlsearch_option input[type="checkbox"] {
 	float: right;
-	margin: 0 0 0 0.5em;
+	margin: 0.5em 0 0 0.5em;
 }
 
 #mlsearch_options .mlsearch_option {
@@ -5323,6 +5323,10 @@ div.labels {
 /* The admin logon form */
 #admin_login {
 	padding: .8em;
+}
+
+.invalid_input, .check_input {
+	border: 2px solid;
 }
 
 /* -------------------------------------------------------

--- a/themes/default/index.template.php
+++ b/themes/default/index.template.php
@@ -834,62 +834,27 @@ function template_member_online($member, $link = true)
  */
 function template_member_email($member, $text = false)
 {
-	global $context, $txt, $scripturl;
+	global $context, $txt;
 
 	if ($context['can_send_email'])
 	{
 		if ($text)
 		{
-			if ($member['show_email'] === 'no_through_forum')
+			if ($member !== false && $member['show_email'])
 			{
-				return '<a class="linkbutton" href="' . $scripturl . '?action=emailuser;sa=email;uid=' . $member['id'] . '">' . $txt['email'] . '</a>';
-			}
-
-			if ($member['show_email'] === 'yes_permission_override' || $member['show_email'] === 'yes')
-			{
-				return '<a class="linkbutton" href="' . $scripturl . '?action=emailuser;sa=email;uid=' . $member['id'] . '">' . $member['email'] . '</a>';
+				return '<a class="linkbutton" href="mailto:' . $member['email'] . '" rel="nofollow">' . $txt['email'] . '</a>';
 			}
 
 			return $txt['hidden'];
 		}
 
-		if ($member['show_email'] !== 'no')
+		if ($member !== false && $member['show_email'])
 		{
-			return '<a href="' . $scripturl . '?action=emailuser;sa=email;uid=' . $member['id'] . '" class="icon i-envelope-o' . ($member['online']['is_online'] ? '' : '-blank') . '" title="' . $txt['email'] . ' ' . $member['name'] . '"><s>' . $txt['email'] . ' ' . $member['name'] . '</s></a>';
+			return '<a href="mailto:' . $member['email'] . '" rel="nofollow" class="icon i-envelope-o' . ($member['online']['is_online'] ? '' : '-blank') . '" title="' . $txt['email'] . ' ' . $member['name'] . '"><s>' . $txt['email'] . ' ' . $member['name'] . '</s></a>';
 		}
 
 		return '<i class="icon i-envelope-o" title="' . $txt['email'] . ' ' . $txt['hidden'] . '"><s>' . $txt['email'] . ' ' . $txt['hidden'] . '</s></i>';
 	}
 
 	return '';
-}
-
-/**
- * Sometimes we only get a message id.
- *
- * @param      $id
- * @param bool|mixed[] $member
- *
- * @return string
- */
-function template_msg_email($id, $member = false)
-{
-	global $context, $txt, $scripturl;
-
-	if (!$context['can_send_email'])
-	{
-		return '';
-	}
-
-	if ($member === false || $member['show_email'] !== 'no')
-	{
-		if (empty($member['id']))
-		{
-			return '<a href="' . $scripturl . '?action=emailuser;sa=email;msg=' . $id . '" class="icon i-envelope-o' . (($member !== false && $member['online']['is_online']) ? '' : '-blank') . '" title="' . $txt['email'] . '"><s>' . $txt['email'] . '</s></a>';
-		}
-
-		return '<a href="' . $scripturl . '?action=emailuser;sa=email;uid=' . $member['id'] . '" class="icon i-envelope-o' . (($member !== false && $member['online']['is_online']) ? '' : '-blank') . '" title="' . $txt['email'] . '"><s>' . $txt['email'] . '</s></a>';
-	}
-
-	return '<i class="icon i-envelope-o" title="' . $txt['email'] . ' ' . $txt['hidden'] . '"><s>' . $txt['email'] . ' ' . $txt['hidden'] . '</s></i>';
 }


### PR DESCRIPTION
This was a rather dated option, and most never want their email shared on a forum anyway.  They can always PM and ask to take it to email.

With this change only mods (and the user) can see an email.  Only mods can search by email.  Email envelope is not shown unless you have those permissions (it used to show but say hidden).  Uses mailto: on links for the few that can email.  Simplifies the email checks etc.