### PR TITLE
News Letter Updates

### DIFF
--- a/sources/ElkArte/AdminController/ManageMembergroups.php
+++ b/sources/ElkArte/AdminController/ManageMembergroups.php
@@ -60,7 +60,7 @@ class ManageMembergroups extends AbstractController
 			'delete' => [$this, 'action_delete', 'permission' => 'manage_membergroups'],
 			'edit' => [$this, 'action_edit', 'permission' => 'manage_membergroups'],
 			'index' => [$this, 'action_list', 'permission' => 'manage_membergroups'],
-			'members' => [Groups::class, 'action_index', 'permission' => 'manage_membergroups'],
+			'members' => ['controller' => Groups::class, 'function' => 'action_index', 'permission' => 'manage_membergroups'],
 			'settings' => [$this, 'action_groupSettings_display', 'permission' => 'admin_forum'],
 		];
 

--- a/sources/ElkArte/AdminController/ManageNews.php
+++ b/sources/ElkArte/AdminController/ManageNews.php
@@ -20,6 +20,8 @@ use ElkArte\AbstractController;
 use ElkArte\Action;
 use ElkArte\Helper\Util;
 use ElkArte\Languages\Txt;
+use ElkArte\Mail\BuildMail;
+use ElkArte\Mail\PreparseMail;
 use ElkArte\SettingsForm\SettingsForm;
 
 /**
@@ -388,8 +390,7 @@ class ManageNews extends AbstractController
 			$context['recipients']['exclude_groups'] = empty($this->_req->post->exclude_groups) ? [] : explode(',', $this->_req->post->exclude_groups);
 			$context['total_emails'] = 0;
 			$context['max_id_member'] = $this->_req->getPost('max_id_member', 'intval', 0);
-			$context['send_pm'] = $this->_req->getPost('send_pm', 'isset', false);
-			$context['send_html'] = $this->_req->getPost('send_html', 'isset', false);
+			$context['send_pm'] = $this->_req->getPost('send_pm', 'intval', 0);
 
 			prepareMailingForPreview();
 
@@ -545,7 +546,7 @@ class ManageNews extends AbstractController
 	 */
 	public function action_mailingsend(bool $clean_only = false): void
 	{
-		global $txt, $context, $scripturl, $modSettings;
+		global $txt, $context, $scripturl, $modSettings, $mbname;
 
 		// A nice successful screen if you did it
 		if ($this->_req->hasQuery('success'))
@@ -571,10 +572,7 @@ class ManageNews extends AbstractController
 		$context['start'] = $this->_req->getPost('start', 'intval', 0);
 		$context['total_emails'] = $this->_req->getPost('total_emails', 'intval', 0);
 		$context['max_id_member'] = $this->_req->getPost('max_id_member', 'intval', 0);
-		$context['send_pm'] = $this->_req->getPost('send_pm', 'isset', false);
-		$context['send_html'] = $this->_req->getPost('send_html', 'isset', false);
-		$context['parse_html'] = $this->_req->getPost('parse_html', 'isset', false);
-
+		$context['send_pm'] = $this->_req->getPost('send_pm', 'intval', 0);
 
 		// How many to send at once? Quantity depends on whether we are queueing or not.
 		$num_at_once = empty($modSettings['mail_queue']) ? 60 : 1000;
@@ -673,29 +671,6 @@ class ManageNews extends AbstractController
 		$context['subject'] = Util::htmlspecialchars($base_subject);
 		$context['message'] = Util::htmlspecialchars($base_message);
 
-		// Prepare the message for sending it as HTML
-		if (!$context['send_pm'] && !empty($context['send_html']))
-		{
-			// Prepare the message for HTML.
-			if (!empty($context['parse_html']))
-			{
-				$base_message = str_replace(["\n", '  '], ['<br />' . "\n", '&nbsp; '], $base_message);
-			}
-
-			// This is here to prevent spam filters from tagging this as spam.
-			if (preg_match('~<html~i', $base_message) == 0)
-			{
-				if (preg_match('~<body~i', $base_message) == 0)
-				{
-					$base_message = '<html><head><title>' . $base_subject . '</title></head>' . "\n" . '<body>' . $base_message . '</body></html>';
-				}
-				else
-				{
-					$base_message = '<html>' . $base_message . '</html>';
-				}
-			}
-		}
-
 		// Something to send?
 		if (empty($base_message) || empty($base_subject))
 		{
@@ -716,17 +691,14 @@ class ManageNews extends AbstractController
 			'{$latest_member.name}'
 		];
 
-		// We might need this in a bit
-		$cleanLatestMember = empty($context['send_html']) || $context['send_pm'] ? un_htmlspecialchars($modSettings['latestRealName']) : $modSettings['latestRealName'];
-
 		// Replace in all the standard things.
 		$base_message = str_replace($variables,
 			[
-				empty($context['send_html']) ? $scripturl : '<a href="' . $scripturl . '">' . $scripturl . '</a>',
+				'<a href="' . $scripturl . '">' . $mbname . '</a>',
 				standardTime(forum_time(), false),
-				empty($context['send_html']) ? ($context['send_pm'] ? '[url=' . getUrl('profile', ['action' => 'profile', 'u' => $modSettings['latestMember'], 'name' => $cleanLatestMember]) . ']' . $cleanLatestMember . '[/url]' : $cleanLatestMember) : ('<a href="' . getUrl('profile', ['action' => 'profile', 'u' => $modSettings['latestMember'], 'name' => $cleanLatestMember]) . '">' . $cleanLatestMember . '</a>'),
+				'<a href="' . getUrl('profile', ['action' => 'profile', 'u' => $modSettings['latestMember'], 'name' => $modSettings['latestRealName']]) . '">' . $modSettings['latestRealName'] . '</a>',
 				$modSettings['latestMember'],
-				$cleanLatestMember
+				$modSettings['latestRealName']
 			], $base_message);
 
 		$base_subject = str_replace($variables,
@@ -738,11 +710,11 @@ class ManageNews extends AbstractController
 				$modSettings['latestRealName']
 			], $base_subject);
 
