### PR TITLE
Attempt to fix why coverage data is not found

### DIFF
--- a/.github/setup-failure.sh
+++ b/.github/setup-failure.sh
@@ -10,9 +10,10 @@ set +x
 # Passed params
 DB=$1
 PHP_VERSION=$2
+CODECOV_TOKEN=$3
 
 # Agents will merge all coverage data...
 if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]
 then
-    bash <(curl -s https://codecov.io/bash) -s "/tmp" -f '*.clover'
+    bash <(curl -s https://codecov.io/bash) -s "/tmp" -f '*.xml' -t "${CODECOV_TOKEN}"
 fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,28 +78,21 @@ jobs:
         run: .github/setup-elkarte.sh $DB $PHP_VERSION
         working-directory: ./elkarte
 
-      - name: Download Selenium
-        run: |
-          sudo mkdir -p /usr/share/selenium
-          wget -nv -O /usr/share/selenium/selenium-server-standalone.jar https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar
-          sudo chmod 777 /usr/share/selenium/selenium-server-standalone.jar
-
-      - name: Setup ChromeDriver
-        uses: nanasess/setup-chromedriver@v2
-
-      - name: Start ChromeDriver
-        run: |
-          export DISPLAY=:99.0
-          xvfb-run --server-args="-screen 0, 2560x1440x24" java -Dwebdriver.chrome.driver=/usr/local/bin/chromedriver -jar /usr/share/selenium/selenium-server-standalone.jar > /tmp/selenium.log &
-
       - name: Run Unit Tests
         env:
           DB: ${{ matrix.db }}
           PHP_VERSION: ${{ matrix.php }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: .github/setup-selenium.sh $DB $PHP_VERSION $CODECOV_TOKEN
+        run: .github/setup-selenium.sh $DB $PHP_VERSION
         working-directory: ./elkarte
         continue-on-error: true
+
+      - name: Code Coverage
+        env:
+          DB: ${{ matrix.db }}
+          PHP_VERSION: ${{ matrix.php }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: .github/setup-failure.sh $DB $PHP_VERSION $CODECOV_TOKEN
+        working-directory: ./elkarte
 
       - name: Server Error Log
         env:
@@ -108,8 +101,7 @@ jobs:
         run: |
           sudo cat /var/log/nginx/127.0.0.1.error.log
           sudo cat /tmp/php_errors.log
-          # sudo cat /tmp/selenium.log
-          .github/setup-failure.sh $DB $PHP_VERSION
+          sudo cat /tmp/selenium.log
         working-directory: ./elkarte
   # End Selenium headless browser testing
 


### PR DESCRIPTION
The code coverage results are not being found when chrome / chromedriver / selenium are installed via actions.  No idea why not or if they are being created "where" ... This pulls those back into our  .sh scripts, as it had been, to see if that fixes the issue