-		$from_member = [
+		$to_member = [
 			'{$member.email}',
 			'{$member.link}',
 			'{$member.id}',
-			'{$member.name}'
+			'{$member.name}',
 		];
 
 		// Got some more to send this batch?
@@ -804,7 +776,10 @@ class ManageNews extends AbstractController
 			$sendQuery .= ' AND mem.notify_announcements = {int:notify_announcements}';
 			$sendParams['notify_announcements'] = 1;
 
+			// We need some functions for this.
 			require_once(SUBSDIR . '/News.subs.php');
+			require_once(SUBSDIR . '/Notification.subs.php');
+			$mailPreparse = new PreparseMail();
 
 			// Get the smelly people - note we respect the id_member range as it gives us a quicker query.
 			$recipients = getNewsletterRecipients($sendQuery, $sendParams, $context['start'], $num_at_once, $i);
@@ -822,19 +797,22 @@ class ManageNews extends AbstractController
 					continue;
 				}
 
-				// We might need this
-				$cleanMemberName = empty($context['send_html']) || $context['send_pm'] ? un_htmlspecialchars($row['real_name']) : $row['real_name'];
+				// Generate the unsubscribe link for this member
+				$unsubscribeLink = replaceBasicActionUrl('{script_url}?action=notify;sa=unsubscribe;token=' .
+					getNotifierToken($row['id_member'], $row['email_address'], $row['password_salt'], 'newsletters', ''));
 
 				// Replace the member-dependant variables
-				$message = str_replace($from_member,
+				$message = str_replace($to_member,
 					[
 						$row['email_address'],
-						empty($context['send_html']) ? ($context['send_pm'] ? '[url=' . getUrl('profile', ['action' => 'profile', 'u' => $row['id_member'], 'name' => $cleanMemberName]) . ']' . $cleanMemberName . '[/url]' : $cleanMemberName) : ('<a href="' . getUrl('profile', ['action' => 'profile', 'u' => $row['id_member'], 'name' => $cleanMemberName]) . '">' . $cleanMemberName . '</a>'),
+						'<a href="' . getUrl('profile', ['action' => 'profile', 'u' => $row['id_member'], 'name' => $row['real_name']]) . '">' . $row['real_name'] . '</a>',
 						$row['id_member'],
-						$cleanMemberName,
+						$row['real_name'],
 					], $base_message);
 
-				$subject = str_replace($from_member,
+				$message = $mailPreparse->preparseHtml($message);
+
+				$subject = str_replace($to_member,
 					[
 						$row['email_address'],
 						$row['real_name'],
@@ -845,7 +823,17 @@ class ManageNews extends AbstractController
 				// Send the actual email - or a PM!
 				if (!$context['send_pm'])
 				{
-					sendmail($row['email_address'], $subject, $message, null, null, !empty($context['send_html']), 5);
+					// Use BuildMail directly
+					$mail = new BuildMail();
+					$mail->setLanguage($row['lngfile']);
+					$mail->setEmailReplacements([
+						'UNSUBSCRIBELINK' => $unsubscribeLink,
+					]);
+					$message = $mail->getBasicHTMLVersion($message);
+					//$message = str_replace('{UNSUBSCRIBELINK}', $unsubscribeLink, $message);
+
+					// Send with priority 5 (newsletter) to bypass PBE
+					$mail->buildEmail($row['email_address'], $subject, $message, null, null, true, 5);
 				}
 				else
 				{

--- a/sources/ElkArte/AdminController/ManageNews.php
+++ b/sources/ElkArte/AdminController/ManageNews.php
@@ -269,7 +269,7 @@ class ManageNews extends AbstractController
 	 * - Requires the send_mail permission.
 	 * - Form is submitted to ?action=admin;area=news;mailingcompose.
 	 *
-	 * @uses the ManageNews template and email_members sub template.
+	 * @uses ManageNews template and email_members sub template.
 	 */
 	public function action_mailingmembers(): void
 	{
@@ -386,8 +386,7 @@ class ManageNews extends AbstractController
 			$context['recipients']['exclude_members'] = empty($this->_req->post->exclude_members) ? [] : explode(',', $this->_req->post->exclude_members);
 			$context['recipients']['groups'] = empty($this->_req->post->groups) ? [] : explode(',', $this->_req->post->groups);
 			$context['recipients']['exclude_groups'] = empty($this->_req->post->exclude_groups) ? [] : explode(',', $this->_req->post->exclude_groups);
-			$context['recipients']['emails'] = empty($this->_req->post->emails) ? [] : explode(';', $this->_req->post->emails);
-			$context['total_emails'] = $this->_req->getPost('total_emails', 'intval', 0);
+			$context['total_emails'] = 0;
 			$context['max_id_member'] = $this->_req->getPost('max_id_member', 'intval', 0);
 			$context['send_pm'] = $this->_req->getPost('send_pm', 'isset', false);
 			$context['send_html'] = $this->_req->getPost('send_html', 'isset', false);
@@ -435,7 +434,7 @@ class ManageNews extends AbstractController
 		require_once(SUBSDIR . '/Members.subs.php');
 
 		// For the progress bar!
-		$context['total_emails'] = count($context['recipients']['emails']);
+		$context['total_emails'] = 0;
 		$context['max_id_member'] = maxMemberID();
 
 		// Make sure to fully load the array with the form choices
@@ -592,7 +591,6 @@ class ManageNews extends AbstractController
 			'exclude_groups' => [],
 			'members' => [],
 			'exclude_members' => [],
-			'emails' => [],
 		];
 
 		// Do we have any excluded members?
@@ -652,20 +650,6 @@ class ManageNews extends AbstractController
 			foreach ($groups as $group)
 			{
 				$context['recipients']['exclude_groups'][] = (int) $group;
-			}
-		}
-
-		// Finally - emails!
-		if (!empty($this->_req->post->emails))
-		{
-			$addressed = array_unique(explode(';', strtr($this->_req->post->emails, ["\n" => ';', "\r" => ';', ',' => ';'])));
-			foreach ($addressed as $curmem)
-			{
-				$curmem = trim($curmem);
-				if ($curmem !== '')
-				{
-					$context['recipients']['emails'][$curmem] = $curmem;
-				}
 			}
 		}
 
@@ -760,39 +744,8 @@ class ManageNews extends AbstractController
 			'{$member.name}'
 		];
 
-		// If we still have emails, do them first!
-		$i = 0;
-		foreach ($context['recipients']['emails'] as $k => $email)
-		{
-			// Done as many as we can?
-			if ($i >= $num_at_once)
-			{
-				break;
-			}
-
-			// Don't send it twice!
-			unset($context['recipients']['emails'][$k]);
-
-			// Dammit - can't PM emails!
-			if ($context['send_pm'])
-			{
-				continue;
-			}
-
-			$to_member = [
-				$email,
-				empty($context['send_html']) ? $email : '<a href="mailto:' . $email . '">' . $email . '</a>',
-				'??',
-				$email
-			];
-
-			sendmail($email, str_replace($from_member, $to_member, $base_subject), str_replace($from_member, $to_member, $base_message), null, null, !empty($context['send_html']), 5);
-
-			// Done another...
-			$i++;
-		}
-
 		// Got some more to send this batch?
+		$i = 0;
 		$last_id_member = 0;
 		if ($i < $num_at_once)
 		{
@@ -911,7 +864,7 @@ class ManageNews extends AbstractController
 			$last_id_member = $context['start'] + $num_at_once;
 		}
 		// If we have no id_member, then we're done.
-		elseif (empty($last_id_member) && empty($context['recipients']['emails']))
+		elseif (empty($last_id_member))
 		{
 			// Log this into the admin log.
 			logAction('newsletter', [], 'admin');
@@ -921,9 +874,7 @@ class ManageNews extends AbstractController
 		$context['start'] = $last_id_member;
 
 		// Working out progress is a black art of sorts.
-		$percentEmails = $context['total_emails'] == 0 ? 0 : ((count($context['recipients']['emails']) / $context['total_emails']) * ($context['total_emails'] / ($context['total_emails'] + $context['max_id_member'])));
-		$percentMembers = ($context['start'] / $context['max_id_member']) * ($context['max_id_member'] / ($context['total_emails'] + $context['max_id_member']));
-		$context['percentage_done'] = round(($percentEmails + $percentMembers) * 100, 2);
+		$context['percentage_done'] = round(($context['start'] / $context['max_id_member']) * 100);
 
 		$context['page_title'] = $txt['admin_newsletters'];
 		$context['sub_template'] = 'email_members_send';

--- a/sources/ElkArte/AdminController/ManageNews.php
+++ b/sources/ElkArte/AdminController/ManageNews.php
@@ -387,7 +387,6 @@ class ManageNews extends AbstractController
 			$context['recipients']['groups'] = empty($this->_req->post->groups) ? [] : explode(',', $this->_req->post->groups);
 			$context['recipients']['exclude_groups'] = empty($this->_req->post->exclude_groups) ? [] : explode(',', $this->_req->post->exclude_groups);
 			$context['recipients']['emails'] = empty($this->_req->post->emails) ? [] : explode(';', $this->_req->post->emails);
-			$context['email_force'] = $this->_req->getPost('email_force', 'isset', false);
 			$context['total_emails'] = $this->_req->getPost('total_emails', 'intval', 0);
 			$context['max_id_member'] = $this->_req->getPost('max_id_member', 'intval', 0);
 			$context['send_pm'] = $this->_req->getPost('send_pm', 'isset', false);
@@ -581,7 +580,6 @@ class ManageNews extends AbstractController
 
 		// Where are we actually to?
 		$context['start'] = $this->_req->getPost('start', 'intval', 0);
-		$context['email_force'] = $this->_req->getPost('email_force', 'isset', false);
 		$context['total_emails'] = $this->_req->getPost('total_emails', 'intval', 0);
 		$context['max_id_member'] = $this->_req->getPost('max_id_member', 'intval', 0);
 		$context['send_pm'] = $this->_req->getPost('send_pm', 'isset', false);
@@ -848,11 +846,9 @@ class ManageNews extends AbstractController
 				$sendParams['exclude_members'] = $context['recipients']['exclude_members'];
 			}
 
-			// Force them to have it?
-			if (empty($context['email_force']))
-			{
-				$sendQuery .= ' AND mem.notify_announcements = {int:notify_announcements}';
-			}
+			// Always respect user notification preferences
+			$sendQuery .= ' AND mem.notify_announcements = {int:notify_announcements}';
+			$sendParams['notify_announcements'] = 1;
 
 			require_once(SUBSDIR . '/News.subs.php');
 

--- a/sources/ElkArte/AdminController/ManageNews.php
+++ b/sources/ElkArte/AdminController/ManageNews.php
@@ -358,8 +358,8 @@ class ManageNews extends AbstractController
 		// Set up the template!
 		$context['page_title'] = $txt['admin_newsletters'];
 		$context['sub_template'] = 'email_members_compose';
-		$context['subject'] = empty($this->_req->post->subject) ? $context['forum_name'] . ': ' . htmlspecialchars($txt['subject'], ENT_COMPAT, 'UTF-8') : $this->_req->post->subject;
-		$context['message'] = empty($this->_req->post->message) ? htmlspecialchars($txt['message'] . "\n\n" . replaceBasicActionUrl($txt['regards_team']) . "\n\n" . '{$board_url}', ENT_COMPAT, 'UTF-8') : $this->_req->post->message;
+		$context['subject'] = empty($this->_req->post->subject) ? $context['forum_name'] . ': ' . Util::htmlspecialchars($txt['subject']) : $this->_req->post->subject;
+		$context['message'] = empty($this->_req->post->message) ? Util::htmlspecialchars($txt['message'] . "\n\n" . replaceBasicActionUrl($txt['regards_team']) . "\n\n" . '{$board_url}') : $this->_req->post->message;
 
 		// Needed for the WYSIWYG editor.
 		require_once(SUBSDIR . '/Editor.subs.php');
@@ -529,7 +529,7 @@ class ManageNews extends AbstractController
 	}
 
 	/**
-	 * Handles the sending of the forum mailing in batches.
+	 * Handles the sending of the mailing in batches.
 	 *
 	 * What it does:
 	 *
@@ -565,16 +565,6 @@ class ManageNews extends AbstractController
 			return;
 		}
 
-		// How many to send at once? Quantity depends on whether we are queueing or not.
-		// @todo Might need an interface? (used in Post.controller.php too with different limits)
-		$num_at_once = empty($modSettings['mail_queue']) ? 60 : 1000;
-
-		// If by PM's I suggest we half the above number.
-		if (!empty($this->_req->post->send_pm))
-		{
-			$num_at_once /= 2;
-		}
-
 		checkSession();
 
 		// Where are we actually to?
@@ -584,6 +574,16 @@ class ManageNews extends AbstractController
 		$context['send_pm'] = $this->_req->getPost('send_pm', 'isset', false);
 		$context['send_html'] = $this->_req->getPost('send_html', 'isset', false);
 		$context['parse_html'] = $this->_req->getPost('parse_html', 'isset', false);
+
+
+		// How many to send at once? Quantity depends on whether we are queueing or not.
+		$num_at_once = empty($modSettings['mail_queue']) ? 60 : 1000;
+
+		// If by PM's I suggest we half the above number.
+		if (!empty($context['send_pm']))
+		{
+			$num_at_once /= 2;
+		}
 
 		// Create our main context.
 		$context['recipients'] = [
@@ -670,8 +670,8 @@ class ManageNews extends AbstractController
 		$base_message = $this->_req->getPost('message', 'strval', '');
 
 		// Save the message and its subject in $context
-		$context['subject'] = htmlspecialchars($base_subject, ENT_COMPAT, 'UTF-8');
-		$context['message'] = htmlspecialchars($base_message, ENT_COMPAT, 'UTF-8');
+		$context['subject'] = Util::htmlspecialchars($base_subject);
+		$context['message'] = Util::htmlspecialchars($base_message);
 
 		// Prepare the message for sending it as HTML
 		if (!$context['send_pm'] && !empty($context['send_html']))
@@ -696,6 +696,7 @@ class ManageNews extends AbstractController
 			}
 		}
 
+		// Something to send?
 		if (empty($base_message) || empty($base_subject))
 		{
 			$context['preview'] = true;

--- a/sources/ElkArte/BBC/ParserWrapper.php
+++ b/sources/ElkArte/BBC/ParserWrapper.php
@@ -272,7 +272,7 @@ final class ParserWrapper
 	 */
 	public function parseEmail($email): string
 	{
-		return $this->enableSmileys(false)->parse('email', $email);
+		return $this->enableSmileys(true)->parse('email', $email);
 	}
 
 	/**

--- a/sources/ElkArte/Controller/Notify.php
+++ b/sources/ElkArte/Controller/Notify.php
@@ -114,7 +114,7 @@ class Notify extends AbstractController
 		}
 
 		checkSession('get');
-		$this->_toggle_topic_notification();
+		$this->_toggleTopicNotification();
 
 		// Send them back to the topic.
 		$start = $this->_req->getQuery('start', 'intval', 0);
@@ -124,7 +124,7 @@ class Notify extends AbstractController
 	/**
 	 * Toggle a topic notification on/off
 	 */
-	private function _toggle_topic_notification($memID = null, $enable = null): void
+	private function _toggleTopicNotification($memID = null, $enable = null): void
 	{
 		global $topic;
 
@@ -185,7 +185,7 @@ class Notify extends AbstractController
 			return;
 		}
 
-		$this->_toggle_topic_notification();
+		$this->_toggleTopicNotification();
 
 		// Return the results so the UI can be updated properly
 		$sa = $this->_req->getQuery('sa', 'trim|strval', '');
@@ -253,7 +253,7 @@ class Notify extends AbstractController
 		checkSession('get');
 
 		// Turn notification on/off for this board.
-		$this->_toggle_board_notification();
+		$this->_toggleBoardNotification();
 
 		// Back to the board!
 		$start = $this->_req->getQuery('start', 'intval', 0);
@@ -263,7 +263,7 @@ class Notify extends AbstractController
 	/**
 	 * Toggle a board notification on/off
 	 */
-	private function _toggle_board_notification($memID = null, $enable = null): void
+	private function _toggleBoardNotification($memID = null, $enable = null): void
 	{
 		global $board;
 
@@ -273,6 +273,20 @@ class Notify extends AbstractController
 		// Turn notification on/off for this board.
 		$isOn = $enable !== null ? $enable : ($this->_req->getQuery('sa', 'trim|strval', '') === 'on');
 		setBoardNotification($memID ?? $this->user->id, $board, $isOn);
+	}
+
+	/**
+	 * Toggle announcement notification on/off for a member
+	 *
+	 * @param int $memID The member id
+	 * @param bool $enable Whether to enable (true) or disable (false) announcements
+	 */
+	private function _toggleAnnouncementNewsletters($memID, $enable): void
+	{
+		require_once(SUBSDIR . '/Members.subs.php');
+
+		// Update the member's notify_announcements setting
+		updateMemberData($memID, ['notify_announcements' => (int) $enable]);
 	}
 
 	/**
@@ -328,7 +342,7 @@ class Notify extends AbstractController
 			return;
 		}
 
-		$this->_toggle_board_notification();
+		$this->_toggleBoardNotification();
 
 		$sa = $this->_req->getQuery('sa', 'trim|strval', '');
 		$start = $this->_req->getQuery('start', 'intval', 0);
@@ -486,7 +500,7 @@ class Notify extends AbstractController
 	{
 		global $board, $topic;
 
-		$baseAreas = ['topic', 'board', 'buddy', 'likemsg', 'mentionmem', 'quotedmem', 'rlikemsg'];
+		$baseAreas = ['topic', 'board', 'newsletters', 'buddy', 'likemsg', 'mentionmem', 'quotedmem', 'rlikemsg'];
 
 		// Not a base method, so an addon will need to process this
 		if (!in_array($area, $baseAreas))
@@ -501,11 +515,14 @@ class Notify extends AbstractController
 		{
 			case 'topic':
 				$topic = $extra;
-				$this->_toggle_topic_notification($member['id_member'], $forceDisable);
+				$this->_toggleTopicNotification($member['id_member'], $forceDisable);
 				break;
 			case 'board':
 				$board = $extra;
-				$this->_toggle_board_notification($member['id_member'], $forceDisable);
+				$this->_toggleBoardNotification($member['id_member'], $forceDisable);
+				break;
+			case 'newsletters':
+				$this->_toggleAnnouncementNewsletters($member['id_member'], $forceDisable);
 				break;
 			case 'buddy':
 			case 'likemsg':
@@ -579,7 +596,7 @@ class Notify extends AbstractController
 			$potentialAreas[] = strtolower($class::getType());
 		}
 
-		$potentialAreas = array_merge($potentialAreas, ['topic', 'board']);
+		$potentialAreas = array_merge($potentialAreas, ['topic', 'board', 'newsletters']);
 
 		// Expand the token
 		[$id_member, $hash, $area, $extra, $time] = explode('_', $match[1]);
@@ -679,6 +696,9 @@ class Notify extends AbstractController
 				$name = boardInfo((int) $extra);
 				$name = $name === null ? $txt['notify_unsubscribed_generic'] : $name['name'];
 				$context['unsubscribe_message'] = sprintf($txt['notify_board_unsubscribed'], $name, $email);
+				break;
+			case 'newsletters':
+				$context['unsubscribe_message'] = sprintf($txt['notify_announcements_unsubscribed'], $txt['news'], $email);
 				break;
 			case 'buddy':
 			case 'likemsg':

--- a/sources/ElkArte/Languages/Admin/English.php
+++ b/sources/ElkArte/Languages/Admin/English.php
@@ -175,7 +175,6 @@ IP: %3$s';
 $txt['email_as_html'] = 'Send in HTML format.  (with this you can put normal HTML in the email.)';
 $txt['email_parsed_html'] = 'Add &lt;br /&gt;s and &amp;nbsp;s to this message.';
 $txt['email_variables'] = 'In this message you can use a few &quot;variables&quot;.<a href="{help_emailmembers}" class="help"> Click here for more information</a>.';
-$txt['email_force'] = 'Send this to members even if they have chosen not to receive announcements.';
 $txt['email_as_pms'] = 'Send this to these groups using personal messages.';
 $txt['email_continue'] = 'Continue';
 $txt['email_done'] = 'done.';
@@ -733,7 +732,6 @@ $txt['admin_news_select_excluded_groups'] = 'Excluded Groups';
 $txt['admin_news_select_excluded_groups_desc'] = 'Select groups who should definitely not receive the newsletter.';
 $txt['admin_news_select_email'] = 'Email Addresses';
 $txt['admin_news_select_email_desc'] = 'A semi-colon separated list of email addresses which should be sent this newsletter. (i.e. address1; address2)';
-$txt['admin_news_select_override_notify'] = 'Override notification settings';
 // Use entities in below.
 $txt['admin_news_cannot_pm_emails_js'] = 'You cannot send a personal message to an email address. If you continue all entered email addresses will be ignored.\\n\\nAre you sure you wish to do this?';
 

--- a/sources/ElkArte/Languages/Admin/English.php
+++ b/sources/ElkArte/Languages/Admin/English.php
@@ -730,8 +730,6 @@ $txt['admin_news_select_excluded_members'] = 'Excluded Members';
 $txt['admin_news_select_excluded_members_desc'] = 'Members who should not receive the newsletter.';
 $txt['admin_news_select_excluded_groups'] = 'Excluded Groups';
 $txt['admin_news_select_excluded_groups_desc'] = 'Select groups who should definitely not receive the newsletter.';
-$txt['admin_news_select_email'] = 'Email Addresses';
-$txt['admin_news_select_email_desc'] = 'A semi-colon separated list of email addresses which should be sent this newsletter. (i.e. address1; address2)';
 // Use entities in below.
 $txt['admin_news_cannot_pm_emails_js'] = 'You cannot send a personal message to an email address. If you continue all entered email addresses will be ignored.\\n\\nAre you sure you wish to do this?';
 

--- a/sources/ElkArte/Languages/Index/English.php
+++ b/sources/ElkArte/Languages/Index/English.php
@@ -782,6 +782,7 @@ $txt['notify_unsubscribed_generic'] = 'specified';
 $txt['notify_board_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and will no longer be sent notifications from the %1$s board.';
 $txt['notify_topic_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and will no longer be sent notifications on the %1$s topic.';
 $txt['notify_mention_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and will no longer be sent "%1$s" notifications.';
+$txt['notify_announcements_unsubscribed'] = 'The email, %2$s, has been successfully unsubscribed and will no longer be sent "%1$s" notifications.';
 $txt['notify_default_unsubscribed'] = 'Your request has been successfully processed.';
 
 $txt['find_members'] = 'Find Members';

--- a/sources/ElkArte/Mail/BuildMail.php
+++ b/sources/ElkArte/Mail/BuildMail.php
@@ -506,9 +506,12 @@ class BuildMail extends BaseMail
 	{
 		global $scripturl;
 
-		$string = strtr($string, [$this->lineBreak => '<br />' . $this->lineBreak]);
+		$string = strtr($string, [$this->lineBreak => '<br />']);
 
-		return preg_replace('~\b(' . preg_quote($scripturl, '~') . '(?:[?/][\w\-%.,?@!:&;=#]+)?)~', '<a href="$1" target="_blank" rel="noopener">$1</a>', $string);
+		// Skip existing HTML tags so URLs inside attributes/anchors are not linkified.
+		$pattern = '~<[^>]+>(*SKIP)(*F)|\b(' . preg_quote($scripturl, '~') . '(?:[?/][\w\-%.,?@!:&;=#]+)?)~';
+
+		return preg_replace($pattern, '<a href="$1" target="_blank" rel="noopener">$1</a>', $string);
 	}
 
 	/**

--- a/sources/subs/Mail.subs.php
+++ b/sources/subs/Mail.subs.php
@@ -401,10 +401,8 @@ function prepareMailingForPreview()
 		'{$latest_member.name}'
 	];
 
-	$html = $context['send_html'];
-
 	// We might need this in a bit
-	$cleanLatestMember = empty($context['send_html']) || $context['send_pm'] ? un_htmlspecialchars($modSettings['latestRealName']) : $modSettings['latestRealName'];
+	$cleanLatestMember = $context['send_pm'] ? un_htmlspecialchars($modSettings['latestRealName']) : $modSettings['latestRealName'];
 
 	$bbc_parser = ParserWrapper::instance();
 
@@ -423,21 +421,18 @@ function prepareMailingForPreview()
 
 		preparsecode($context[$key]);
 
-		// Sending as HTML then we convert any bbc
-		if ($html)
-		{
-			$enablePostHTML = $modSettings['enablePostHTML'];
-			$modSettings['enablePostHTML'] = $context['send_html'];
-			$context[$key] = $bbc_parser->parseEmail($context[$key]);
-			$modSettings['enablePostHTML'] = $enablePostHTML;
-		}
+		// Sending as HTML so we convert any bbc
+		$enablePostHTML = $modSettings['enablePostHTML'];
+		$modSettings['enablePostHTML'] = $context['send_html'];
+		$context[$key] = $bbc_parser->parseEmail($context[$key]);
+		$modSettings['enablePostHTML'] = $enablePostHTML;
 
 		// Replace in all the standard things.
 		$context[$key] = str_replace($variables,
 			[
-				!empty($context['send_html']) ? '<a href="' . $scripturl . '">' . $scripturl . '</a>' : $scripturl,
+				'<a href="' . $scripturl . '">' . $scripturl . '</a>',
 				standardTime(forum_time(), false),
-				!empty($context['send_html']) ? '<a href="' . $scripturl . '?action=profile;u=' . $modSettings['latestMember'] . '">' . $cleanLatestMember . '</a>' : ($context['send_pm'] ? '[url=' . $scripturl . '?action=profile;u=' . $modSettings['latestMember'] . ']' . $cleanLatestMember . '[/url]' : $cleanLatestMember),
+				'<a href="' . $scripturl . '?action=profile;u=' . $modSettings['latestMember'] . '">' . $cleanLatestMember . '</a>',
 				$modSettings['latestMember'],
 				$cleanLatestMember
 			], $context[$key]);

--- a/sources/subs/News.subs.php
+++ b/sources/subs/News.subs.php
@@ -173,7 +173,8 @@ function getNewsletterRecipients($sendQuery, $sendParams, $start, $increment, $c
 
 	$db->fetchQuery('
 		SELECT 
-			mem.id_member, mem.email_address, mem.real_name, mem.id_group, mem.additional_groups, mem.id_post_group
+			mem.id_member, mem.email_address, mem.real_name, mem.id_group, mem.additional_groups,
+			mem.id_post_group, mem.lngfile, mem.password_salt
 		FROM {db_prefix}members AS mem
 		WHERE mem.id_member > {int:min_id_member}
 			AND mem.id_member < {int:max_id_member}

--- a/themes/default/ManageNews.template.php
+++ b/themes/default/ManageNews.template.php
@@ -224,17 +224,7 @@ function template_email_members_compose()
 					<ul>
 						<li>
 							<label for="send_pm">
-								<input type="checkbox" name="send_pm" id="send_pm" ', empty($context['send_pm']) ? '' : 'checked="checked"', 'onclick="checkboxes_status(this);" /> ', $txt['email_as_pms'], '
-							</label>
-						</li>
-						<li>
-							<label for="send_html">
-								<input type="checkbox" name="send_html" id="send_html" ', empty($context['send_html']) ? '' : 'checked="checked"', 'onclick="checkboxes_status(this);" /> ', $txt['email_as_html'], '
-							</label>
-						</li>
-						<li>
-							<label for="parse_html">
-								<input type="checkbox" name="parse_html" id="parse_html" checked="checked" disabled="disabled" /> ', $txt['email_parsed_html'], '
+								<input type="checkbox" name="send_pm" id="send_pm" ', empty($context['send_pm']) ? '' : 'checked="checked"', ' /> ', $txt['email_as_pms'], '
 							</label>
 						</li>
 					</ul>
@@ -258,23 +248,7 @@ function template_email_members_compose()
 		var form_name = "newsmodify",
 			preview_area = "news",
 			txt_preview_title = "' . $txt['preview_title'] . '",
-			txt_preview_fetch = "' . $txt['preview_fetch'] . '";
-
-		function checkboxes_status (item)
-		{
-			if (item.id === \'send_html\')
-				document.getElementById(\'parse_html\').disabled = !document.getElementById(\'parse_html\').disabled;
-
-			if (item.id === \'send_pm\')
-			{
-				if (!document.getElementById(\'send_html\').checked)
-					document.getElementById(\'parse_html\').disabled = true;
-				else
-					document.getElementById(\'parse_html\').disabled = false;
-
-				document.getElementById(\'send_html\').disabled = !document.getElementById(\'send_html\').disabled;
-			}
-		}', true);
+			txt_preview_fetch = "' . $txt['preview_fetch'] . '";', true);
 
 	echo '
 		</form>
@@ -306,9 +280,7 @@ function template_email_members_send()
 					<input type="hidden" name="start" value="', $context['start'], '" />
 					<input type="hidden" name="total_emails" value="', $context['total_emails'], '" />
 					<input type="hidden" name="max_id_member" value="', $context['max_id_member'], '" />
-					<input type="hidden" name="send_pm" value="', $context['send_pm'], '" />
-					<input type="hidden" name="send_html" value="', $context['send_html'], '" />
-					<input type="hidden" name="parse_html" value="', $context['parse_html'], '" />';
+					<input type="hidden" name="send_pm" value="', $context['send_pm'], '" />';
 
 	// All the things we must remember!
 	foreach ($context['recipients'] as $key => $values)

--- a/themes/default/ManageNews.template.php
+++ b/themes/default/ManageNews.template.php
@@ -60,16 +60,6 @@ function template_email_members()
 						<span id="members_container"></span>
 					</dd>
 				</dl>
-				<hr class="bordercolor" />
-				<dl class="settings">
-					<dt>
-						<label for="email_force">', $txt['admin_news_select_override_notify'], ':</label><br />
-						<span class="smalltext">', $txt['email_force'], '</span>
-					</dt>
-					<dd>
-						<input type="checkbox" name="email_force" id="email_force" value="1" />
-					</dd>
-				</dl>
 			</div>
 			<div id="exclude_panel_header">
 				<h2 class="category_header panel_toggle">
@@ -258,7 +248,6 @@ function template_email_members_compose()
 					<div class="submitbutton">
 						', template_control_richedit_buttons($context['post_box_name']), '
 						<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
-						<input type="hidden" name="email_force" value="', $context['email_force'], '" />
 						<input type="hidden" name="total_emails" value="', $context['total_emails'], '" />
 						<input type="hidden" name="max_id_member" value="', $context['max_id_member'], '" />
 					</div>

--- a/themes/default/ManageNews.template.php
+++ b/themes/default/ManageNews.template.php
@@ -45,13 +45,6 @@ function template_email_members()
 	echo '
 					</dd>
 					<dt>
-						<label for="emails">', $txt['admin_news_select_email'], ':</label><br />
-						<span class="smalltext">', $txt['admin_news_select_email_desc'], '</span>
-					</dt>
-					<dd>
-						<textarea id="emails" name="emails" rows="5" cols="30" style="width: 98%;"></textarea>
-					</dd>
-					<dt>
 						<label for="members">', $txt['admin_news_select_members'], ':</label><br />
 						<span class="smalltext">', $txt['admin_news_select_members_desc'], '</span>
 					</dt>
@@ -257,7 +250,7 @@ function template_email_members_compose()
 	foreach ($context['recipients'] as $key => $values)
 	{
 		echo '
-			<input type="hidden" name="', $key, '" value="', implode(($key === 'emails' ? ';' : ','), $values), '" />';
+			<input type="hidden" name="', $key, '" value="', implode(',', $values), '" />';
 	}
 
 	// The vars used to preview a newsletter without loading a new page, used by post.js previewControl()
@@ -321,7 +314,7 @@ function template_email_members_send()
 	foreach ($context['recipients'] as $key => $values)
 	{
 		echo '
-					<input type="hidden" name="', $key, '" value="', implode(($key === 'emails' ? ';' : ','), $values), '" />';
+					<input type="hidden" name="', $key, '" value="', implode(',', $values), '" />';
 	}
 
 	echo '


### PR DESCRIPTION
This simplifies the news letters section by remove a  number of rather useless options.  It also properly uses the BuildMail functions so what is sent it proper HTML and importantly provides the Opt_out unsubscribe link in the email

removed old non html options.  Send you newsletter via email or PM, simple.  No HTML in an email is a spam (+) flag.
removed ability to randomly send email to any address, a very bad idea
removed ability to send even when the member had opted out just use PM and be done.
fixed a couple of "bugs"
